### PR TITLE
feat(c-bindings): expose store protocol

### DIFF
--- a/library/README.md
+++ b/library/README.md
@@ -277,6 +277,10 @@ interface JsonConfig {
     discV5?: boolean;
     discV5BootstrapNodes?: Array<string>;
     discV5UDPPort?: number;
+    store?: boolean;
+    databaseURL?: string;
+    storeRetentionMaxMessages?: number;
+    storeRetentionTimeSeconds?: number;
 }
 ```
 
@@ -311,6 +315,15 @@ If a key is `undefined`, or `null`, a default value will be set.
 - `discV5BootstrapNodes`: Array of bootstrap nodes ENR
 - `discV5UDPPort`: UDP port for DiscoveryV5
   Default `9000`
+- `store`: Enable store protocol to persist message history
+  Default `false`
+- `databaseURL`: url connection string. Accepts SQLite and PostgreSQL connection strings
+  Default: `sqlite3://store.db`
+- `storeRetentionMaxMessages`: max number of messages to store in the database.
+  Default `10000`
+- `storeRetentionTimeSeconds`: max number of seconds that a message will be persisted in the database.
+  Default `2592000` (30d)
+
   
 For example:
 ```json

--- a/library/api.go
+++ b/library/api.go
@@ -34,6 +34,10 @@ func main() {}
 // - discV5BootstrapNodes: Array of bootstrap nodes ENR
 // - discV5UDPPort: UDP port for DiscoveryV5
 // - logLevel: Set the log level. Default `INFO`. Allowed values "DEBUG", "INFO", "WARN", "ERROR", "DPANIC", "PANIC", "FATAL"
+// - store: Enable Store. Default `false`
+// - databaseURL: url connection string. Default: "sqlite3://store.db". Also accepts PostgreSQL connection strings
+// - storeRetentionMaxMessages: max number of messages to store in the database. Default 10000
+// - storeRetentionTimeSeconds: max number of seconds that a message will be persisted in the database. Default 2592000 (30d)
 //
 //export waku_new
 func waku_new(configJSON *C.char) *C.char {

--- a/library/api_store.go
+++ b/library/api_store.go
@@ -40,3 +40,36 @@ func waku_store_query(queryJSON *C.char, peerID *C.char, ms C.int) *C.char {
 	response := mobile.StoreQuery(C.GoString(queryJSON), C.GoString(peerID), int(ms))
 	return C.CString(response)
 }
+
+// Query historic messages stored in the localDB using waku store protocol.
+// queryJSON must contain a valid json string with the following format:
+//
+//	{
+//		"pubsubTopic": "...", // optional string
+//	 "startTime": 1234, // optional, unix epoch time in nanoseconds
+//	 "endTime": 1234, // optional, unix epoch time in nanoseconds
+//	 "contentFilters": [ // optional
+//			{
+//		      contentTopic: "contentTopic1"
+//			}, ...
+//	 ],
+//	 "pagingOptions": {// optional pagination information
+//	     "pageSize": 40, // number
+//			"cursor": { // optional
+//				"digest": ...,
+//				"receiverTime": ...,
+//				"senderTime": ...,
+//				"pubsubTopic" ...,
+//	     }
+//			"forward": true, // sort order
+//	 }
+//	}
+//
+// If a non empty cursor is returned, this function should be executed again, setting  the `cursor` attribute with the cursor returned in the response
+// Requires the `store` option to be passed when setting up the initial configuration
+//
+//export waku_store_local_query
+func waku_store_local_query(queryJSON *C.char) *C.char {
+	response := mobile.StoreLocalQuery(C.GoString(queryJSON))
+	return C.CString(response)
+}

--- a/waku/db.go
+++ b/waku/db.go
@@ -18,7 +18,7 @@ func validateDBUrl(val string) error {
 	return nil
 }
 
-func extractDBAndMigration(databaseURL string) (*sql.DB, func(*sql.DB) error, error) {
+func ExtractDBAndMigration(databaseURL string) (*sql.DB, func(*sql.DB) error, error) {
 	var db *sql.DB
 	var migrationFn func(*sql.DB) error
 	var err error

--- a/waku/node.go
+++ b/waku/node.go
@@ -101,7 +101,7 @@ func Execute(options Options) {
 	var db *sql.DB
 	var migrationFn func(*sql.DB) error
 	if options.Store.Enable {
-		db, migrationFn, err = extractDBAndMigration(options.Store.DatabaseURL)
+		db, migrationFn, err = ExtractDBAndMigration(options.Store.DatabaseURL)
 		failOnErr(err, "Could not connect to DB")
 	}
 


### PR DESCRIPTION
Allows an application using the c-bindings to act as a storenode


Adds the following config items:
```
- `store`: Enable store protocol to persist message history
  Default `false`
- `databaseURL`: url connection string. Accepts SQLite and PostgreSQL connection strings
  Default: `sqlite3://store.db`
- `storeRetentionMaxMessages`: max number of messages to store in the database.
  Default `10000`
- `storeRetentionTimeSeconds`: max number of seconds that a message will be persisted in the database.
  Default `2592000` (30d)
```

And a new function to retrieve data from local database:
```c
// Query historic messages stored in the localDB
// queryJSON must contain a valid json string with the following format:
//
//	{
//		"pubsubTopic": "...", // optional string
//	 "startTime": 1234, // optional, unix epoch time in nanoseconds
//	 "endTime": 1234, // optional, unix epoch time in nanoseconds
//	 "contentFilters": [ // optional
//			{
//		      contentTopic: "contentTopic1"
//			}, ...
//	 ],
//	 "pagingOptions": {// optional pagination information
//	     "pageSize": 40, // number
//			"cursor": { // optional
//				"digest": ...,
//				"receiverTime": ...,
//				"senderTime": ...,
//				"pubsubTopic" ...,
//	     }
//			"forward": true, // sort order
//	 }
//	}
//
// If a non empty cursor is returned, this function should be executed again, setting  the `cursor` attribute with the cursor returned in the response
// Requires the `store` option to be passed when setting up the initial configuration
//
extern char* waku_store_local_query(char* queryJSON);
```
