### PR TITLE
fix: adding circuit relay information to enr

### DIFF
--- a/waku/v2/node/address_test.go
+++ b/waku/v2/node/address_test.go
@@ -1,0 +1,45 @@
+package node
+
+import (
+	"net"
+	"testing"
+
+	ma "github.com/multiformats/go-multiaddr"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExternalAddressSelection(t *testing.T) {
+	a1, _ := ma.NewMultiaddr("/ip4/192.168.0.106/tcp/60000/p2p/16Uiu2HAmUVVrJo1KMw4QwUANYF7Ws4mfcRqf9xHaaGP87GbMuY2f")                                                                                                                // Valid
+	a2, _ := ma.NewMultiaddr("/ip4/127.0.0.1/tcp/60000/p2p/16Uiu2HAmUVVrJo1KMw4QwUANYF7Ws4mfcRqf9xHaaGP87GbMuY2f")                                                                                                                    // Valid but should not be prefered
+	a3, _ := ma.NewMultiaddr("/ip4/192.168.1.20/tcp/19710/p2p/16Uiu2HAmUVVrJo1KMw4QwUANYF7Ws4mfcRqf9xHaaGP87GbMuY2f")                                                                                                                 // Valid
+	a4, _ := ma.NewMultiaddr("/dns4/www.status.im/tcp/2012/ws/p2p/16Uiu2HAmUVVrJo1KMw4QwUANYF7Ws4mfcRqf9xHaaGP87GbMuY2f")                                                                                                             // Invalid (it's useless)
+	a5, _ := ma.NewMultiaddr("/dns4/www.status.im/tcp/443/wss/p2p/16Uiu2HAmUVVrJo1KMw4QwUANYF7Ws4mfcRqf9xHaaGP87GbMuY2f")                                                                                                             // Valid
+	a6, _ := ma.NewMultiaddr("/ip4/192.168.1.20/tcp/19710/wss/p2p/16Uiu2HAmUVVrJo1KMw4QwUANYF7Ws4mfcRqf9xHaaGP87GbMuY2f")                                                                                                             // Invalid (local + wss)
+	a7, _ := ma.NewMultiaddr("/ip4/192.168.1.20/tcp/19710/ws/p2p/16Uiu2HAmUVVrJo1KMw4QwUANYF7Ws4mfcRqf9xHaaGP87GbMuY2f")                                                                                                              // Invalid  (it's useless)
+	a8, _ := ma.NewMultiaddr("/dns4/node-02.gc-us-central1-a.status.prod.statusim.net/tcp/30303/p2p/16Uiu2HAmDQugwDHM3YeUp86iGjrUvbdw3JPRgikC7YoGBsT2ymMg/p2p-circuit/p2p/16Uiu2HAmUVVrJo1KMw4QwUANYF7Ws4mfcRqf9xHaaGP87GbMuY2f")     // VALID
+	a9, _ := ma.NewMultiaddr("/dns4/node-02.gc-us-central1-a.status.prod.statusim.net/tcp/443/wss/p2p/16Uiu2HAmDQugwDHM3YeUp86iGjrUvbdw3JPRgikC7YoGBsT2ymMg/p2p-circuit/p2p/16Uiu2HAmUVVrJo1KMw4QwUANYF7Ws4mfcRqf9xHaaGP87GbMuY2f")   // VALID
+	a10, _ := ma.NewMultiaddr("/dns4/node-01.gc-us-central1-a.wakuv2.test.statusim.net/tcp/8000/wss/p2p/16Uiu2HAmJb2e28qLXxT5kZxVUUoJt72EMzNGXB47Rxx5hw3q4YjS/p2p-circuit/p2p/16Uiu2HAmUVVrJo1KMw4QwUANYF7Ws4mfcRqf9xHaaGP87GbMuY2f") // VALID
+	a11, _ := ma.NewMultiaddr("/dns4/node-01.gc-us-central1-a.wakuv2.test.statusim.net/tcp/30303/p2p/16Uiu2HAmJb2e28qLXxT5kZxVUUoJt72EMzNGXB47Rxx5hw3q4YjS/p2p-circuit/p2p/16Uiu2HAmUVVrJo1KMw4QwUANYF7Ws4mfcRqf9xHaaGP87GbMuY2f")    // VALID
+
+	addrs := []ma.Multiaddr{a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11}
+
+	w := &WakuNode{}
+	extAddr, multiaddr, err := w.getENRAddresses(addrs)
+
+	a5NoP2P, _ := decapsulateP2P(a5)
+	a8RelayNode, _ := decapsulateCircuitRelayAddr(a8)
+
+	require.NoError(t, err)
+	require.Equal(t, extAddr.IP, net.IPv4(192, 168, 0, 106))
+	require.Equal(t, extAddr.Port, 60000)
+	require.Equal(t, multiaddr[0].String(), a5NoP2P.String())
+	require.Equal(t, multiaddr[1].String(), a8RelayNode.String())
+	require.Len(t, multiaddr, 5)
+	a12, _ := ma.NewMultiaddr("/ip4/188.23.1.8/tcp/30303/p2p/16Uiu2HAmUVVrJo1KMw4QwUANYF7Ws4mfcRqf9xHaaGP87GbMuY2f") // VALID
+	addrs = append(addrs, a12)
+
+	extAddr, _, err = w.getENRAddresses(addrs)
+	require.NoError(t, err)
+	require.Equal(t, extAddr.IP, net.IPv4(188, 23, 1, 8))
+	require.Equal(t, extAddr.Port, 30303)
+}

--- a/waku/v2/node/address_test.go
+++ b/waku/v2/node/address_test.go
@@ -24,22 +24,25 @@ func TestExternalAddressSelection(t *testing.T) {
 	addrs := []ma.Multiaddr{a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11}
 
 	w := &WakuNode{}
-	extAddr, multiaddr, err := w.getENRAddresses(addrs)
+	extAddr, multiaddr, err := w.getENRAddresses([]ma.Multiaddr{a1, a2, a3, a4, a5, a6, a7, a8})
 
 	a5NoP2P, _ := decapsulateP2P(a5)
-	a8RelayNode, _ := decapsulateCircuitRelayAddr(a8)
-
 	require.NoError(t, err)
 	require.Equal(t, extAddr.IP, net.IPv4(192, 168, 0, 106))
 	require.Equal(t, extAddr.Port, 60000)
 	require.Equal(t, multiaddr[0].String(), a5NoP2P.String())
-	require.Equal(t, multiaddr[1].String(), a8RelayNode.String())
-	require.Len(t, multiaddr, 5)
+	require.Len(t, multiaddr, 1) // Should only have 1, without circuit relay
+
 	a12, _ := ma.NewMultiaddr("/ip4/188.23.1.8/tcp/30303/p2p/16Uiu2HAmUVVrJo1KMw4QwUANYF7Ws4mfcRqf9xHaaGP87GbMuY2f") // VALID
 	addrs = append(addrs, a12)
-
 	extAddr, _, err = w.getENRAddresses(addrs)
 	require.NoError(t, err)
 	require.Equal(t, extAddr.IP, net.IPv4(188, 23, 1, 8))
 	require.Equal(t, extAddr.Port, 30303)
+
+	a8RelayNode, _ := decapsulateCircuitRelayAddr(a8)
+	_, multiaddr, err = w.getENRAddresses([]ma.Multiaddr{a1, a8})
+	require.NoError(t, err)
+	require.Len(t, multiaddr, 1)
+	require.Equal(t, multiaddr[0].String(), a8RelayNode.String()) // Should have included circuit-relay addr
 }

--- a/waku/v2/node/localnode.go
+++ b/waku/v2/node/localnode.go
@@ -13,7 +13,6 @@ import (
 	"github.com/ethereum/go-ethereum/p2p/enode"
 	"github.com/ethereum/go-ethereum/p2p/enr"
 	ma "github.com/multiformats/go-multiaddr"
-	"github.com/waku-org/go-waku/logging"
 	"github.com/waku-org/go-waku/waku/v2/utils"
 	"go.uber.org/zap"
 )
@@ -26,7 +25,7 @@ func (w *WakuNode) newLocalnode(priv *ecdsa.PrivateKey) (*enode.LocalNode, error
 	return enode.NewLocalNode(db, priv), nil
 }
 
-func (w *WakuNode) updateLocalNode(localnode *enode.LocalNode, wsAddr []ma.Multiaddr, ipAddr *net.TCPAddr, udpPort uint, wakuFlags utils.WakuEnrBitfield, advertiseAddr *net.IP, shouldAutoUpdate bool, log *zap.Logger) error {
+func (w *WakuNode) updateLocalNode(localnode *enode.LocalNode, multiaddrs []ma.Multiaddr, ipAddr *net.TCPAddr, udpPort uint, wakuFlags utils.WakuEnrBitfield, advertiseAddr *net.IP, shouldAutoUpdate bool, log *zap.Logger) error {
 	localnode.SetFallbackUDP(int(udpPort))
 	localnode.Set(enr.WithEntry(utils.WakuENRField, wakuFlags))
 	localnode.SetFallbackIP(net.IP{127, 0, 0, 1})
@@ -69,21 +68,10 @@ func (w *WakuNode) updateLocalNode(localnode *enode.LocalNode, wsAddr []ma.Multi
 		}
 	}
 
-	// Adding websocket multiaddresses
+	// Adding extra multiaddresses
 	var fieldRaw []byte
-
-	for _, addr := range wsAddr {
-		p2p, err := addr.ValueForProtocol(ma.P_P2P)
-		if err != nil {
-			return err
-		}
-
-		p2pAddr, err := ma.NewMultiaddr("/p2p/" + p2p)
-		if err != nil {
-			return fmt.Errorf("could not create p2p addr: %w", err)
-		}
-
-		maRaw := addr.Decapsulate(p2pAddr).Bytes()
+	for _, addr := range multiaddrs {
+		maRaw := addr.Bytes()
 		maSize := make([]byte, 2)
 		binary.BigEndian.PutUint16(maSize, uint16(len(maRaw)))
 
@@ -98,19 +86,19 @@ func (w *WakuNode) updateLocalNode(localnode *enode.LocalNode, wsAddr []ma.Multi
 	return nil
 }
 
-func isPrivate(addr candidateAddr) bool {
-	return addr.ip.IP.IsPrivate()
+func isPrivate(addr *net.TCPAddr) bool {
+	return addr.IP.IsPrivate()
 }
 
-func isExternal(addr candidateAddr) bool {
-	return !isPrivate(addr) && !addr.ip.IP.IsLoopback() && !addr.ip.IP.IsUnspecified()
+func isExternal(addr *net.TCPAddr) bool {
+	return !isPrivate(addr) && !addr.IP.IsLoopback() && !addr.IP.IsUnspecified()
 }
 
-func isLoopback(addr candidateAddr) bool {
-	return addr.ip.IP.IsLoopback()
+func isLoopback(addr *net.TCPAddr) bool {
+	return addr.IP.IsLoopback()
 }
 
-func filterIP(ss []candidateAddr, fn func(candidateAddr) bool) (ret []candidateAddr) {
+func filterIP(ss []*net.TCPAddr, fn func(*net.TCPAddr) bool) (ret []*net.TCPAddr) {
 	for _, s := range ss {
 		if fn(s) {
 			ret = append(ret, s)
@@ -119,12 +107,25 @@ func filterIP(ss []candidateAddr, fn func(candidateAddr) bool) (ret []candidateA
 	return
 }
 
-type candidateAddr struct {
-	ip    *net.TCPAddr
-	maddr ma.Multiaddr
-}
+func extractIPAddressForENR(addr ma.Multiaddr) (*net.TCPAddr, error) {
+	// It's a p2p-circuit address. We shouldnt use these
+	// for building the ENR record default keys
+	_, err := addr.ValueForProtocol(ma.P_CIRCUIT)
+	if err == nil {
+		return nil, errors.New("can't use IP address from a p2p-circuit address")
+	}
 
-func extractIP(addr ma.Multiaddr) (*net.TCPAddr, error) {
+	// ws and wss addresses are handled by the multiaddr key
+	// they shouldnt be used for building the ENR record default keys
+	_, err = addr.ValueForProtocol(ma.P_WS)
+	if err == nil {
+		return nil, errors.New("can't use IP address from a ws address")
+	}
+	_, err = addr.ValueForProtocol(ma.P_WSS)
+	if err == nil {
+		return nil, errors.New("can't use IP address from a wss address")
+	}
+
 	var ipStr string
 	dns4, err := addr.ValueForProtocol(ma.P_DNS4)
 	if err != nil {
@@ -154,76 +155,88 @@ func extractIP(addr ma.Multiaddr) (*net.TCPAddr, error) {
 	}, nil
 }
 
-func selectMostExternalAddress(addresses []ma.Multiaddr) (ma.Multiaddr, *net.TCPAddr, error) {
-	var ipAddrs []candidateAddr
+func selectMostExternalAddress(addresses []ma.Multiaddr) (*net.TCPAddr, error) {
+	var ipAddrs []*net.TCPAddr
 
 	for _, addr := range addresses {
-		ipAddr, err := extractIP(addr)
+		ipAddr, err := extractIPAddressForENR(addr)
 		if err != nil {
 			continue
 		}
 
-		ipAddrs = append(ipAddrs, candidateAddr{
-			ip:    ipAddr,
-			maddr: addr,
-		})
+		fmt.Println(ipAddr, addr)
+		ipAddrs = append(ipAddrs, ipAddr)
 	}
 
 	externalIPs := filterIP(ipAddrs, isExternal)
 	if len(externalIPs) > 0 {
-		return externalIPs[0].maddr, externalIPs[0].ip, nil
+		return externalIPs[0], nil
 	}
 
 	privateIPs := filterIP(ipAddrs, isPrivate)
 	if len(privateIPs) > 0 {
-		return privateIPs[0].maddr, privateIPs[0].ip, nil
+		return privateIPs[0], nil
 	}
 
 	loopback := filterIP(ipAddrs, isLoopback)
 	if len(loopback) > 0 {
-		return loopback[0].maddr, loopback[0].ip, nil
+		return loopback[0], nil
 	}
 
-	return nil, nil, errors.New("could not obtain ip address")
+	return nil, errors.New("could not obtain ip address")
 }
 
-func selectWSListenAddress(addresses []ma.Multiaddr, extAddr ma.Multiaddr) ([]ma.Multiaddr, error) {
-	extAddrDNS, err := extAddr.ValueForProtocol(ma.P_DNS4)
-	var extAddrIP string
+func decapsulateP2P(addr ma.Multiaddr) (ma.Multiaddr, error) {
+	p2p, err := addr.ValueForProtocol(ma.P_P2P)
 	if err != nil {
-		extAddrIP, err = extAddr.ValueForProtocol(ma.P_IP4)
-		if err != nil {
-			return nil, err
-		}
+		return nil, err
 	}
 
+	p2pAddr, err := ma.NewMultiaddr("/p2p/" + p2p)
+	if err != nil {
+		return nil, err
+	}
+
+	addr = addr.Decapsulate(p2pAddr)
+
+	return addr, nil
+}
+
+func decapsulateCircuitRelayAddr(addr ma.Multiaddr) (ma.Multiaddr, error) {
+	_, err := addr.ValueForProtocol(ma.P_CIRCUIT)
+	if err != nil {
+		return nil, errors.New("not a circuit relay address")
+	}
+
+	// We remove the node's multiaddress from the addr
+	addr, _ = ma.SplitFunc(addr, func(c ma.Component) bool {
+		return c.Protocol().Code == ma.P_CIRCUIT
+	})
+
+	return addr, nil
+}
+
+func selectWSSListenAddresses(addresses []ma.Multiaddr) ([]ma.Multiaddr, error) {
 	var result []ma.Multiaddr
 	for _, addr := range addresses {
-		// Filter addresses that match the extAddr
-		if extAddrDNS != "" {
-			dns4, err := addr.ValueForProtocol(ma.P_DNS4)
-			if err != nil {
-				continue
-			}
-			if dns4 != extAddrDNS {
-				continue
-			}
-		} else {
-			ip4, err := addr.ValueForProtocol(ma.P_IP4)
-			if err != nil {
-				continue
-			}
-			if ip4 != extAddrIP {
-				continue
-			}
+		// It's a p2p-circuit address. We dont use these at this stage yet
+		_, err := addr.ValueForProtocol(ma.P_CIRCUIT)
+		if err == nil {
+			continue
 		}
 
-		_, err := addr.ValueForProtocol(ma.P_WS)
-		if err == nil {
-			result = append(result, addr)
+		// Only WSS with a domain name are allowed
+		_, err = addr.ValueForProtocol(ma.P_DNS4)
+		if err != nil {
+			continue
 		}
 
 		_, err = addr.ValueForProtocol(ma.P_WSS)
+		if err != nil {
+			continue
+		}
+
+		addr, err = decapsulateP2P(addr)
 		if err == nil {
 			result = append(result, addr)
 		}
@@ -232,22 +245,52 @@ func selectWSListenAddress(addresses []ma.Multiaddr, extAddr ma.Multiaddr) ([]ma
 	return result, nil
 }
 
+func selectCircuitRelayListenAddresses(addresses []ma.Multiaddr) ([]ma.Multiaddr, error) {
+	var result []ma.Multiaddr
+	for _, addr := range addresses {
+		addr, err := decapsulateCircuitRelayAddr(addr)
+		if err != nil {
+			continue
+		}
+		result = append(result, addr)
+	}
+
+	return result, nil
+}
+
+func (w *WakuNode) getENRAddresses(addrs []ma.Multiaddr) (extAddr *net.TCPAddr, multiaddr []ma.Multiaddr, err error) {
+
+	extAddr, err = selectMostExternalAddress(addrs)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	wssAddrs, err := selectWSSListenAddresses(addrs)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	circuitAddrs, err := selectCircuitRelayListenAddresses(addrs)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	multiaddr = append(multiaddr, wssAddrs...)
+	multiaddr = append(multiaddr, circuitAddrs...)
+
+	return
+}
+
 func (w *WakuNode) setupENR(ctx context.Context, addrs []ma.Multiaddr) error {
-	extAddr, ipAddr, err := selectMostExternalAddress(addrs)
+	ipAddr, multiaddresses, err := w.getENRAddresses(addrs)
 	if err != nil {
 		w.log.Error("obtaining external address", zap.Error(err))
 		return err
 	}
 
-	wsAddresses, err := selectWSListenAddress(addrs, extAddr)
+	err = w.updateLocalNode(w.localNode, multiaddresses, ipAddr, w.opts.udpPort, w.wakuFlag, w.opts.advertiseAddr, w.opts.discV5autoUpdate, w.log)
 	if err != nil {
-		w.log.Error("obtaining websocket addresses", zap.Error(err))
-		return err
-	}
-
-	err = w.updateLocalNode(w.localNode, wsAddresses, ipAddr, w.opts.udpPort, w.wakuFlag, w.opts.advertiseAddr, w.opts.discV5autoUpdate, w.log)
-	if err != nil {
-		w.log.Error("obtaining ENR record from multiaddress", logging.MultiAddrs("multiaddr", extAddr), zap.Error(err))
+		w.log.Error("updating localnode ENR record", zap.Error(err))
 		return err
 	}
 


### PR DESCRIPTION
To run new test:
```
 go test -timeout 30s -run ^TestMultiaddr$ github.com/waku-org/go-waku/waku/v2/utils -count 1 -v
```

Edit `waku/v2/utils/enr_test.go` on line 100 to 104 to modify which multiaddresses would get stored in the `multiaddrs` key
