### PR TITLE
fix: dead loop after calling WakuNode.Stop()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -176,3 +176,5 @@ iOSInjectionProject/
 **/xcshareddata/WorkspaceSettings.xcsettings
 
 # End of https://www.toptal.com/developers/gitignore/api/swift,xcode,Cobjective-c,osx
+
+.idea/

--- a/waku/v2/node/wakunode2.go
+++ b/waku/v2/node/wakunode2.go
@@ -486,11 +486,11 @@ func (w *WakuNode) Stop() {
 	w.store.Stop()
 	w.legacyFilter.Stop()
 	w.filterFullnode.Stop()
-	w.peerExchange.Stop()
 
 	if w.opts.enableDiscV5 {
 		w.discoveryV5.Stop()
 	}
+	w.peerExchange.Stop()
 
 	w.peerConnector.Stop()
 


### PR DESCRIPTION
When `peer exchange service` is enabled, running [TestCreateAccountAndLogin](https://github.com/status-im/status-go/blob/c7aebfeed36754e03d002cda03ff3339d3d1d2f7/api/create_account_and_login_test.go#L14) will stuck at [logout](https://github.com/status-im/status-go/blob/c7aebfeed36754e03d002cda03ff3339d3d1d2f7/api/create_account_and_login_test.go#L53) , because there exist [dead loop](https://github.com/status-im/status-go/blob/860dee664b3ca6f2dce9a2f58039bb131687473d/vendor/github.com/waku-org/go-discover/discover/lookup.go#L212) , we need exchange the location between `w.peerExchange.Stop()` and `w.discoveryV5.Stop()` within [Stop](https://github.com/waku-org/go-waku/blob/31e960e1fcdd5ff7c244b4acbeebc962db6a87b6/waku/v2/node/wakunode2.go#L468) function so that we can get `Stop` smoothly 