### PR TITLE
refactor: add `--ext-ip` and `--dns4-domain-name` values to the list of node multiaddressess

### DIFF
--- a/waku/v2/node/wakuoptions.go
+++ b/waku/v2/node/wakuoptions.go
@@ -167,9 +167,9 @@ func WithLogLevel(lvl zapcore.Level) WakuNodeOption {
 func WithDns4Domain(dns4Domain string) WakuNodeOption {
 	return func(params *WakuNodeParameters) error {
 		params.dns4Domain = dns4Domain
-
-		params.addressFactory = func([]multiaddr.Multiaddr) []multiaddr.Multiaddr {
-			var result []multiaddr.Multiaddr
+		previousAddrFactory := params.addressFactory
+		params.addressFactory = func(inputAddr []multiaddr.Multiaddr) (addresses []multiaddr.Multiaddr) {
+			addresses = append(addresses, inputAddr...)
 
 			hostAddrMA, err := multiaddr.NewMultiaddr("/dns4/" + params.dns4Domain)
 			if err != nil {
@@ -178,18 +178,23 @@ func WithDns4Domain(dns4Domain string) WakuNodeOption {
 
 			tcp, _ := multiaddr.NewMultiaddr(fmt.Sprintf("/tcp/%d", params.hostAddr.Port))
 
-			result = append(result, hostAddrMA.Encapsulate(tcp))
+			addresses = append(addresses, hostAddrMA.Encapsulate(tcp))
 
 			if params.enableWS || params.enableWSS {
 				if params.enableWSS {
 					wss, _ := multiaddr.NewMultiaddr(fmt.Sprintf("/tcp/%d/wss", params.wssPort))
-					result = append(result, hostAddrMA.Encapsulate(wss))
+					addresses = append(addresses, hostAddrMA.Encapsulate(wss))
 				} else {
 					ws, _ := multiaddr.NewMultiaddr(fmt.Sprintf("/tcp/%d/ws", params.wsPort))
-					result = append(result, hostAddrMA.Encapsulate(ws))
+					addresses = append(addresses, hostAddrMA.Encapsulate(ws))
 				}
 			}
-			return result
+
+			if previousAddrFactory != nil {
+				return previousAddrFactory(addresses)
+			} else {
+				return addresses
+			}
 		}
 
 		return nil
@@ -214,17 +219,17 @@ func WithHostAddress(hostAddr *net.TCPAddr) WakuNodeOption {
 func WithAdvertiseAddresses(advertiseAddrs ...ma.Multiaddr) WakuNodeOption {
 	return func(params *WakuNodeParameters) error {
 		params.advertiseAddrs = advertiseAddrs
-		params.addressFactory = func([]multiaddr.Multiaddr) (addresses []multiaddr.Multiaddr) {
-			return advertiseAddrs
-		}
-		return nil
+		return WithMultiaddress(advertiseAddrs...)(params)
 	}
 }
 
 // WithExternalIP is a WakuNodeOption that allows overriding the advertised external IP used in the waku node with custom value
 func WithExternalIP(ip net.IP) WakuNodeOption {
 	return func(params *WakuNodeParameters) error {
+		oldAddrFactory := params.addressFactory
 		params.addressFactory = func(inputAddr []multiaddr.Multiaddr) (addresses []multiaddr.Multiaddr) {
+			addresses = append(addresses, inputAddr...)
+
 			component := "/ip4/"
 			if ip.To4() == nil && ip.To16() != nil {
 				component = "/ip6/"
@@ -248,14 +253,18 @@ func WithExternalIP(ip net.IP) WakuNodeOption {
 				addresses = append(addresses, addr)
 			}
 
-			return addresses
+			if oldAddrFactory != nil {
+				return oldAddrFactory(addresses)
+			} else {
+				return addresses
+			}
 		}
 		return nil
 	}
 }
 
 // WithMultiaddress is a WakuNodeOption that configures libp2p to listen on a list of multiaddresses
-func WithMultiaddress(addresses []multiaddr.Multiaddr) WakuNodeOption {
+func WithMultiaddress(addresses ...multiaddr.Multiaddr) WakuNodeOption {
 	return func(params *WakuNodeParameters) error {
 		params.multiAddr = append(params.multiAddr, addresses...)
 		return nil

--- a/waku/v2/node/wakuoptions_test.go
+++ b/waku/v2/node/wakuoptions_test.go
@@ -34,7 +34,7 @@ func TestWakuOptions(t *testing.T) {
 	options := []WakuNodeOption{
 		WithHostAddress(hostAddr),
 		WithAdvertiseAddresses(addr),
-		WithMultiaddress([]multiaddr.Multiaddr{addr}),
+		WithMultiaddress(addr),
 		WithPrivateKey(prvKey),
 		WithLibP2POptions(),
 		WithWakuRelay(),


### PR DESCRIPTION
This allows using both flags without one overriding the other