### PR TITLE
feat(c-bindings): expose enr via dns-discovery

### DIFF
--- a/library/README.md
+++ b/library/README.md
@@ -1045,7 +1045,7 @@ An `error` message otherwise.
 ## DNS Discovery
 
 ### `extern char* waku_dns_discovery(char* url, char* nameserver, int timeoutMs)`
-Returns a list of multiaddress given a url to a DNS discoverable ENR tree
+Returns a list of multiaddress and enrs given a url to a DNS discoverable ENR tree
 
 **Parameters**
 
@@ -1060,16 +1060,21 @@ Returns a list of multiaddress given a url to a DNS discoverable ENR tree
 **Returns**
 
 A [`JsonResponse`](#jsonresponse-type).
-If the execution is successful, the `result` field contains an array with multiaddresses.
+If the execution is successful, the `result` field contains an array objects describing the multiaddresses, enr and peerID each node found has.
 An `error` message otherwise.
 
 ```json
 {
-  "result": [
-    "/ip4/134.209.139.210/tcp/30303/p2p/16Uiu2HAmPLe7Mzm8TsYUubgCAW1aJoeFScxrLj8ppHFivPo97bUZ",
-    "/ip4/104.154.239.128/tcp/30303/p2p/16Uiu2HAmJb2e28qLXxT5kZxVUUoJt72EMzNGXB47Rxx5hw3q4YjS",
-    "/ip4/47.242.210.73/tcp/30303/p2p/16Uiu2HAkvWiyFsgRhuJEb9JfjYxEkoHLgnUQmr1N5mKWnYjxYRVm"
-  ]
+  "result":[
+    {
+        "peerID":"16Uiu2HAmPLe7Mzm8TsYUubgCAW1aJoeFScxrLj8ppHFivPo97bUZ",
+        "multiaddrs":[
+            "/ip4/134.209.139.210/tcp/30303/p2p/16Uiu2HAmPLe7Mzm8TsYUubgCAW1aJoeFScxrLj8ppHFivPo97bUZ",
+            "/dns4/node-01.do-ams3.wakuv2.test.statusim.net/tcp/8000/wss/p2p/16Uiu2HAmPLe7Mzm8TsYUubgCAW1aJoeFScxrLj8ppHFivPo97bUZ"
+        ],
+        "enr":"enr:-M-4QCtJKX2WDloRYDT4yjeMGKUCRRcMlsNiZP3cnPO0HZn6IdJ035RPCqsQ5NvTyjqHzKnTM6pc2LoKliV4CeV0WrgBgmlkgnY0gmlwhIbRi9KKbXVsdGlhZGRyc7EALzYobm9kZS0wMS5kby1hbXMzLndha3V2Mi50ZXN0LnN0YXR1c2ltLm5ldAYfQN4DiXNlY3AyNTZrMaEDnr03Tuo77930a7sYLikftxnuG3BbC3gCFhA4632ooDaDdGNwgnZfg3VkcIIjKIV3YWt1Mg8"
+    },
+    ...
 }
 ```
 

--- a/library/api_discovery.go
+++ b/library/api_discovery.go
@@ -6,7 +6,8 @@ import (
 	mobile "github.com/waku-org/go-waku/mobile"
 )
 
-// Returns a list of multiaddress given a url to a DNS discoverable ENR tree
+// Returns a list of objects containing the peerID, enr and multiaddresses for each node found
+//  given a url to a DNS discoverable ENR tree
 // The nameserver can optionally be specified to resolve the enrtree url. Otherwise NULL or
 // empty to automatically use the default system dns.
 // If ms is greater than 0, the subscription must happen before the timeout

--- a/mobile/api_discovery.go
+++ b/mobile/api_discovery.go
@@ -9,8 +9,8 @@ import (
 )
 
 type DnsDiscoveryItem struct {
-	PeerID    string   `json:"peerID,omitempty"`
-	Addresses []string `json:"multiaddrs,omitempty"`
+	PeerID    string   `json:"peerID"`
+	Addresses []string `json:"multiaddrs"`
 	ENR       string   `json:"enr,omitempty"`
 }
 

--- a/mobile/api_filter.go
+++ b/mobile/api_filter.go
@@ -38,7 +38,7 @@ func FilterSubscribe(filterJSON string, peerID string, ms int) string {
 		return MakeJSONResponse(err)
 	}
 
-	if wakuNode == nil {
+	if wakuState.node == nil {
 		return MakeJSONResponse(errWakuNodeNotReady)
 	}
 
@@ -63,7 +63,7 @@ func FilterSubscribe(filterJSON string, peerID string, ms int) string {
 		fOptions = append(fOptions, filter.WithAutomaticPeerSelection())
 	}
 
-	_, f, err := wakuNode.Filter().Subscribe(ctx, cf, fOptions...)
+	_, f, err := wakuState.node.Filter().Subscribe(ctx, cf, fOptions...)
 	if err != nil {
 		return MakeJSONResponse(err)
 	}
@@ -83,7 +83,7 @@ func FilterUnsubscribe(filterJSON string, ms int) string {
 		return MakeJSONResponse(err)
 	}
 
-	if wakuNode == nil {
+	if wakuState.node == nil {
 		return MakeJSONResponse(errWakuNodeNotReady)
 	}
 
@@ -97,7 +97,7 @@ func FilterUnsubscribe(filterJSON string, ms int) string {
 		ctx = context.Background()
 	}
 
-	err = wakuNode.Filter().UnsubscribeFilter(ctx, cf)
+	err = wakuState.node.Filter().UnsubscribeFilter(ctx, cf)
 	if err != nil {
 		return MakeJSONResponse(err)
 	}

--- a/mobile/api_lightpush.go
+++ b/mobile/api_lightpush.go
@@ -12,7 +12,7 @@ import (
 )
 
 func lightpushPublish(msg *pb.WakuMessage, pubsubTopic string, peerID string, ms int) (string, error) {
-	if wakuNode == nil {
+	if wakuState.node == nil {
 		return "", errWakuNodeNotReady
 	}
 
@@ -37,7 +37,7 @@ func lightpushPublish(msg *pb.WakuMessage, pubsubTopic string, peerID string, ms
 		lpOptions = append(lpOptions, lightpush.WithAutomaticPeerSelection())
 	}
 
-	hash, err := wakuNode.Lightpush().PublishToTopic(ctx, msg, pubsubTopic, lpOptions...)
+	hash, err := wakuState.node.Lightpush().PublishToTopic(ctx, msg, pubsubTopic, lpOptions...)
 	return hexutil.Encode(hash), err
 }
 

--- a/mobile/api_relay.go
+++ b/mobile/api_relay.go
@@ -16,7 +16,7 @@ var relaySubscriptions map[string]*relay.Subscription = make(map[string]*relay.S
 var relaySubsMutex sync.Mutex
 
 func RelayEnoughPeers(topic string) string {
-	if wakuNode == nil {
+	if wakuState.node == nil {
 		return MakeJSONResponse(errWakuNodeNotReady)
 	}
 
@@ -25,11 +25,11 @@ func RelayEnoughPeers(topic string) string {
 		topicToCheck = topic
 	}
 
-	return PrepareJSONResponse(wakuNode.Relay().EnoughPeersToPublishToTopic(topicToCheck), nil)
+	return PrepareJSONResponse(wakuState.node.Relay().EnoughPeersToPublishToTopic(topicToCheck), nil)
 }
 
 func relayPublish(msg *pb.WakuMessage, pubsubTopic string, ms int) (string, error) {
-	if wakuNode == nil {
+	if wakuState.node == nil {
 		return "", errWakuNodeNotReady
 	}
 
@@ -43,7 +43,7 @@ func relayPublish(msg *pb.WakuMessage, pubsubTopic string, ms int) (string, erro
 		ctx = context.Background()
 	}
 
-	hash, err := wakuNode.Relay().PublishToTopic(ctx, msg, pubsubTopic)
+	hash, err := wakuState.node.Relay().PublishToTopic(ctx, msg, pubsubTopic)
 	return hexutil.Encode(hash), err
 }
 
@@ -80,7 +80,7 @@ func RelayPublishEncodeSymmetric(messageJSON string, topic string, symmetricKey 
 }
 
 func RelaySubscribe(topic string) string {
-	if wakuNode == nil {
+	if wakuState.node == nil {
 		return MakeJSONResponse(errWakuNodeNotReady)
 	}
 
@@ -94,7 +94,7 @@ func RelaySubscribe(topic string) string {
 		return MakeJSONResponse(nil)
 	}
 
-	subscription, err := wakuNode.Relay().SubscribeToTopic(context.Background(), topicToSubscribe)
+	subscription, err := wakuState.node.Relay().SubscribeToTopic(context.Background(), topicToSubscribe)
 	if err != nil {
 		return MakeJSONResponse(err)
 	}
@@ -111,7 +111,7 @@ func RelaySubscribe(topic string) string {
 }
 
 func RelayUnsubscribe(topic string) string {
-	if wakuNode == nil {
+	if wakuState.node == nil {
 		return MakeJSONResponse(errWakuNodeNotReady)
 	}
 
@@ -129,7 +129,7 @@ func RelayUnsubscribe(topic string) string {
 
 	delete(relaySubscriptions, topicToUnsubscribe)
 
-	err := wakuNode.Relay().Unsubscribe(context.Background(), topicToUnsubscribe)
+	err := wakuState.node.Relay().Unsubscribe(context.Background(), topicToUnsubscribe)
 	if err != nil {
 		return MakeJSONResponse(err)
 	}

--- a/mobile/api_store.go
+++ b/mobile/api_store.go
@@ -41,7 +41,7 @@ func queryResponse(ctx context.Context, args storeMessagesArgs, options []store.
 		contentTopics = append(contentTopics, ct.ContentTopic)
 	}
 
-	res, err := wakuNode.Store().Query(
+	res, err := wakuState.node.Store().Query(
 		ctx,
 		store.Query{
 			Topic:         args.Topic,
@@ -69,7 +69,7 @@ func queryResponse(ctx context.Context, args storeMessagesArgs, options []store.
 }
 
 func StoreQuery(queryJSON string, peerID string, ms int) string {
-	if wakuNode == nil {
+	if wakuState.node == nil {
 		return MakeJSONResponse(errWakuNodeNotReady)
 	}
 
@@ -109,7 +109,7 @@ func StoreQuery(queryJSON string, peerID string, ms int) string {
 }
 
 func StoreLocalQuery(queryJSON string) string {
-	if wakuNode == nil {
+	if wakuState.node == nil {
 		return MakeJSONResponse(errWakuNodeNotReady)
 	}
 

--- a/waku/v2/discv5/discover.go
+++ b/waku/v2/discv5/discover.go
@@ -288,7 +288,7 @@ func (d *DiscoveryV5) iterate(ctx context.Context) error {
 			break
 		}
 
-		addresses, err := utils.Multiaddress(iterator.Node())
+		_, addresses, err := utils.Multiaddress(iterator.Node())
 		if err != nil {
 			d.log.Error("extracting multiaddrs from enr", zap.Error(err))
 			continue

--- a/waku/v2/dnsdisc/enr.go
+++ b/waku/v2/dnsdisc/enr.go
@@ -6,6 +6,7 @@ import (
 	"github.com/ethereum/go-ethereum/p2p/dnsdisc"
 	"github.com/ethereum/go-ethereum/p2p/enode"
 	"github.com/ethereum/go-ethereum/p2p/enr"
+	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/waku-org/go-waku/waku/v2/utils"
 
 	ma "github.com/multiformats/go-multiaddr"
@@ -25,6 +26,7 @@ func WithNameserver(nameserver string) DnsDiscoveryOption {
 }
 
 type DiscoveredNode struct {
+	PeerID    peer.ID
 	Addresses []ma.Multiaddr
 	ENR       *enode.Node
 }
@@ -48,12 +50,16 @@ func RetrieveNodes(ctx context.Context, url string, opts ...DnsDiscoveryOption) 
 	}
 
 	for _, node := range tree.Nodes() {
-		m, err := utils.Multiaddress(node)
+		peerID, m, err := utils.Multiaddress(node)
 		if err != nil {
 			return nil, err
 		}
 
-		d := DiscoveredNode{Addresses: m}
+		d := DiscoveredNode{
+			PeerID:    peerID,
+			Addresses: m,
+		}
+
 		if hasUDP(node) {
 			d.ENR = node
 		}

--- a/waku/v2/protocol/peer_exchange/waku_peer_exchange.go
+++ b/waku/v2/protocol/peer_exchange/waku_peer_exchange.go
@@ -343,7 +343,7 @@ func (wakuPX *WakuPeerExchange) iterate(ctx context.Context) error {
 			break
 		}
 
-		addresses, err := utils.Multiaddress(iterator.Node())
+		_, addresses, err := utils.Multiaddress(iterator.Node())
 		if err != nil {
 			wakuPX.log.Error("extracting multiaddrs from enr", zap.Error(err))
 			continue

--- a/waku/v2/utils/enr_test.go
+++ b/waku/v2/utils/enr_test.go
@@ -156,6 +156,6 @@ func TestMultiaddr(t *testing.T) {
 
 	_ = localNode.Node() // Should not panic
 
-	_, err = Multiaddress(localNode.Node())
+	_, _, err = Multiaddress(localNode.Node())
 	require.NoError(t, err)
 }


### PR DESCRIPTION
This is a breaking change that modifies the `waku_dns_discovery` function response. Instead of returning an array of multiaddresses, it returns an array of objects with the following structure:

```js
{"result":[
    // Node 1
    {
        "peerID":"16Uiu2HAmPLe7Mzm8TsYUubgCAW1aJoeFScxrLj8ppHFivPo97bUZ",
        "multiaddrs":[
            "/ip4/134.209.139.210/tcp/30303/p2p/16Uiu2HAmPLe7Mzm8TsYUubgCAW1aJoeFScxrLj8ppHFivPo97bUZ",
            "/dns4/node-01.do-ams3.wakuv2.test.statusim.net/tcp/8000/wss/p2p/16Uiu2HAmPLe7Mzm8TsYUubgCAW1aJoeFScxrLj8ppHFivPo97bUZ"
        ],
        "enr":"enr:-M-4QCtJKX2WDloRYDT4yjeMGKUCRRcMlsNiZP3cnPO0HZn6IdJ035RPCqsQ5NvTyjqHzKnTM6pc2LoKliV4CeV0WrgBgmlkgnY0gmlwhIbRi9KKbXVsdGlhZGRyc7EALzYobm9kZS0wMS5kby1hbXMzLndha3V2Mi50ZXN0LnN0YXR1c2ltLm5ldAYfQN4DiXNlY3AyNTZrMaEDnr03Tuo77930a7sYLikftxnuG3BbC3gCFhA4632ooDaDdGNwgnZfg3VkcIIjKIV3YWt1Mg8"
    },
    ...
    // Node N....
}
```