### PR TITLE
feat: add WakuMessage validation in gossipsub

### DIFF
--- a/waku/v2/node/wakunode2.go
+++ b/waku/v2/node/wakunode2.go
@@ -408,9 +408,9 @@ func (w *WakuNode) Stop() {
 
 	w.host.Close()
 
-	close(w.enrChangeCh)
-
 	w.wg.Wait()
+
+	close(w.enrChangeCh)
 }
 
 // Host returns the libp2p Host used by the WakuNode

--- a/waku/v2/node/wakunode2_test.go
+++ b/waku/v2/node/wakunode2_test.go
@@ -157,6 +157,7 @@ func Test500(t *testing.T) {
 			if err := wakuNode2.Publish(ctx, msg); err != nil {
 				require.Fail(t, "Could not publish all messages")
 			}
+			time.Sleep(5 * time.Millisecond)
 		}
 	}()
 

--- a/waku/v2/node/wakunode2_test.go
+++ b/waku/v2/node/wakunode2_test.go
@@ -59,8 +59,8 @@ func int2Bytes(i int) []byte {
 	return append(big.NewInt(int64(i)).Bytes(), byte(0))
 }
 
-func Test5000(t *testing.T) {
-	maxMsgs := 5000
+func Test500(t *testing.T) {
+	maxMsgs := 500
 	maxMsgBytes := int2Bytes(maxMsgs)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)

--- a/waku/v2/protocol/relay/waku_relay.go
+++ b/waku/v2/protocol/relay/waku_relay.go
@@ -30,18 +30,6 @@ const WakuRelayID_v200 = protocol.ID("/vac/waku/relay/2.0.0")
 
 var DefaultWakuTopic string = waku_proto.DefaultPubsubTopic().String()
 
-type cacheItem struct {
-	msg         *pb.WakuMessage
-	id          string
-	pubsubTopic string
-}
-
-type msgReq struct {
-	id          string
-	pubsubTopic string
-	ch          chan *pb.WakuMessage
-}
-
 type WakuRelay struct {
 	host       host.Host
 	opts       []pubsub.Option
@@ -63,10 +51,11 @@ type WakuRelay struct {
 	subscriptions      map[string][]*Subscription
 	subscriptionsMutex sync.Mutex
 
-	msgCache      map[string]*pb.WakuMessage
-	msgCacheCh    chan cacheItem
-	deleteCacheCh chan string
-	getMsgCh      chan msgReq
+	// TODO: convert to concurrent map with gc
+	msgCacheMutex     sync.Mutex
+	msgCacheDeletions int
+	msgCache          map[string]*pb.WakuMessage
+	shrinkCacheReq    chan struct{}
 
 	ctx    context.Context
 	cancel context.CancelFunc
@@ -120,10 +109,8 @@ func (w *WakuRelay) Start(ctx context.Context) error {
 	w.ctx = ctx // TODO: create worker for creating subscriptions instead of storing context
 	w.cancel = cancel
 
-	w.msgCacheCh = make(chan cacheItem)
-	w.deleteCacheCh = make(chan string)
+	w.shrinkCacheReq = make(chan struct{})
 	w.msgCache = make(map[string]*pb.WakuMessage, 1000)
-	w.getMsgCh = make(chan msgReq)
 
 	w.wg.Add(1)
 	go w.cacheWorker(ctx)
@@ -139,58 +126,46 @@ func (w *WakuRelay) Start(ctx context.Context) error {
 }
 
 func (w *WakuRelay) getMessageFromCache(topic string, id string) *pb.WakuMessage {
-	resultCh := make(chan *pb.WakuMessage, 1)
-	defer close(resultCh)
+	w.msgCacheMutex.Lock()
 
-	w.getMsgCh <- msgReq{
-		id:          id,
-		pubsubTopic: topic,
-		ch:          resultCh,
+	key := topic + id
+	msg := w.msgCache[key]
+	delete(w.msgCache, key)
+	w.msgCacheDeletions++
+	deleteCnt := w.msgCacheDeletions
+	w.msgCacheMutex.Unlock()
+
+	if deleteCnt > 1000 {
+		w.shrinkCacheReq <- struct{}{}
 	}
 
-	result := <-resultCh
-
-	w.deleteCacheCh <- topic + id
-
-	return result
+	return msg
 }
 
-func (w *WakuRelay) AddToCache(pubsubTopic string, id string, msg *pb.WakuMessage) {
-	w.msgCacheCh <- cacheItem{
-		msg:         msg,
-		id:          id,
-		pubsubTopic: pubsubTopic,
-	}
+func (w *WakuRelay) AddToCache(topic string, id string, msg *pb.WakuMessage) {
+	w.msgCacheMutex.Lock()
+	defer w.msgCacheMutex.Unlock()
+
+	key := topic + id
+	w.msgCache[key] = msg
 }
 
 func (w *WakuRelay) cacheWorker(ctx context.Context) {
 	defer w.wg.Done()
 
-	deleteCounter := 0
 	for {
 		select {
 		case <-ctx.Done():
 			return
-		case item := <-w.msgCacheCh:
-			key := item.pubsubTopic + item.id
-			_, ok := w.msgCache[key]
-			if !ok {
-				w.msgCache[item.pubsubTopic+item.id] = item.msg
-			}
-		case req := <-w.getMsgCh:
-			key := req.pubsubTopic + req.id
-			req.ch <- w.msgCache[key]
-		case key := <-w.deleteCacheCh:
-			delete(w.msgCache, key)
-			deleteCounter++
+		case <-w.shrinkCacheReq:
+			w.msgCacheMutex.Lock()
 			// Shrink msg cache to avoid oom
-			if deleteCounter > 1000 {
-				newMsgCache := make(map[string]*pb.WakuMessage, 1000)
-				for k, v := range w.msgCache {
-					newMsgCache[k] = v
-				}
-				w.msgCache = newMsgCache
+			newMsgCache := make(map[string]*pb.WakuMessage, 1000)
+			for k, v := range w.msgCache {
+				newMsgCache[k] = v
 			}
+			w.msgCache = newMsgCache
+			w.msgCacheMutex.Unlock()
 		}
 	}
 }
@@ -326,9 +301,7 @@ func (w *WakuRelay) Stop() {
 	w.cancel()
 	w.wg.Wait()
 
-	close(w.msgCacheCh)
-	close(w.deleteCacheCh)
-	close(w.getMsgCh)
+	close(w.shrinkCacheReq)
 
 	w.msgCache = nil
 

--- a/waku/v2/protocol/relay/waku_relay.go
+++ b/waku/v2/protocol/relay/waku_relay.go
@@ -10,6 +10,7 @@ import (
 
 	proto "github.com/golang/protobuf/proto"
 	"github.com/libp2p/go-libp2p/core/host"
+	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/libp2p/go-libp2p/core/protocol"
 	"go.opencensus.io/stats"
 	"go.opencensus.io/tag"
@@ -28,6 +29,18 @@ import (
 const WakuRelayID_v200 = protocol.ID("/vac/waku/relay/2.0.0")
 
 var DefaultWakuTopic string = waku_proto.DefaultPubsubTopic().String()
+
+type cacheItem struct {
+	msg         *pb.WakuMessage
+	id          string
+	pubsubTopic string
+}
+
+type msgReq struct {
+	id          string
+	pubsubTopic string
+	ch          chan *pb.WakuMessage
+}
 
 type WakuRelay struct {
 	host       host.Host
@@ -49,6 +62,14 @@ type WakuRelay struct {
 	// TODO: convert to concurrent maps
 	subscriptions      map[string][]*Subscription
 	subscriptionsMutex sync.Mutex
+
+	msgCache      map[string]*pb.WakuMessage
+	msgCacheCh    chan cacheItem
+	deleteCacheCh chan string
+	getMsgCh      chan msgReq
+
+	cancel context.CancelFunc
+	wg     sync.WaitGroup
 }
 
 func msgIdFn(pmsg *pubsub_pb.Message) string {
@@ -66,6 +87,7 @@ func NewWakuRelay(h host.Host, bcaster v2.Broadcaster, minPeersToPublish int, ti
 	w.subscriptions = make(map[string][]*Subscription)
 	w.bcaster = bcaster
 	w.minPeersToPublish = minPeersToPublish
+	w.wg = sync.WaitGroup{}
 	w.log = log.Named("relay")
 
 	// default options required by WakuRelay
@@ -92,6 +114,18 @@ func NewWakuRelay(h host.Host, bcaster v2.Broadcaster, minPeersToPublish int, ti
 }
 
 func (w *WakuRelay) Start(ctx context.Context) error {
+	w.wg.Wait()
+	ctx, cancel := context.WithCancel(ctx)
+	w.cancel = cancel
+
+	w.msgCacheCh = make(chan cacheItem, 1000)
+	w.deleteCacheCh = make(chan string, 1000)
+	w.msgCache = make(map[string]*pb.WakuMessage, 1000)
+	w.getMsgCh = make(chan msgReq, 1000)
+
+	w.wg.Add(1)
+	go w.cacheWorker(ctx)
+
 	ps, err := pubsub.NewGossipSub(ctx, w.host, w.opts...)
 	if err != nil {
 		return err
@@ -100,6 +134,56 @@ func (w *WakuRelay) Start(ctx context.Context) error {
 
 	w.log.Info("Relay protocol started")
 	return nil
+}
+
+func (w *WakuRelay) getMessageFromCache(topic string, id string) *pb.WakuMessage {
+	resultCh := make(chan *pb.WakuMessage, 1)
+	defer close(resultCh)
+
+	w.getMsgCh <- msgReq{
+		id:          id,
+		pubsubTopic: topic,
+		ch:          resultCh,
+	}
+
+	return <-resultCh
+}
+
+func (w *WakuRelay) AddToCache(pubsubTopic string, id string, msg *pb.WakuMessage) {
+	w.msgCacheCh <- cacheItem{
+		msg:         msg,
+		id:          id,
+		pubsubTopic: pubsubTopic,
+	}
+}
+
+func (w *WakuRelay) cacheWorker(ctx context.Context) {
+	defer w.wg.Done()
+
+	deleteCounter := 0
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case item := <-w.msgCacheCh:
+			w.msgCache[item.pubsubTopic+item.id] = item.msg
+		case req := <-w.getMsgCh:
+			key := req.pubsubTopic + req.id
+			req.ch <- w.msgCache[key]
+			w.deleteCacheCh <- key
+		case key := <-w.deleteCacheCh:
+			delete(w.msgCache, key)
+			deleteCounter++
+			// Shrink msg cache to avoid oom
+			if deleteCounter > 1000 {
+				newMsgCache := make(map[string]*pb.WakuMessage, 1000)
+				for k, v := range w.msgCache {
+					newMsgCache[k] = v
+				}
+				w.msgCache = newMsgCache
+			}
+		}
+	}
 }
 
 // PubSub returns the implementation of the pubsub system
@@ -140,10 +224,29 @@ func (w *WakuRelay) upsertTopic(topic string) (*pubsub.Topic, error) {
 	return pubSubTopic, nil
 }
 
+func (w *WakuRelay) validatorFactory(pubsubTopic string) func(ctx context.Context, peerID peer.ID, message *pubsub.Message) bool {
+	return func(ctx context.Context, peerID peer.ID, message *pubsub.Message) bool {
+		msg := new(pb.WakuMessage)
+		err := proto.Unmarshal(message.Data, msg)
+		if err != nil {
+			return false
+		}
+
+		w.AddToCache(pubsubTopic, message.ID, msg)
+
+		return true
+	}
+}
+
 func (w *WakuRelay) subscribe(topic string) (subs *pubsub.Subscription, err error) {
 	sub, ok := w.relaySubs[topic]
 	if !ok {
 		pubSubTopic, err := w.upsertTopic(topic)
+		if err != nil {
+			return nil, err
+		}
+
+		err = w.pubsub.RegisterTopicValidator(topic, w.validatorFactory(topic))
 		if err != nil {
 			return nil, err
 		}
@@ -205,7 +308,21 @@ func (w *WakuRelay) Publish(ctx context.Context, message *pb.WakuMessage) ([]byt
 
 // Stop unmounts the relay protocol and stops all subscriptions
 func (w *WakuRelay) Stop() {
+	if w.cancel == nil {
+		return // Not started
+	}
+
 	w.host.RemoveStreamHandler(WakuRelayID_v200)
+
+	w.cancel()
+	w.wg.Wait()
+
+	close(w.msgCacheCh)
+	close(w.deleteCacheCh)
+	close(w.getMsgCh)
+
+	w.msgCache = nil
+
 	w.subscriptionsMutex.Lock()
 	defer w.subscriptionsMutex.Unlock()
 
@@ -229,10 +346,7 @@ func (w *WakuRelay) EnoughPeersToPublishToTopic(topic string) bool {
 
 // SubscribeToTopic returns a Subscription to receive messages from a pubsub topic
 func (w *WakuRelay) SubscribeToTopic(ctx context.Context, topic string) (*Subscription, error) {
-	// Subscribes to a PubSub topic.
-	// NOTE The data field SHOULD be decoded as a WakuMessage.
 	sub, err := w.subscribe(topic)
-
 	if err != nil {
 		return nil, err
 	}
@@ -315,7 +429,7 @@ func (w *WakuRelay) nextMessage(ctx context.Context, sub *pubsub.Subscription) <
 	return msgChannel
 }
 
-func (w *WakuRelay) subscribeToTopic(ctx context.Context, t string, subscription *Subscription, sub *pubsub.Subscription) {
+func (w *WakuRelay) subscribeToTopic(ctx context.Context, pubsubTopic string, subscription *Subscription, sub *pubsub.Subscription) {
 	ctx, err := tag.New(ctx, tag.Insert(metrics.KeyType, "relay"))
 	if err != nil {
 		w.log.Error("creating tag map", zap.Error(err))
@@ -323,7 +437,6 @@ func (w *WakuRelay) subscribeToTopic(ctx context.Context, t string, subscription
 	}
 
 	subChannel := w.nextMessage(ctx, sub)
-
 	for {
 		select {
 		case <-subscription.quit:
@@ -340,20 +453,16 @@ func (w *WakuRelay) subscribeToTopic(ctx context.Context, t string, subscription
 				}
 
 				close(subscription.C)
-			}(t)
+			}(pubsubTopic)
 			// TODO: if there are no more relay subscriptions, close the pubsub subscription
 		case msg := <-subChannel:
 			if msg == nil {
 				return
 			}
 			stats.Record(ctx, metrics.Messages.M(1))
-			wakuMessage := &pb.WakuMessage{}
-			if err := proto.Unmarshal(msg.Data, wakuMessage); err != nil {
-				w.log.Error("decoding message", zap.Error(err))
-				return
-			}
 
-			envelope := waku_proto.NewEnvelope(wakuMessage, w.timesource.Now().UnixNano(), string(t))
+			wakuMessage := w.getMessageFromCache(pubsubTopic, msg.ID)
+			envelope := waku_proto.NewEnvelope(wakuMessage, w.timesource.Now().UnixNano(), string(pubsubTopic))
 
 			w.log.Info("waku.relay received", logging.HexString("hash", envelope.Hash()))
 

--- a/waku/v2/protocol/relay/waku_relay_test.go
+++ b/waku/v2/protocol/relay/waku_relay_test.go
@@ -35,6 +35,7 @@ func TestWakuRelay(t *testing.T) {
 	require.Equal(t, testTopic, topics[0])
 
 	ctx, cancel := context.WithCancel(context.Background())
+
 	go func() {
 		defer cancel()
 

--- a/waku/v2/protocol/rln/waku_rln_relay.go
+++ b/waku/v2/protocol/rln/waku_rln_relay.go
@@ -372,6 +372,9 @@ func (r *WakuRLNRelay) addValidator(
 				zap.Binary("payload", wakuMessage.Payload),
 				zap.Any("proof", wakuMessage.RateLimitProof),
 			)
+
+			relay.AddToCache(pubsubTopic, message.ID, wakuMessage)
+
 			return true
 		case MessageValidationResult_Invalid:
 			r.log.Debug("message could not be verified",
@@ -403,6 +406,9 @@ func (r *WakuRLNRelay) addValidator(
 			return false
 		}
 	}
+
+	// In case there's a topic validator registered
+	_ = relay.PubSub().UnregisterTopicValidator(pubsubTopic)
 
 	return relay.PubSub().RegisterTopicValidator(pubsubTopic, validator)
 }

--- a/waku/v2/rest/relay.go
+++ b/waku/v2/rest/relay.go
@@ -165,10 +165,8 @@ func (d *RelayService) getV1Messages(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var response []*pb.WakuMessage
-	for i := range d.messages[topic] {
-		response = append(response, d.messages[topic][i])
-	}
+	response := d.messages[topic]
+
 	d.messages[topic] = []*pb.WakuMessage{}
 	writeErrOrResponse(w, nil, response)
 }


### PR DESCRIPTION
This also stores the waku message in a cache to avoid having to decode it twice.
RLN validator is also modified to store the messages in the cache
Matches https://github.com/waku-org/nwaku/pull/1537