### PR TITLE
feat: rendezvous client

### DIFF
--- a/cmd/waku/flags.go
+++ b/cmd/waku/flags.go
@@ -363,10 +363,9 @@ var (
 		Destination: &options.DiscV5.AutoUpdate,
 		EnvVars:     []string{"WAKUNODE2_DISCV5_ENR_AUTO_UPDATE"},
 	})
-
 	Rendezvous = altsrc.NewBoolFlag(&cli.BoolFlag{
 		Name:        "rendezvous",
-		Usage:       "Enable rendezvous protocol server for peer discovery",
+		Usage:       "Enable rendezvous protocol for peer discovery",
 		Destination: &options.Rendezvous.Enable,
 		EnvVars:     []string{"WAKUNODE2_RENDEZVOUS"},
 	})
@@ -377,6 +376,12 @@ var (
 			Values: &options.Rendezvous.Nodes,
 		},
 		EnvVars: []string{"WAKUNODE2_RENDEZVOUSNODE"},
+	})
+	RendezvousServer = altsrc.NewBoolFlag(&cli.BoolFlag{
+		Name:        "rendezvous-server",
+		Usage:       "Enable rendezvous protocol server so other peers can use this node for discovery",
+		Destination: &options.Rendezvous.Server,
+		EnvVars:     []string{"WAKUNODE2_RENDEZVOUS_SERVER"},
 	})
 	PeerExchange = altsrc.NewBoolFlag(&cli.BoolFlag{
 		Name:        "peer-exchange",

--- a/cmd/waku/main.go
+++ b/cmd/waku/main.go
@@ -75,6 +75,7 @@ func main() {
 		DNSDiscoveryNameServer,
 		Rendezvous,
 		RendezvousNode,
+		RendezvousServer,
 		MetricsServer,
 		MetricsServerAddress,
 		MetricsServerPort,

--- a/examples/noise/go.mod
+++ b/examples/noise/go.mod
@@ -62,7 +62,7 @@ require (
 	github.com/libp2p/go-flow-metrics v0.1.0 // indirect
 	github.com/libp2p/go-libp2p v0.25.1 // indirect
 	github.com/libp2p/go-libp2p-asn-util v0.2.0 // indirect
-	github.com/libp2p/go-libp2p-pubsub v0.9.1 // indirect
+	github.com/libp2p/go-libp2p-pubsub v0.9.3 // indirect
 	github.com/libp2p/go-mplex v0.7.0 // indirect
 	github.com/libp2p/go-msgio v0.3.0 // indirect
 	github.com/libp2p/go-nat v0.1.0 // indirect

--- a/examples/noise/go.sum
+++ b/examples/noise/go.sum
@@ -413,8 +413,8 @@ github.com/libp2p/go-libp2p v0.25.1 h1:YK+YDCHpYyTvitKWVxa5PfElgIpOONU01X5UcLEwJ
 github.com/libp2p/go-libp2p v0.25.1/go.mod h1:xnK9/1d9+jeQCVvi/f1g12KqtVi/jP/SijtKV1hML3g=
 github.com/libp2p/go-libp2p-asn-util v0.2.0 h1:rg3+Os8jbnO5DxkC7K/Utdi+DkY3q/d1/1q+8WeNAsw=
 github.com/libp2p/go-libp2p-asn-util v0.2.0/go.mod h1:WoaWxbHKBymSN41hWSq/lGKJEca7TNm58+gGJi2WsLI=
-github.com/libp2p/go-libp2p-pubsub v0.9.1 h1:A6LBg9BaoLf3NwRz+E974sAxTVcbUZYg95IhK2BZz9g=
-github.com/libp2p/go-libp2p-pubsub v0.9.1/go.mod h1:RYA7aM9jIic5VV47WXu4GkcRxRhrdElWf8xtyli+Dzc=
+github.com/libp2p/go-libp2p-pubsub v0.9.3 h1:ihcz9oIBMaCK9kcx+yHWm3mLAFBMAUsM4ux42aikDxo=
+github.com/libp2p/go-libp2p-pubsub v0.9.3/go.mod h1:RYA7aM9jIic5VV47WXu4GkcRxRhrdElWf8xtyli+Dzc=
 github.com/libp2p/go-libp2p-testing v0.12.0 h1:EPvBb4kKMWO29qP4mZGyhVzUyR25dvfUIK5WDu6iPUA=
 github.com/libp2p/go-mplex v0.7.0 h1:BDhFZdlk5tbr0oyFq/xv/NPGfjbnrsDam1EvutpBDbY=
 github.com/libp2p/go-mplex v0.7.0/go.mod h1:rW8ThnRcYWft/Jb2jeORBmPd6xuG3dGxWN/W168L9EU=

--- a/waku/node.go
+++ b/waku/node.go
@@ -59,7 +59,7 @@ func failOnErr(err error, msg string) {
 }
 
 func requiresDB(options Options) bool {
-	return options.Store.Enable || options.Rendezvous.Enable
+	return options.Store.Enable || options.Rendezvous.Server
 }
 
 const dialTimeout = 7 * time.Second
@@ -243,6 +243,10 @@ func Execute(options Options) {
 	}
 
 	if options.Rendezvous.Enable {
+		nodeOpts = append(nodeOpts, node.WithRendezvous(options.Rendezvous.Nodes))
+	}
+
+	if options.Rendezvous.Server {
 		rdb := rendezvous.NewDB(ctx, db, logger)
 		nodeOpts = append(nodeOpts, node.WithRendezvousServer(rdb))
 	}

--- a/waku/options.go
+++ b/waku/options.go
@@ -141,6 +141,7 @@ type PeerExchangeOptions struct {
 
 type RendezvousOptions struct {
 	Enable bool
+	Server bool
 	Nodes  []multiaddr.Multiaddr
 }
 

--- a/waku/v2/node/wakunode2.go
+++ b/waku/v2/node/wakunode2.go
@@ -214,7 +214,7 @@ func New(opts ...WakuNodeOption) (*WakuNode, error) {
 		return nil, err
 	}
 
-	w.rendezvous = rendezvous.NewRendezvous(w.host, w.opts.rendezvousDB, w.peerConnector, w.log)
+	w.rendezvous = rendezvous.NewRendezvous(w.host, w.opts.enableRendezvousServer, w.opts.rendezvousDB, w.opts.enableRendezvous, w.opts.rendezvousNodes, w.peerConnector, w.log)
 	w.relay = relay.NewWakuRelay(w.host, w.bcaster, w.opts.minRelayPeersToPublish, w.timesource, w.log, w.opts.wOpts...)
 	w.filter = filter.NewWakuFilter(w.host, w.bcaster, w.opts.isFilterFullNode, w.timesource, w.log, w.opts.filterOpts...)
 	w.filterV2Full = filterv2.NewWakuFilterFullnode(w.host, w.bcaster, w.timesource, w.log, w.opts.filterV2Opts...)
@@ -393,7 +393,7 @@ func (w *WakuNode) Start(ctx context.Context) error {
 		}
 	}
 
-	if w.opts.enableRendezvous {
+	if w.opts.enableRendezvousServer || w.opts.enableRendezvous {
 		err := w.rendezvous.Start(ctx)
 		if err != nil {
 			return err
@@ -425,7 +425,7 @@ func (w *WakuNode) Stop() {
 	defer w.identificationEventSub.Close()
 	defer w.addressChangesSub.Close()
 
-	if w.opts.enableRendezvous {
+	if w.opts.enableRendezvousServer || w.opts.enableRendezvous {
 		w.rendezvous.Stop()
 	}
 

--- a/waku/v2/node/wakunode2.go
+++ b/waku/v2/node/wakunode2.go
@@ -214,7 +214,16 @@ func New(opts ...WakuNodeOption) (*WakuNode, error) {
 		return nil, err
 	}
 
-	w.rendezvous = rendezvous.NewRendezvous(w.host, w.opts.enableRendezvousServer, w.opts.rendezvousDB, w.opts.enableRendezvous, w.opts.rendezvousNodes, w.peerConnector, w.log)
+	var rendezvousPoints []peer.ID
+	for _, p := range w.opts.rendezvousNodes {
+		peerID, err := utils.GetPeerID(p)
+		if err != nil {
+			return nil, err
+		}
+		rendezvousPoints = append(rendezvousPoints, peerID)
+	}
+
+	w.rendezvous = rendezvous.NewRendezvous(w.host, w.opts.enableRendezvousServer, w.opts.rendezvousDB, w.opts.enableRendezvous, rendezvousPoints, w.peerConnector, w.log)
 	w.relay = relay.NewWakuRelay(w.host, w.bcaster, w.opts.minRelayPeersToPublish, w.timesource, w.log, w.opts.wOpts...)
 	w.filter = filter.NewWakuFilter(w.host, w.bcaster, w.opts.isFilterFullNode, w.timesource, w.log, w.opts.filterOpts...)
 	w.filterV2Full = filterv2.NewWakuFilterFullnode(w.host, w.bcaster, w.timesource, w.log, w.opts.filterV2Opts...)

--- a/waku/v2/node/wakuoptions.go
+++ b/waku/v2/node/wakuoptions.go
@@ -81,7 +81,10 @@ type WakuNodeParameters struct {
 	messageProvider store.MessageProvider
 
 	enableRendezvous bool
-	rendezvousDB     *rendezvous.DB
+	rendezvousNodes  []multiaddr.Multiaddr
+
+	enableRendezvousServer bool
+	rendezvousDB           *rendezvous.DB
 
 	swapMode                int
 	swapDisconnectThreshold int
@@ -437,11 +440,20 @@ func WithWebsockets(address string, port int) WakuNodeOption {
 	}
 }
 
+// WithRendezvous is a WakuOption used to enable rendezvous as a discovery
+func WithRendezvous(rendezvousPoints []multiaddr.Multiaddr) WakuNodeOption {
+	return func(params *WakuNodeParameters) error {
+		params.enableRendezvous = true
+		params.rendezvousNodes = rendezvousPoints
+		return nil
+	}
+}
+
 // WithRendezvousServer is a WakuOption used to set the node as a rendezvous
 // point, using an specific storage for the peer information
 func WithRendezvousServer(db *rendezvous.DB) WakuNodeOption {
 	return func(params *WakuNodeParameters) error {
-		params.enableRendezvous = true
+		params.enableRendezvousServer = true
 		params.rendezvousDB = db
 		return nil
 	}

--- a/waku/v2/rendezvous/rendezvous.go
+++ b/waku/v2/rendezvous/rendezvous.go
@@ -2,36 +2,51 @@ package rendezvous
 
 import (
 	"context"
+	"math"
+	"sync"
+	"time"
 
 	rvs "github.com/berty/go-libp2p-rendezvous"
 	"github.com/libp2p/go-libp2p/core/host"
 	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/multiformats/go-multiaddr"
+	"github.com/waku-org/go-waku/waku/v2/protocol/relay"
 	"go.uber.org/zap"
 )
 
 const RendezvousID = rvs.RendezvousProto
 
 type Rendezvous struct {
-	host          host.Host
-	peerConnector PeerConnector
+	host host.Host
+
+	enableServer  bool
 	db            *DB
 	rendezvousSvc *rvs.RendezvousService
 
-	log *zap.Logger
+	discoverPeers    bool
+	rendezvousPoints []multiaddr.Multiaddr
+	peerConnector    PeerConnector
+
+	log    *zap.Logger
+	wg     sync.WaitGroup
+	cancel context.CancelFunc
 }
 
 type PeerConnector interface {
 	PeerChannel() chan<- peer.AddrInfo
 }
 
-func NewRendezvous(host host.Host, db *DB, peerConnector PeerConnector, log *zap.Logger) *Rendezvous {
+func NewRendezvous(host host.Host, enableServer bool, db *DB, discoverPeers bool, rendevousPoints []multiaddr.Multiaddr, peerConnector PeerConnector, log *zap.Logger) *Rendezvous {
 	logger := log.Named("rendezvous")
 
 	return &Rendezvous{
-		host:          host,
-		db:            db,
-		peerConnector: peerConnector,
-		log:           logger,
+		host:             host,
+		enableServer:     enableServer,
+		db:               db,
+		discoverPeers:    discoverPeers,
+		rendezvousPoints: rendevousPoints,
+		peerConnector:    peerConnector,
+		log:              logger,
 	}
 }
 
@@ -41,12 +56,84 @@ func (r *Rendezvous) Start(ctx context.Context) error {
 		return err
 	}
 
-	r.rendezvousSvc = rvs.NewRendezvousService(r.host, r.db)
+	ctx, cancel := context.WithCancel(ctx)
+
+	r.cancel = cancel
+
+	if r.enableServer {
+		r.rendezvousSvc = rvs.NewRendezvousService(r.host, r.db)
+	}
+
+	if r.discoverPeers {
+		r.wg.Add(1)
+		go r.register(ctx)
+	}
+
+	// TODO: Execute discovery and push nodes to peer connector. If asking for peers fail, add timeout and exponential backoff
+
 	r.log.Info("rendezvous protocol started")
 	return nil
 }
 
+const registerBackoff = 200 * time.Millisecond
+const registerMaxRetries = 7
+
+func (r *Rendezvous) callRegister(ctx context.Context, rendezvousClient rvs.RendezvousClient, retries int) (<-chan time.Time, int) {
+	ttl, err := rendezvousClient.Register(ctx, relay.DefaultWakuTopic, rvs.DefaultTTL) // TODO: determine which topic to use
+	var t <-chan time.Time
+	if err != nil {
+		r.log.Error("registering rendezvous client", zap.Error(err))
+		backoff := registerBackoff * time.Duration(math.Exp2(float64(retries)))
+		t = time.After(backoff)
+		retries++
+	} else {
+		t = time.After(ttl)
+	}
+
+	return t, retries
+}
+
+func (r *Rendezvous) register(ctx context.Context) {
+	for _, m := range r.rendezvousPoints {
+		r.wg.Add(1)
+		go func(m multiaddr.Multiaddr) {
+			r.wg.Done()
+
+			peerIDStr, err := m.ValueForProtocol(multiaddr.P_P2P)
+			if err != nil {
+				r.log.Error("error obtaining peerID", zap.Error(err))
+				return
+			}
+
+			peerID, err := peer.Decode(peerIDStr)
+			if err != nil {
+				r.log.Error("error obtaining peerID", zap.Error(err))
+				return
+			}
+
+			rendezvousClient := rvs.NewRendezvousClient(r.host, peerID)
+			retries := 0
+			var t <-chan time.Time
+
+			t, retries = r.callRegister(ctx, rendezvousClient, retries)
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				case <-t:
+					t, retries = r.callRegister(ctx, rendezvousClient, retries)
+					if retries >= registerMaxRetries {
+						return
+					}
+				}
+			}
+		}(m)
+	}
+}
+
 func (r *Rendezvous) Stop() {
+	r.cancel()
+	r.wg.Wait()
 	r.host.RemoveStreamHandler(rvs.RendezvousProto)
 	r.rendezvousSvc = nil
 }

--- a/waku/v2/rendezvous/rendezvous_test.go
+++ b/waku/v2/rendezvous/rendezvous_test.go
@@ -1,0 +1,96 @@
+package rendezvous
+
+import (
+	"context"
+	"crypto/rand"
+	"database/sql"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/libp2p/go-libp2p/core/peerstore"
+	"github.com/multiformats/go-multiaddr"
+	"github.com/stretchr/testify/require"
+	"github.com/waku-org/go-waku/tests"
+	"github.com/waku-org/go-waku/waku/persistence/sqlite"
+	"github.com/waku-org/go-waku/waku/v2/utils"
+)
+
+type PeerConn struct {
+	ch chan peer.AddrInfo
+}
+
+func (p PeerConn) PeerChannel() chan<- peer.AddrInfo {
+	return p.ch
+}
+
+func NewPeerConn() PeerConn {
+	x := PeerConn{}
+	x.ch = make(chan peer.AddrInfo, 1000)
+	return x
+}
+
+func TestRendezvous(t *testing.T) {
+	port1, err := tests.FindFreePort(t, "", 5)
+	require.NoError(t, err)
+	host1, err := tests.MakeHost(context.Background(), port1, rand.Reader)
+	require.NoError(t, err)
+
+	var db *sql.DB
+	db, migration, err := sqlite.NewDB(":memory:")
+	require.NoError(t, err)
+
+	err = migration(db)
+	require.NoError(t, err)
+
+	rdb := NewDB(context.Background(), db, utils.Logger())
+	rendezvousPoint := NewRendezvous(host1, true, rdb, false, nil, nil, utils.Logger())
+	err = rendezvousPoint.Start(context.Background())
+	require.NoError(t, err)
+	defer rendezvousPoint.Stop()
+
+	hostInfo, _ := multiaddr.NewMultiaddr(fmt.Sprintf("/p2p/%s", host1.ID().Pretty()))
+	host1Addr := host1.Addrs()[0].Encapsulate(hostInfo)
+
+	port2, err := tests.FindFreePort(t, "", 5)
+	require.NoError(t, err)
+	host2, err := tests.MakeHost(context.Background(), port2, rand.Reader)
+	require.NoError(t, err)
+
+	info, err := peer.AddrInfoFromP2pAddr(host1Addr)
+	require.NoError(t, err)
+
+	host2.Peerstore().AddAddrs(info.ID, info.Addrs, peerstore.PermanentAddrTTL)
+	err = host2.Peerstore().AddProtocols(info.ID, RendezvousID)
+	require.NoError(t, err)
+
+	rendezvousClient1 := NewRendezvous(host2, false, nil, false, []peer.ID{host1.ID()}, nil, utils.Logger())
+	err = rendezvousClient1.Start(context.Background())
+	require.NoError(t, err)
+	defer rendezvousClient1.Stop()
+
+	port3, err := tests.FindFreePort(t, "", 5)
+	require.NoError(t, err)
+	host3, err := tests.MakeHost(context.Background(), port3, rand.Reader)
+	require.NoError(t, err)
+
+	host3.Peerstore().AddAddrs(info.ID, info.Addrs, peerstore.PermanentAddrTTL)
+	err = host3.Peerstore().AddProtocols(info.ID, RendezvousID)
+	require.NoError(t, err)
+
+	myPeerConnector := NewPeerConn()
+
+	rendezvousClient2 := NewRendezvous(host3, false, nil, true, []peer.ID{host1.ID()}, myPeerConnector, utils.Logger())
+	err = rendezvousClient2.Start(context.Background())
+	require.NoError(t, err)
+	defer rendezvousClient2.Stop()
+
+	timer := time.After(5 * time.Second)
+	select {
+	case <-timer:
+		require.Fail(t, "no peer discovered")
+	case p := <-myPeerConnector.ch:
+		require.Equal(t, p.ID.Pretty(), host2.ID().Pretty())
+	}
+}

--- a/waku/v2/utils/peer.go
+++ b/waku/v2/utils/peer.go
@@ -11,12 +11,27 @@ import (
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/libp2p/go-libp2p/core/protocol"
 	"github.com/libp2p/go-libp2p/p2p/protocol/ping"
+	"github.com/multiformats/go-multiaddr"
 	"go.uber.org/zap"
 )
 
 // ErrNoPeersAvailable is emitted when no suitable peers are found for
 // some protocol
 var ErrNoPeersAvailable = errors.New("no suitable peers found")
+
+func GetPeerID(m multiaddr.Multiaddr) (peer.ID, error) {
+	peerIDStr, err := m.ValueForProtocol(multiaddr.P_P2P)
+	if err != nil {
+		return "", err
+	}
+
+	peerID, err := peer.Decode(peerIDStr)
+	if err != nil {
+		return "", err
+	}
+
+	return peerID, nil
+}
 
 // SelectPeer is used to return a random peer that supports a given protocol.
 // If a list of specific peers is passed, the peer will be chosen from that list assuming


### PR DESCRIPTION
@cammellos  @fryorcraken @iurimatias @jm-clius @siphiuel 
This 'finishes' the main work related to re-adding rendezvous in go-waku (with an improved API compared to what I had before).

To test this:
```
1. Start service node:
./build/waku --nodekey=1122334455667788990011223344556677889900112233445566778899001122 --rendezvous-server

2. Start a node and connect it to service node:
./build/waku --nodekey=1122334455667788990011223344556677889900112233445566778899001133 --port 0 --rendezvous --rendezvous-node=/ip4/192.168.1.19/tcp/60000/p2p/16Uiu2HAmMGhfSTUzKbsjMWxc6T1X4wiTWSF1bEWSLjAukCm7KiHV

3. Start another node, and connect it to service node:
./build/waku --nodekey=1122334455667788990011223344556677889900112233445566778899001144 --port 0 --rendezvous --rendezvous-node=/ip4/192.168.1.19/tcp/60000/p2p/16Uiu2HAmMGhfSTUzKbsjMWxc6T1X4wiTWSF1bEWSLjAukCm7KiHV
```
Nodes 2 and 3 should connect to each other automagically.

---

To use this functionality within status-go, when a waku node is instantiated the following option must be passed:
```
node.WithRendezvous(rendezvousNodes)
```
with `rendezvousNodes` being a slice of multiaddr.Multiaddr  . I imagine these could be obtained from here: https://github.com/status-im/status-go/blob/develop/wakuv2/waku.go#L490-L511 which uses dns discovery to obtain the list of peers from the fleet (nwaku should support rendezvous first); or, the list of multiaddresses could be hardcoded, and use go-waku nodes.


---

Some stuff that is pending and can be part of a separate PR:
- I'm using as namespace (defined in here https://github.com/libp2p/specs/blob/master/rendezvous/README.md#the-protocol) the Default Waku Topic. This might change with pubsub topic sharding, I think? cc: @kaiserd
- [x] It would be nice to add some unit test. I'll attempt to do so during the week.
- [ ] In this code it probably makes sense to add an exponential backoff to attempt to connect to same peer, and the same should apply if a rendezvous peer returns an empty slice in `addrInfo` (on line 117), meaning that the server does not have any peer registered. https://github.com/waku-org/go-waku/blob/fd002ebdd13d8635fe7e29346cd7f1aa021e84e9/waku/v2/rendezvous/rendezvous.go#L117-L136 
- [x] go-libp2p-rendezvous has a noisy log line:
```
2023-03-13T20:42:19.987-0400    INFO    rendezvous      go-libp2p-rendezvous@v0.4.1/svc.go:234  discover query: 16Uiu2HAmG4jyX7gz2MVHzeczDvHa5owG9H7Liu7RAXS2DHG1r8Hm /waku/2/default-waku/proto -> 1   {"node": "16Uiu2HAmMGhfSTUzKbsjMWxc6T1X4wiTWSF1bEWSLjAukCm7KiHV"}
```
Ideally we'd change this to DEBUG and send a PR upstream. https://github.com/waku-org/go-libp2p-rendezvous

