### PR TITLE
fix: use base64url encoding

### DIFF
--- a/waku/v2/rpc/rpc_type.go
+++ b/waku/v2/rpc/rpc_type.go
@@ -1,8 +1,44 @@
 package rpc
 
+import (
+	"encoding/base64"
+	"strings"
+)
+
 type SuccessReply = bool
 
 type Empty struct {
 }
 
 type MessagesReply = []*RPCWakuMessage
+
+type Base64URLByte []byte
+
+func (u Base64URLByte) MarshalJSON() ([]byte, error) {
+	base64Value := base64.URLEncoding.EncodeToString(u)
+	return []byte("\"" + base64Value + "\""), nil
+}
+
+func (h *Base64URLByte) UnmarshalText(b []byte) error {
+	inputValue := ""
+	if b != nil {
+		inputValue = string(b)
+	}
+
+	enc := base64.StdEncoding
+	if strings.ContainsAny(inputValue, "-_") {
+		enc = base64.URLEncoding
+	}
+	if len(inputValue)%4 != 0 {
+		enc = enc.WithPadding(base64.NoPadding)
+	}
+
+	decodedBytes, err := enc.DecodeString(inputValue)
+	if err != nil {
+		return err
+	}
+
+	*h = decodedBytes
+
+	return nil
+}

--- a/waku/v2/rpc/util_test.go
+++ b/waku/v2/rpc/util_test.go
@@ -2,14 +2,38 @@ package rpc
 
 import (
 	"bytes"
+	"encoding/base64"
+	"encoding/json"
 	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"github.com/waku-org/go-waku/waku/v2/protocol/pb"
 )
 
 func makeRequest(t *testing.T) *http.Request {
 	request, err := http.NewRequest(http.MethodPost, "url", bytes.NewReader([]byte("")))
 	require.NoError(t, err)
 	return request
+}
+
+func TestBase64Encoding(t *testing.T) {
+	input := "Hello World"
+
+	rpcMsg := ProtoToRPC(&pb.WakuMessage{
+		Payload: []byte(input),
+	})
+
+	jsonBytes, err := json.Marshal(rpcMsg)
+	require.NoError(t, err)
+
+	m := make(map[string]interface{})
+	err = json.Unmarshal(jsonBytes, &m)
+	require.NoError(t, err)
+	require.Equal(t, base64.URLEncoding.EncodeToString([]byte(input)), m["payload"])
+
+	decodedRpcMsg := new(RPCWakuMessage)
+	err = json.Unmarshal(jsonBytes, decodedRpcMsg)
+	require.NoError(t, err)
+	require.Equal(t, input, string(decodedRpcMsg.Payload))
 }

--- a/waku/v2/rpc/utils.go
+++ b/waku/v2/rpc/utils.go
@@ -5,17 +5,17 @@ import (
 )
 
 type RateLimitProof struct {
-	Proof         []byte `json:"proof,omitempty"`
-	MerkleRoot    []byte `json:"merkle_root,omitempty"`
-	Epoch         []byte `json:"epoch,omitempty"`
-	ShareX        []byte `json:"share_x,omitempty"`
-	ShareY        []byte `json:"share_y,omitempty"`
-	Nullifier     []byte `json:"nullifier,omitempty"`
-	RlnIdentifier []byte `json:"rln_identifier,omitempty"`
+	Proof         Base64URLByte `json:"proof,omitempty"`
+	MerkleRoot    Base64URLByte `json:"merkle_root,omitempty"`
+	Epoch         Base64URLByte `json:"epoch,omitempty"`
+	ShareX        Base64URLByte `json:"share_x,omitempty"`
+	ShareY        Base64URLByte `json:"share_y,omitempty"`
+	Nullifier     Base64URLByte `json:"nullifier,omitempty"`
+	RlnIdentifier Base64URLByte `json:"rln_identifier,omitempty"`
 }
 
 type RPCWakuMessage struct {
-	Payload        []byte          `json:"payload,omitempty"`
+	Payload        Base64URLByte   `json:"payload,omitempty"`
 	ContentTopic   string          `json:"contentTopic,omitempty"`
 	Version        uint32          `json:"version"`
 	Timestamp      int64           `json:"timestamp,omitempty"`


### PR DESCRIPTION
Uses base64url encoding as described in https://github.com/vacp2p/rfc/pull/574