### PR TITLE
refactor(c-bindings): do not subscribe automatically to default waku topic

### DIFF
--- a/library/README.md
+++ b/library/README.md
@@ -271,6 +271,7 @@ interface JsonConfig {
     nodeKey?: string;
     keepAliveInterval?: number;
     relay?: boolean;
+    relayTopics?: Array<string>;
     minPeersToPublish?: number;
     filter?: boolean;
     discV5?: boolean;
@@ -299,6 +300,8 @@ If a key is `undefined`, or `null`, a default value will be set.
   Default `20`.
 - `relay`: Enable relay protocol.
   Default `true`.
+- `relayTopics`:  Array of pubsub topics that WakuRelay will automatically subscribe to when the node starts
+  Default `[]`
 - `minPeersToPublish`: The minimum number of peers required on a topic to allow broadcasting a message.
   Default `0`.
 - `filter`: Enable filter protocol.

--- a/library/api.go
+++ b/library/api.go
@@ -27,6 +27,7 @@ func main() {}
 // - nodeKey: secp256k1 private key. Default random
 // - keepAliveInterval: interval in seconds to ping all peers
 // - relay: Enable WakuRelay. Default `true`
+// - relayTopics: Array of pubsub topics that WakuRelay will automatically subscribe to when the node starts
 // - minPeersToPublish: The minimum number of peers required on a topic to allow broadcasting a message. Default `0`
 // - filter: Enable Filter. Default `false`
 // - discV5: Enable DiscoveryV5. Default `false`

--- a/waku/v2/node/wakuoptions.go
+++ b/waku/v2/node/wakuoptions.go
@@ -57,11 +57,12 @@ type WakuNodeParameters struct {
 
 	logger *zap.Logger
 
-	enableRelay      bool
-	enableFilter     bool
-	isFilterFullNode bool
-	filterOpts       []filter.Option
-	wOpts            []pubsub.Option
+	noDefaultWakuTopic bool
+	enableRelay        bool
+	enableFilter       bool
+	isFilterFullNode   bool
+	filterOpts         []filter.Option
+	wOpts              []pubsub.Option
 
 	minRelayPeersToPublish int
 
@@ -262,6 +263,15 @@ func (w *WakuNodeParameters) GetPrivKey() *crypto.PrivKey {
 func WithLibP2POptions(opts ...libp2p.Option) WakuNodeOption {
 	return func(params *WakuNodeParameters) error {
 		params.libP2POpts = opts
+		return nil
+	}
+}
+
+// NoDefaultWakuTopic will stop the node from subscribing to the default
+// pubsub topic automatically
+func NoDefaultWakuTopic() WakuNodeOption {
+	return func(params *WakuNodeParameters) error {
+		params.noDefaultWakuTopic = true
 		return nil
 	}
 }


### PR DESCRIPTION
Adds a new config item: `relayTopics`, which can optionally contain an array of strings representing the topics a node will automatically subscribe to.