### PR TITLE
nix: upgrade nixpkgs to include xcodeWrapper fixes

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,16 +2,16 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1677779205,
-        "narHash": "sha256-6DBjL9wjq86p2GczmwnHtFRnWPBPItc67gapWENBgX8=",
+        "lastModified": 1683105740,
+        "narHash": "sha256-Lmka1QIg178IV6qX01aNJWKiJl6Tb0wJNWVi92sBl5w",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "96e18717904dfedcd884541e5a92bf9ff632cf39",
+        "rev": "8fd4097529b4a71e0de000c90c8c4279f534eada",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-22.11",
+        "ref": "master",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,7 @@
 {
   description = "Nix flake for Go implementaion of Waku v2 node.";
 
-  inputs.nixpkgs.url = github:NixOS/nixpkgs/nixos-22.11;
+  inputs.nixpkgs.url = github:NixOS/nixpkgs/master;
 
   outputs = { self, nixpkgs }:
     let
@@ -51,7 +51,7 @@
           inputsFrom = [ packages.${system}.node ];
           buildInputs = with pkgs; [ golangci-lint ];
           nativeBuildInputs = lib.optional stdenv.isDarwin [
-            (pkgs.xcodeenv.composeXcodeWrapper { version = "14.2"; })
+            (pkgs.xcodeenv.composeXcodeWrapper { version = "14.2"; allowHigher = true; })
           ];
         };
 


### PR DESCRIPTION
Fixes:
- https://github.com/NixOS/nixpkgs/pull/204278
- https://github.com/NixOS/nixpkgs/pull/228696

Other notable upgrades:

- Bash from `5.1` to `5.2`
- Binutils from `2.39` to `2.40`
- GnuAWK from `5.1.1` to `5.2.1`
- GCC  from `11.3.0` to `12.2.0`
- GNU Make from `4.3` to `4.4.1`
- Go from `1.19.6` to `1.19.8`