### PR TITLE
nix: add Nix flake to build node and library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,8 @@ Gowaku.xcframework
 # Icon must end with two \r
 Icon
 
+# Nix
+result
 
 # Thumbnails
 ._*

--- a/README.md
+++ b/README.md
@@ -21,6 +21,19 @@ make
 # See the available command line options with
 ./build/waku --help
 ```
+#### Nix
+You can build Waku v2 node using [Nix](https://nixos.org/) [Flakes](https://nixos.wiki/wiki/Flakes):
+```sh
+nix build github:waku-org/go-waku
+```
+Or build the library using:
+```
+nix build github:waku-org/go-waku#library
+```
+To start a shell with build dependencies use:
+```
+nix develop
+```
 
 #### Docker
 ```

--- a/ci/Jenkinsfile.nix-flake
+++ b/ci/Jenkinsfile.nix-flake
@@ -1,0 +1,70 @@
+library 'status-jenkins-lib@v1.6.8'
+
+pipeline {
+  agent {
+    label 'linux'
+  }
+
+  options {
+    timestamps()
+    disableConcurrentBuilds()
+    /* Prevent Jenkins jobs from running forever */
+    timeout(time: 30, unit: 'MINUTES')
+    /* Limit builds retained */
+    buildDiscarder(logRotator(
+      numToKeepStr: '10',
+      daysToKeepStr: '20',
+      artifactNumToKeepStr: '10',
+    ))
+  }
+
+  environment {
+    TARGET = 'nix-flake'
+  }
+
+  stages {
+    stage('Node') {
+      stages {
+        stage('Build') {
+          steps { script {
+            sh("""#!/usr/bin/env bash
+              ${nix._sourceProfileInline()}
+              nix build --print-out-paths .#node
+            """)
+          } }
+        }
+        stage('Check') {
+          steps {
+            sh './result/bin/waku --version'
+          }
+        }
+      }
+    }
+
+    stage('Library') {
+      stages {
+        stage('Build') {
+          steps { script {
+            sh("""#!/usr/bin/env bash
+              ${nix._sourceProfileInline()}
+              nix build --print-out-paths .#library
+            """)
+          } }
+        }
+        stage('Check') {
+          steps {
+            sh 'ldd ./result/bin/library'
+          }
+        }
+      }
+    }
+  }
+  post {
+    always { script { /* No artifact but a PKG_URL is necessary. */
+      env.PKG_URL = "${currentBuild.absoluteUrl}/consoleText"
+    } }
+    success { script { github.notifyPR(true) } }
+    failure { script { github.notifyPR(false) } }
+    cleanup { cleanWs() }
+  }
+}

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1677779205,
+        "narHash": "sha256-6DBjL9wjq86p2GczmwnHtFRnWPBPItc67gapWENBgX8=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "96e18717904dfedcd884541e5a92bf9ff632cf39",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-22.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,44 @@
+{
+  description = "Nix flake for Go implementaion of Waku v2 node.";
+
+  inputs.nixpkgs.url = github:NixOS/nixpkgs/nixos-22.11;
+
+  outputs = { self, nixpkgs }:
+    let
+      supportedSystems = [ "x86_64-linux" "i686-linux" "aarch64-linux" ];
+      forAllSystems = f: nixpkgs.lib.genAttrs supportedSystems (system: f system);
+
+      nixpkgsFor = forAllSystems (system: import nixpkgs { inherit system; });
+
+      buildPackage = system: subPackages:
+        let
+          pkgs = nixpkgsFor.${system};
+          commit = builtins.substring 0 7 (self.rev or "dirty");
+          version = builtins.readFile ./VERSION;
+        in pkgs.buildGo119Module {
+          name = "go-waku";
+          src = self;
+          inherit subPackages;
+          ldflags = [
+            "-X github.com/waku-org/go-waku/waku/v2/node.GitCommit=${commit}"
+            "-X github.com/waku-org/go-waku/waku/v2/node.Version=${version}"
+          ];
+          doCheck = false;
+          # FIXME: This needs to be manually changed when updating modules.
+          vendorSha256 = "sha256-TvQfLQEYDujfXInQ+i/LoSGtedozZvX8WgzpqiryYHY=";
+        };
+    in rec {
+      packages = forAllSystems (system: {
+        node    = buildPackage system ["cmd/waku"];
+        library = buildPackage system ["library"];
+      });
+
+      defaultPackage = forAllSystems (system:
+        buildPackage system ["cmd/waku"]
+      );
+
+      devShells.default = forAllSystems (system:
+        packages.${system}.node
+      );
+  };
+}


### PR DESCRIPTION
This way we can build stuff locally using:
```sh
nix build
nix build .#node
nix build .#library
```
Or just start a shell with Go `1.19.x` using:
```
nix develop
```
Which simply has the same environment as the build shell for the node.

One known snag is that there is currently no simple way to keep `vendorSha256` updated to match the contents of `go.mod` and `go.sum`. For more details see:
https://discourse.nixos.org/t/how-should-i-build-a-go-package-from-local-source/19490/8

One way around this would be to have our own `vendor` folder, but that's also a pretty ugly solution that requires manual updating.

Resolves:
* https://github.com/waku-org/go-waku/issues/256