### PR TITLE
ci: fix GOPATH, PATH, and GOCACHE

### DIFF
--- a/ci/Jenkinsfile.android
+++ b/ci/Jenkinsfile.android
@@ -21,13 +21,13 @@ pipeline {
   }
 
   environment {
-    BUILD_PLATFORM   = 'android'
-    CC="gcc-10"
+    CC = "gcc-10"
     /* Other stuff */
-    TARGET   = 'android'
-    REPO   = "${env.WORKSPACE}/src/github.com/waku-org/go-waku"
-    GOPATH = "${env.WORKSPACE}"
-    PATH   = "/usr/local/go/bin:${env.PATH}:${env.GOPATH}/bin"
+    TARGET  = 'android'
+    REPO    = "${env.WORKSPACE}/src/github.com/waku-org/go-waku"
+    GOCACHE = "${env.WORKSPACE_TMP}/go-build"
+    GOPATH  = "${env.WORKSPACE}"
+    PATH    = "${env.PATH}:${env.GOPATH}/bin"
     /* Android SDK */
     ANDROID_HOME     = '/usr/lib/android-sdk'
     ANDROID_SDK_ROOT = '/usr/lib/android-sdk'

--- a/ci/Jenkinsfile.ios
+++ b/ci/Jenkinsfile.ios
@@ -20,13 +20,11 @@ pipeline {
   }
 
   environment {
-    BUILD_PLATFORM   = 'android'
-
-    /* Other stuff */
-    TARGET   = 'ios'
-    REPO   = "${env.WORKSPACE}/src/github.com/waku-org/go-waku"
-    GOPATH = "${env.WORKSPACE}"
-    PATH   = "/usr/local/go/bin:${env.PATH}:${env.GOPATH}/bin"
+    TARGET  = 'ios'
+    REPO    = "${env.WORKSPACE}/src/github.com/waku-org/go-waku"
+    GOCACHE = "${env.WORKSPACE_TMP}/go-build"
+    GOPATH  = "${env.WORKSPACE}"
+    PATH    = "${env.PATH}:${env.GOPATH}/bin"
   }
 
   stages {

--- a/ci/Jenkinsfile.linux
+++ b/ci/Jenkinsfile.linux
@@ -23,12 +23,11 @@ pipeline {
   }
 
   environment {
-    BUILD_PLATFORM   = 'linux'
-    /* Other stuff */
-    TARGET   = 'linux'
-    REPO   = "${env.WORKSPACE}/src/github.com/waku-org/go-waku"
-    GOPATH = "${env.WORKSPACE}"
-    PATH   = "/usr/local/go/bin:${env.PATH}:${env.GOPATH}/bin"
+    TARGET  = 'linux'
+    REPO    = "${env.WORKSPACE}/src/github.com/waku-org/go-waku"
+    GOCACHE = "${env.WORKSPACE_TMP}/go-build"
+    GOPATH  = "${env.WORKSPACE}"
+    PATH    = "${env.PATH}:${env.GOPATH}/bin"
   }
 
   stages {

--- a/ci/Jenkinsfile.tests
+++ b/ci/Jenkinsfile.tests
@@ -8,6 +8,10 @@ pipeline {
   options {
     timestamps()
     disableConcurrentBuilds()
+    /* Prevent Jenkins jobs from running forever */
+    timeout(time: 30, unit: 'MINUTES')
+    /* Go requires a certain directory structure */
+    checkoutToSubdirectory('src/github.com/waku-org/go-waku')
     buildDiscarder(logRotator(
       numToKeepStr: '10',
       daysToKeepStr: '30',
@@ -15,22 +19,26 @@ pipeline {
   }
 
   environment {
-    TARGET = 'tests'
-    GOPATH = "${env.HOME}/go"
-    PATH   = "${env.PATH}:${env.GOPATH}/bin"
+    TARGET  = 'tests'
+    REPO    = "${env.WORKSPACE}/src/github.com/waku-org/go-waku"
+    GOCACHE = "${env.WORKSPACE_TMP}/go-build"
+    GOPATH  = "${env.WORKSPACE}/go"
+    PATH    = "${env.PATH}:${env.GOPATH}/bin"
+    /* Necesary to avoid cache poisoning by other builds. */
+    GOLANGCI_LINT_CACHE = "${env.WORKSPACE_TMP}/golangci-lint"
   }
 
   stages {
     stage('Lint') {
-      steps { script {
+      steps { script { dir(env.REPO) {
         nix.develop('make lint', pure: false)
-      } }
+      } } }
     }
 
     stage('Test') {
-      steps { script {
+      steps { script { dir(env.REPO) {
         nix.develop('make test-ci', pure: false)
-      } }
+      } } }
     }
   }
   post {


### PR DESCRIPTION
Using `$HOME/go` is bad and you should feel bad.
Also, adding `/usr/loca/go/bin` is a terrible idea.
And `GOCACHE` is poisoning stuff for linter.