### PR TITLE
fix: p2p circuit and discv5 conns

### DIFF
--- a/cmd/waku/node.go
+++ b/cmd/waku/node.go
@@ -615,10 +615,9 @@ func printListeningAddresses(ctx context.Context, nodeOpts []node.WakuNodeOption
 		panic(err)
 	}
 
-	hostInfo, _ := multiaddr.NewMultiaddr(fmt.Sprintf("/p2p/%s", h.ID().Pretty()))
-
-	for _, addr := range h.Addrs() {
-		fmt.Println(addr.Encapsulate(hostInfo))
+	hostAddrs := utils.EncapsulatePeerID(h.ID(), h.Addrs()...)
+	for _, addr := range hostAddrs {
+		fmt.Println(addr)
 	}
 
 }

--- a/waku/v2/node/wakunode2.go
+++ b/waku/v2/node/wakunode2.go
@@ -244,9 +244,9 @@ func New(opts ...WakuNodeOption) (*WakuNode, error) {
 	// Setup peer connection strategy
 	cacheSize := 600
 	rngSrc := rand.NewSource(rand.Int63())
-	minBackoff, maxBackoff := time.Second*30, time.Hour
+	minBackoff, maxBackoff := time.Minute, time.Hour
 	bkf := backoff.NewExponentialBackoff(minBackoff, maxBackoff, backoff.FullJitter, time.Second, 5.0, 0, rand.New(rngSrc))
-	w.peerConnector, err = v2.NewPeerConnectionStrategy(cacheSize, w.opts.discoveryMinPeers, network.DialPeerTimeout, bkf, w.log)
+	w.peerConnector, err = v2.NewPeerConnectionStrategy(cacheSize, w.opts.discoveryMinPeers, 20*time.Second, bkf, w.log)
 	if err != nil {
 		w.log.Error("creating peer connection strategy", zap.Error(err))
 	}

--- a/waku/v2/node/wakunode2.go
+++ b/waku/v2/node/wakunode2.go
@@ -27,6 +27,7 @@ import (
 	"github.com/libp2p/go-libp2p/p2p/host/peerstore/pstoremem"
 	"github.com/libp2p/go-libp2p/p2p/protocol/circuitv2/proto"
 	ws "github.com/libp2p/go-libp2p/p2p/transport/websocket"
+	"github.com/multiformats/go-multiaddr"
 	ma "github.com/multiformats/go-multiaddr"
 	"go.opencensus.io/stats"
 
@@ -818,6 +819,11 @@ func (w *WakuNode) Peers() ([]*Peer, error) {
 		}
 
 		addrs := w.host.Peerstore().Addrs(peerId)
+		hostInfo, _ := multiaddr.NewMultiaddr(fmt.Sprintf("/p2p/%s", peerId.Pretty()))
+		for i := range addrs {
+			addrs[i] = addrs[i].Encapsulate(hostInfo)
+		}
+
 		peers = append(peers, &Peer{
 			ID:        peerId,
 			Protocols: protocols,

--- a/waku/v2/utils/multiaddr.go
+++ b/waku/v2/utils/multiaddr.go
@@ -1,0 +1,18 @@
+package utils
+
+import (
+	"fmt"
+
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/multiformats/go-multiaddr"
+)
+
+// EncapsulatePeerID takes a peer.ID and adds a p2p component to all multiaddresses it receives
+func EncapsulatePeerID(peerID peer.ID, addrs ...multiaddr.Multiaddr) []multiaddr.Multiaddr {
+	hostInfo, _ := multiaddr.NewMultiaddr(fmt.Sprintf("/p2p/%s", peerID.Pretty()))
+	var result []multiaddr.Multiaddr
+	for _, addr := range addrs {
+		result = append(result, addr.Encapsulate(hostInfo))
+	}
+	return result
+}


### PR DESCRIPTION
This PR fixes some issues found while doing a comparison between go-waku and nwaku.
1. Adds two artificial delays to discv5 iterators: When `Next()` is called, if it takes less than 50ms, it wait `50ms - elapsed time` before requesting another peer from DiscV5; and adds a 5s delay every 15 peers.
2. Disables concurrent dialing in peer connector. This should be re-enabled once a performance comparison is done again with PR https://github.com/waku-org/go-waku/pull/597
3. Fixes the multiaddresses sent to the discovery connector since they were missing the `p2p` component

PR made in collaboration with @alrevuelta 