### PR TITLE
feat: add message size and received time to debug log

### DIFF
--- a/waku/v2/protocol/relay/waku_relay.go
+++ b/waku/v2/protocol/relay/waku_relay.go
@@ -2,7 +2,6 @@ package relay
 
 import (
 	"context"
-	"encoding/hex"
 	"errors"
 	"fmt"
 	"sync"
@@ -220,7 +219,7 @@ func (w *WakuRelay) PublishToTopic(ctx context.Context, message *pb.WakuMessage,
 
 	hash := message.Hash(topic)
 
-	w.log.Debug("waku.relay published", zap.String("hash", hex.EncodeToString(hash)))
+	w.log.Debug("waku.relay published", zap.String("pubsubTopic", topic), logging.HexString("hash", hash), zap.Int64("publishTime", w.timesource.Now().UnixNano()), zap.Int("payloadSizeBytes", len(message.Payload)))
 
 	return hash, nil
 }
@@ -390,11 +389,12 @@ func (w *WakuRelay) subscribeToTopic(userCtx context.Context, pubsubTopic string
 				return
 			}
 
-			msgSizeInKb := len(wakuMessage.Payload) / 1000
-			stats.Record(ctx, metrics.Messages.M(1), metrics.MessageSize.M(int64(msgSizeInKb)))
+			payloadSizeInBytes := len(wakuMessage.Payload)
+			payloadSizeInKb := payloadSizeInBytes / 1000
+			stats.Record(ctx, metrics.Messages.M(1), metrics.MessageSize.M(int64(payloadSizeInKb)))
 
 			envelope := waku_proto.NewEnvelope(wakuMessage, w.timesource.Now().UnixNano(), pubsubTopic)
-			w.log.Debug("waku.relay received", logging.HexString("hash", envelope.Hash()))
+			w.log.Debug("waku.relay received", zap.String("pubsubTopic", pubsubTopic), logging.HexString("hash", envelope.Hash()), zap.Int64("receivedTime", envelope.Index().ReceiverTime), zap.Int("payloadSizeBytes", payloadSizeInBytes))
 
 			if w.bcaster != nil {
 				w.bcaster.Submit(envelope)


### PR DESCRIPTION
cc: @Daimakaimura 

To see it in action,  use --log-level=DEBUG  (there's no TRACE level in go-waku)

example output:
```
2023-05-03T10:22:01.526-0400    DEBUG   gowaku.node2.relay      relay/waku_relay.go:399 waku.relay received     {"node": "16Uiu2HAmGZU7iExmPSQ6AbCS64WKrwYMNocScNXoJAfFtuYUHXFU", "topic": "/waku/2/default-waku/proto", "hash": "0xbafff0fdf326a587ff91b74695372dd338d3f412e8bb1413a985d3475be1fdce", "receivedTime": 1683123721512878171, "payloadSizeBytes": 540}
```