### PR TITLE
chore: use go-chi for rest server instead of archived gorilla/rpc

### DIFF
--- a/waku/v2/rest/debug.go
+++ b/waku/v2/rest/debug.go
@@ -3,13 +3,13 @@ package rest
 import (
 	"net/http"
 
-	"github.com/gorilla/mux"
+	"github.com/go-chi/chi/v5"
 	"github.com/waku-org/go-waku/waku/v2/node"
 )
 
 type DebugService struct {
 	node *node.WakuNode
-	mux  *mux.Router
+	mux  *chi.Mux
 }
 
 type InfoArgs struct {
@@ -23,14 +23,14 @@ type InfoReply struct {
 const ROUTE_DEBUG_INFOV1 = "/debug/v1/info"
 const ROUTE_DEBUG_VERSIONV1 = "/debug/v1/info"
 
-func NewDebugService(node *node.WakuNode, m *mux.Router) *DebugService {
+func NewDebugService(node *node.WakuNode, m *chi.Mux) *DebugService {
 	d := &DebugService{
 		node: node,
 		mux:  m,
 	}
 
-	m.HandleFunc(ROUTE_DEBUG_INFOV1, d.getV1Info).Methods(http.MethodGet)
-	m.HandleFunc(ROUTE_DEBUG_VERSIONV1, d.getV1Version).Methods(http.MethodGet)
+	m.Get(ROUTE_DEBUG_INFOV1, d.getV1Info)
+	m.Get(ROUTE_DEBUG_VERSIONV1, d.getV1Version)
 
 	return d
 }

--- a/waku/v2/rest/waku_rest.go
+++ b/waku/v2/rest/waku_rest.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"net/http/pprof"
 	"sync"
 
-	"github.com/gorilla/mux"
+	"github.com/go-chi/chi/v5"
+	"github.com/go-chi/chi/v5/middleware"
 	"github.com/waku-org/go-waku/waku/v2/node"
 	"go.uber.org/zap"
 )
@@ -25,11 +25,12 @@ func NewWakuRest(node *node.WakuNode, address string, port int, enableAdmin bool
 	wrpc := new(WakuRest)
 	wrpc.log = log.Named("rest")
 
-	mux := mux.NewRouter()
+	mux := chi.NewRouter()
+	mux.Use(middleware.Logger)
+	mux.Use(middleware.NoCache)
 
 	if enablePProf {
-		mux.PathPrefix("/debug/").Handler(http.DefaultServeMux)
-		mux.HandleFunc("/debug/pprof/", pprof.Index)
+		mux.Mount("/debug", middleware.Profiler())
 	}
 
 	_ = NewDebugService(node, mux)


### PR DESCRIPTION
- RPC server is not modified since it's going to be deprecated