### PR TITLE
nix: install golangci-lint in devel shell

### DIFF
--- a/ci/Jenkinsfile.tests
+++ b/ci/Jenkinsfile.tests
@@ -21,12 +21,6 @@ pipeline {
   }
 
   stages {
-    stage('Deps') {
-      steps { script {
-        nix.develop('make deps', pure: false)
-      } }
-    }
-
     stage('Lint') {
       steps { script {
         nix.develop('make lint', pure: false)

--- a/flake.nix
+++ b/flake.nix
@@ -49,6 +49,7 @@
         default = mkShell {
           GOFLAGS = "-trimpath"; # Drop -mod=vendor
           inputsFrom = [ packages.${system}.node ];
+          buildInputs = with pkgs; [ golangci-lint ];
           nativeBuildInputs = lib.optional stdenv.isDarwin [
             (pkgs.xcodeenv.composeXcodeWrapper { version = "14.2"; })
           ];


### PR DESCRIPTION
This way we don't need to depend on `make deps`.