### PR TITLE
nix: fix nix run by setting mainProgram to waku

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -26,6 +26,8 @@
           doCheck = false;
           # FIXME: This needs to be manually changed when updating modules.
           vendorSha256 = "sha256-TvQfLQEYDujfXInQ+i/LoSGtedozZvX8WgzpqiryYHY=";
+          # Fix for 'nix run' trying to execute 'go-waku'.
+          meta = { mainProgram = "waku"; };
         };
     in rec {
       packages = forAllSystems (system: {


### PR DESCRIPTION
Otherwise it fails with:
```
 > nix run github:status-im/go-waku
error: unable to execute '/nix/store/xsmhw1yqz5w9bdgfsprxmhcycl7011wz-go-waku/bin/go-waku': No such file or directory

 > ls -l /nix/store/xsmhw1yqz5w9bdgfsprxmhcycl7011wz-go-waku/bin
total 37914
-r-xr-xr-x 1 root root 38775544 Jan  1  1970 waku
```
The other option is to change the output binary path from `waku` to `go-waku`, but that would have to be done by either renaming `cmd/waku` to `cmd/go-waku` or some awkward patching of `buildGo119Module`.