### PR TITLE
ci: cleanup Ganache container after tests finish

### DIFF
--- a/ci/Jenkinsfile.tests
+++ b/ci/Jenkinsfile.tests
@@ -44,14 +44,16 @@ pipeline {
       } } }
     }
 
-    stage('Ganache') { steps { script {
-      ganache = docker.image(
-        'trufflesuite/ganache:v7.4.1'
-      ).run(
-        ["-p 127.0.0.1:${env.GANACHE_RPC_PORT}:8545"].join(' '),
-        ["-m='${GANACHE_MNEMONIC}'"].join(' ')
-      )
-    } } }
+    stage('Ganache') {
+      steps { script {
+        ganache = docker.image(
+          'trufflesuite/ganache:v7.4.1'
+        ).run(
+          "-p 127.0.0.1:${env.GANACHE_RPC_PORT}:8545",
+          "-m='${GANACHE_MNEMONIC}'"
+        )
+      } }
+    }
 
     stage('On-chain tests') {
       environment {
@@ -68,6 +70,11 @@ pipeline {
     } }
     success { script { github.notifyPR(true) } }
     failure { script { github.notifyPR(false) } }
-    cleanup { cleanWs() }
+    cleanup { script {
+      cleanWs()
+      catchError {
+        ganache.stop()
+      }
+    } }
   }
 }


### PR DESCRIPTION
We've had too many leftover containers conflicting with new ones.

Also, no idea why we were joining a single element array.