### PR TITLE
fix: use sync.Pool for msgId hasher

### DIFF
--- a/waku/v2/protocol/relay/waku_relay_test.go
+++ b/waku/v2/protocol/relay/waku_relay_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"testing"
 
+	pubsub_pb "github.com/libp2p/go-libp2p-pubsub/pb"
 	"github.com/stretchr/testify/require"
 	"github.com/waku-org/go-waku/tests"
 	"github.com/waku-org/go-waku/waku/v2/protocol/pb"
@@ -52,4 +53,18 @@ func TestWakuRelay(t *testing.T) {
 	require.NoError(t, err)
 
 	<-ctx.Done()
+}
+
+func TestMsgID(t *testing.T) {
+	expectedMsgIdBytes := []byte{208, 214, 63, 55, 144, 6, 206, 39, 40, 251, 138, 74, 66, 168, 43, 32, 91, 94, 149, 122, 237, 198, 149, 87, 232, 156, 197, 34, 53, 131, 78, 112}
+
+	topic := "abcde"
+	msg := &pubsub_pb.Message{
+		Data:  []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11},
+		Topic: &topic,
+	}
+
+	msgId := msgIdFn(msg)
+
+	require.Equal(t, expectedMsgIdBytes, []byte(msgId))
 }


### PR DESCRIPTION
cc: @LNSD in case something similar could be happening in nwaku.


While executing pprof, I got the following results, where the msgIdFn accounts for 29.95% of objects in memory due to the way hashers are created when using `sha256.Sum256` function. To avoid this happening, I'm using a pool so i can reuse hashers

```
File: waku
Build ID: 8a9ce1246202e29639f22ec01594a1f8d7eb753e
Type: inuse_objects
Time: Mar 2, 2023 at 12:52pm (UTC)
Entering interactive mode (type "help" for commands, "o" for options)
(pprof) top
Showing nodes accounting for 811015, 98.84% of 820504 total
Dropped 113 nodes (cum <= 4102)
Showing top 10 nodes out of 43
      flat  flat%   sum%        cum   cum%
    245767 29.95% 29.95%     245767 29.95%  github.com/waku-org/go-waku/waku/v2/protocol/relay.msgIdFn
    196608 23.96% 53.92%     196608 23.96%  github.com/libp2p/go-cidranger/net.NetworkNumberMask.Mask
     98305 11.98% 65.90%      98305 11.98%  net.CIDRMask (inline)
     98305 11.98% 77.88%      98305 11.98%  net.IP.Mask
     76454  9.32% 87.20%      76454  9.32%  github.com/libp2p/go-cidranger.newPrefixTree (inline)
     49155  5.99% 93.19%     475137 57.91%  github.com/libp2p/go-libp2p-asn-util.newAsnStore
     32768  3.99% 97.18%      32768  3.99%  github.com/waku-org/go-discover/discover/v5wire.deriveKeys
      8192     1% 98.18%       9096  1.11%  github.com/syndtr/goleveldb/leveldb/table.(*Reader).readBlock
      5461  0.67% 98.84%       5461  0.67%  github.com/libp2p/go-mplex.NewMultiplex
         0     0% 98.84%       8806  1.07%  github.com/ethereum/go-ethereum/p2p/enode.(*DB).expireNodes
(pprof) list relay.msgIdFn
Total: 820504
ROUTINE ======================== github.com/waku-org/go-waku/waku/v2/protocol/relay.msgIdFn in /root/go-waku/waku/v2/protocol/relay/waku_relay.go
    245767     245767 (flat, cum) 29.95% of Total
         .          .     54:func msgIdFn(pmsg *pubsub_pb.Message) string {
         .          .     55:	hash := sha256.Sum256(pmsg.Data)
    245767     245767     56:	return string(hash[:])
         .          .     57:}
         .          .     58:
         .          .     59:// NewWakuRelay returns a new instance of a WakuRelay struct
         .          .     60:func NewWakuRelay(h host.Host, bcaster v2.Broadcaster, minPeersToPublish int, timesource timesource.Timesource, log *zap.Logger, opts ...pubsub.Option) *WakuRelay {
         .          .     61:	w := new(WakuRelay)
(pprof) 
```
