### PR TITLE
refactor: fetch membership events

### DIFF
--- a/waku/node.go
+++ b/waku/node.go
@@ -112,7 +112,6 @@ func Execute(options Options) {
 		node.WithHostAddress(hostAddr),
 		node.WithKeepAlive(options.KeepAlive),
 	}
-
 	if len(options.AdvertiseAddresses) != 0 {
 		nodeOpts = append(nodeOpts, node.WithAdvertiseAddresses(options.AdvertiseAddresses...))
 	}

--- a/waku/v2/protocol/rln/rln_relay_builder.go
+++ b/waku/v2/protocol/rln/rln_relay_builder.go
@@ -153,10 +153,7 @@ func RlnRelayDynamic(
 		return rlnPeer.insertMember(pubkey)
 	}
 
-	errChan := make(chan error)
-	go rlnPeer.HandleGroupUpdates(handler, errChan)
-	err = <-errChan
-	if err != nil {
+	if err = rlnPeer.HandleGroupUpdates(handler); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
- WatchMembershipRegistered func either returns nil, err or Subscription, nil. 
<img width="823" alt="image" src="https://user-images.githubusercontent.com/23700929/229715296-3470ca52-9131-4396-9f09-5b47626d9cb5.png">

So, subs.Subscribe https://github.com/waku-org/go-waku/blob/master/waku/v2/protocol/rln/web3.go#L197 will fail when there is an err. subs will be nil.

- I think the purpose of `errCh` and `done` in watchNewEvents func is to get the first error while creating a subscription (like if the node doesn't support ws notifications). On such err, application should terminate. But  https://github.com/waku-org/go-waku/blob/master/waku/v2/protocol/rln/web3.go#L205 done might be closed before  `Resubscribe` creates the first subscription internally. Hence, the first subscription error might not be captured.