### PR TITLE
refactor: setting nodeKey via GOWAKU-NODEKEY env

### DIFF
--- a/cmd/waku/flags.go
+++ b/cmd/waku/flags.go
@@ -88,11 +88,11 @@ var (
 	})
 	NodeKey = cliutils.NewGenericFlagSingleValue(&cli.GenericFlag{
 		Name:  "nodekey",
-		Usage: "P2P node private key as hex. Can also be set with GOWAKU-NODEKEY env variable (default random)",
+		Usage: "P2P node private key as hex.",
 		Value: &cliutils.PrivateKeyValue{
 			Value: &options.NodeKey,
 		},
-		EnvVars: []string{"WAKUNODE2_NODEKEY"},
+		EnvVars: []string{"WAKUNODE2_NODEKEY", "GOWAKU-NODEKEY"},
 	})
 	KeyFile = altsrc.NewPathFlag(&cli.PathFlag{
 		Name:        "key-file",


### PR DESCRIPTION
Since issue https://github.com/urfave/cli/issues/1272 is closed, and go-waku is already using version greater than 2.14.1, extra env logic can be removed.