### PR TITLE
feat: subscribe to shards with --topic and refactors

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -28,7 +28,7 @@
           ];
           doCheck = false;
           # FIXME: This needs to be manually changed when updating modules.
-          vendorSha256 = "sha256-6VBZ0ilGcXhTXCoUmGdrRQqgnRwVJOtAe4JIMUCVw8Y=";
+          vendorSha256 = "sha256-TU/jog0MZNC4g13gaGm88gsKTRvmlcKkMeXZbaVf3fc=";
           # Fix for 'nix run' trying to execute 'go-waku'.
           meta = { mainProgram = "waku"; };
         };

--- a/mobile/api.go
+++ b/mobile/api.go
@@ -92,7 +92,6 @@ func NewNode(configJSON string) string {
 		node.WithPrivateKey(prvKey),
 		node.WithHostAddress(hostAddr),
 		node.WithKeepAlive(time.Duration(*config.KeepAliveInterval) * time.Second),
-		node.NoDefaultWakuTopic(),
 	}
 
 	if *config.EnableRelay {

--- a/waku/node.go
+++ b/waku/node.go
@@ -227,7 +227,6 @@ func Execute(options Options) {
 	}
 
 	if options.Store.Enable {
-		nodeOpts = append(nodeOpts, node.WithWakuStore(options.Store.ResumeNodes...))
 		nodeOpts = append(nodeOpts, node.WithMessageProvider(dbStore))
 	}
 
@@ -314,27 +313,6 @@ func Execute(options Options) {
 	addStaticPeers(wakuNode, options.Rendezvous.Nodes, rendezvous.RendezvousID)
 	addStaticPeers(wakuNode, options.Filter.Nodes, filter.FilterSubscribeID_v20beta1)
 
-	if options.DiscV5.Enable {
-		if err = wakuNode.DiscV5().Start(ctx); err != nil {
-			logger.Fatal("starting discovery v5", zap.Error(err))
-		}
-	}
-
-	// retrieve and connect to peer exchange peers
-	if options.PeerExchange.Enable && options.PeerExchange.Node != nil {
-		logger.Info("retrieving peer info via peer exchange protocol")
-
-		peerId, err := wakuNode.AddPeer(*options.PeerExchange.Node, peers.Static, peer_exchange.PeerExchangeID_v20alpha1)
-		if err != nil {
-			logger.Error("adding peer exchange peer", logging.MultiAddrs("node", *options.PeerExchange.Node), zap.Error(err))
-		} else {
-			desiredOutDegree := wakuNode.Relay().Params().D
-			if err = wakuNode.PeerExchange().Request(ctx, desiredOutDegree, peer_exchange.WithPeer(peerId)); err != nil {
-				logger.Error("requesting peers via peer exchange", zap.Error(err))
-			}
-		}
-	}
-
 	if len(options.Relay.Topics.Value()) == 0 {
 		options.Relay.Topics = *cli.NewStringSlice(relay.DefaultWakuTopic)
 	}
@@ -398,6 +376,27 @@ func Execute(options Options) {
 		}(ctx, n)
 	}
 
+	if options.DiscV5.Enable {
+		if err = wakuNode.DiscV5().Start(ctx); err != nil {
+			logger.Fatal("starting discovery v5", zap.Error(err))
+		}
+	}
+
+	// retrieve and connect to peer exchange peers
+	if options.PeerExchange.Enable && options.PeerExchange.Node != nil {
+		logger.Info("retrieving peer info via peer exchange protocol")
+
+		peerId, err := wakuNode.AddPeer(*options.PeerExchange.Node, peers.Static, peer_exchange.PeerExchangeID_v20alpha1)
+		if err != nil {
+			logger.Error("adding peer exchange peer", logging.MultiAddrs("node", *options.PeerExchange.Node), zap.Error(err))
+		} else {
+			desiredOutDegree := wakuNode.Relay().Params().D
+			if err = wakuNode.PeerExchange().Request(ctx, desiredOutDegree, peer_exchange.WithPeer(peerId)); err != nil {
+				logger.Error("requesting peers via peer exchange", zap.Error(err))
+			}
+		}
+	}
+
 	if len(discoveredNodes) != 0 {
 		for _, n := range discoveredNodes {
 			go func(ctx context.Context, info peer.AddrInfo) {
@@ -412,13 +411,39 @@ func Execute(options Options) {
 		}
 	}
 
+	var wg sync.WaitGroup
+
+	if options.Store.Enable && len(options.Store.ResumeNodes) != 0 {
+		// TODO: extract this to a function and run it when you go offline
+		// TODO: determine if a store is listening to a topic
+
+		var peerIDs []peer.ID
+		for _, n := range options.Store.ResumeNodes {
+			pID, err := wakuNode.AddPeer(n, peers.Static, store.StoreID_v20beta4)
+			if err != nil {
+				logger.Warn("adding peer to peerstore", logging.MultiAddrs("peer", n), zap.Error(err))
+			}
+			peerIDs = append(peerIDs, pID)
+		}
+
+		for _, t := range options.Relay.Topics.Value() {
+			wg.Add(1)
+			go func(topic string) {
+				defer wg.Done()
+				ctxWithTimeout, ctxCancel := context.WithTimeout(ctx, 20*time.Second)
+				defer ctxCancel()
+				if _, err := wakuNode.Store().Resume(ctxWithTimeout, topic, peerIDs); err != nil {
+					logger.Error("Could not resume history", zap.Error(err))
+				}
+			}(t)
+		}
+	}
+
 	var rpcServer *rpc.WakuRpc
 	if options.RPCServer.Enable {
 		rpcServer = rpc.NewWakuRpc(wakuNode, options.RPCServer.Address, options.RPCServer.Port, options.RPCServer.Admin, options.RPCServer.Private, options.PProf, options.RPCServer.RelayCacheCapacity, logger)
 		rpcServer.Start()
 	}
-
-	var wg sync.WaitGroup
 
 	var restServer *rest.WakuRest
 	if options.RESTServer.Enable {

--- a/waku/v2/discv5/discover.go
+++ b/waku/v2/discv5/discover.go
@@ -373,7 +373,7 @@ func (d *DiscoveryV5) peerLoop(ctx context.Context) error {
 			return true
 		}
 
-		nodeRS, err := enr.RelaySharding(d.localnode.Node().Record())
+		nodeRS, err := enr.RelaySharding(n.Record())
 		if err != nil || nodeRS == nil {
 			return false
 		}
@@ -383,7 +383,7 @@ func (d *DiscoveryV5) peerLoop(ctx context.Context) error {
 		}
 
 		// Contains any
-		for _, idx := range nodeRS.Indices {
+		for _, idx := range localRS.Indices {
 			if nodeRS.Contains(localRS.Cluster, idx) {
 				return true
 			}

--- a/waku/v2/node/keepalive.go
+++ b/waku/v2/node/keepalive.go
@@ -14,7 +14,6 @@ import (
 )
 
 const maxAllowedPingFailures = 2
-const maxPublishAttempt = 5
 
 func disconnectPeers(host host.Host, logger *zap.Logger) {
 	logger.Warn("keep alive hasnt been executed recently. Killing all connections to peers")

--- a/waku/v2/node/wakunode2.go
+++ b/waku/v2/node/wakunode2.go
@@ -2,7 +2,6 @@ package node
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"math/rand"
 	"net"
@@ -32,7 +31,6 @@ import (
 	"go.opencensus.io/stats"
 
 	"github.com/waku-org/go-waku/logging"
-	"github.com/waku-org/go-waku/waku/try"
 	v2 "github.com/waku-org/go-waku/waku/v2"
 	"github.com/waku-org/go-waku/waku/v2/discv5"
 	"github.com/waku-org/go-waku/waku/v2/metrics"
@@ -403,14 +401,6 @@ func (w *WakuNode) Start(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
-
-		if !w.opts.noDefaultWakuTopic {
-			sub, err := w.Relay().Subscribe(ctx)
-			if err != nil {
-				return err
-			}
-			sub.Unsubscribe()
-		}
 	}
 
 	w.store = w.storeFactory(w)
@@ -666,34 +656,6 @@ func (w *WakuNode) Broadcaster() relay.Broadcaster {
 	return w.bcaster
 }
 
-// Publish will attempt to publish a message via WakuRelay if there are enough
-// peers available, otherwise it will attempt to publish via Lightpush protocol
-func (w *WakuNode) Publish(ctx context.Context, msg *pb.WakuMessage) error {
-	if !w.opts.enableLightPush && !w.opts.enableRelay {
-		return errors.New("cannot publish message, relay and lightpush are disabled")
-	}
-
-	hash := msg.Hash(relay.DefaultWakuTopic)
-	err := try.Do(func(attempt int) (bool, error) {
-		var err error
-
-		relay := w.Relay()
-		lightpush := w.Lightpush()
-
-		if relay == nil || !relay.EnoughPeersToPublish() {
-			w.log.Debug("publishing message via lightpush", logging.HexBytes("hash", hash))
-			_, err = lightpush.Publish(ctx, msg)
-		} else {
-			w.log.Debug("publishing message via relay", logging.HexBytes("hash", hash))
-			_, err = relay.Publish(ctx, msg)
-		}
-
-		return attempt < maxPublishAttempt, err
-	})
-
-	return err
-}
-
 func (w *WakuNode) mountDiscV5() error {
 	discV5Options := []discv5.DiscoveryV5Option{
 		discv5.WithBootnodes(w.opts.discV5bootnodes),
@@ -718,33 +680,6 @@ func (w *WakuNode) startStore(ctx context.Context, sub relay.Subscription) error
 		return err
 	}
 
-	if len(w.opts.resumeNodes) != 0 {
-		// TODO: extract this to a function and run it when you go offline
-		// TODO: determine if a store is listening to a topic
-
-		var peerIDs []peer.ID
-		for _, n := range w.opts.resumeNodes {
-			pID, err := w.AddPeer(n, peers.Static, store.StoreID_v20beta4)
-			if err != nil {
-				w.log.Warn("adding peer to peerstore", logging.MultiAddrs("peer", n), zap.Error(err))
-			}
-			peerIDs = append(peerIDs, pID)
-		}
-
-		if !w.opts.noDefaultWakuTopic {
-			w.wg.Add(1)
-			go func() {
-				defer w.wg.Done()
-
-				ctxWithTimeout, ctxCancel := context.WithTimeout(ctx, 20*time.Second)
-				defer ctxCancel()
-				if _, err := w.store.(store.Store).Resume(ctxWithTimeout, string(relay.DefaultWakuTopic), peerIDs); err != nil {
-					w.log.Error("Could not resume history", zap.Error(err))
-					time.Sleep(10 * time.Second)
-				}
-			}()
-		}
-	}
 	return nil
 }
 

--- a/waku/v2/node/wakunode2_test.go
+++ b/waku/v2/node/wakunode2_test.go
@@ -154,7 +154,7 @@ func Test500(t *testing.T) {
 			msg := createTestMsg(0)
 			msg.Payload = int2Bytes(i)
 			msg.Timestamp = int64(i)
-			if err := wakuNode2.Publish(ctx, msg); err != nil {
+			if _, err := wakuNode2.Relay().Publish(ctx, msg); err != nil {
 				require.Fail(t, "Could not publish all messages")
 			}
 			time.Sleep(5 * time.Millisecond)
@@ -181,6 +181,10 @@ func TestDecoupledStoreFromRelay(t *testing.T) {
 	err = wakuNode1.Start(ctx)
 	require.NoError(t, err)
 	defer wakuNode1.Stop()
+
+	subs, err := wakuNode1.Relay().Subscribe(ctx)
+	require.NoError(t, err)
+	subs.Unsubscribe()
 
 	// NODE2: Filter Client/Store
 	db, migration, err := sqlite.NewDB(":memory:")
@@ -230,7 +234,7 @@ func TestDecoupledStoreFromRelay(t *testing.T) {
 
 	time.Sleep(500 * time.Millisecond)
 
-	if err := wakuNode1.Publish(ctx, msg); err != nil {
+	if _, err := wakuNode1.Relay().Publish(ctx, msg); err != nil {
 		require.Fail(t, "Could not publish all messages")
 	}
 

--- a/waku/v2/node/wakuoptions.go
+++ b/waku/v2/node/wakuoptions.go
@@ -66,7 +66,6 @@ type WakuNodeParameters struct {
 	logger   *zap.Logger
 	logLevel logging.LogLevel
 
-	noDefaultWakuTopic     bool
 	enableRelay            bool
 	enableLegacyFilter     bool
 	isLegacyFilterFullnode bool
@@ -79,7 +78,6 @@ type WakuNodeParameters struct {
 	minRelayPeersToPublish int
 
 	enableStore     bool
-	resumeNodes     []multiaddr.Multiaddr
 	messageProvider store.MessageProvider
 
 	rendezvousNodes        []multiaddr.Multiaddr
@@ -318,15 +316,6 @@ func WithPeerStore(ps peerstore.Peerstore) WakuNodeOption {
 	}
 }
 
-// NoDefaultWakuTopic will stop the node from subscribing to the default
-// pubsub topic automatically
-func NoDefaultWakuTopic() WakuNodeOption {
-	return func(params *WakuNodeParameters) error {
-		params.noDefaultWakuTopic = true
-		return nil
-	}
-}
-
 // WithWakuRelay enables the Waku V2 Relay protocol. This WakuNodeOption
 // accepts a list of WakuRelay gossipsub option to setup the protocol
 func WithWakuRelay(opts ...pubsub.Option) WakuNodeOption {
@@ -400,12 +389,10 @@ func WithWakuFilterFullNode(filterOpts ...filter.Option) WakuNodeOption {
 }
 
 // WithWakuStore enables the Waku V2 Store protocol and if the messages should
-// be stored or not in a message provider. If resumeNodes are specified, the
-// store will attempt to resume message history using those nodes
-func WithWakuStore(resumeNodes ...multiaddr.Multiaddr) WakuNodeOption {
+// be stored or not in a message provider.
+func WithWakuStore() WakuNodeOption {
 	return func(params *WakuNodeParameters) error {
 		params.enableStore = true
-		params.resumeNodes = resumeNodes
 		return nil
 	}
 }

--- a/waku/v2/protocol/enr/localnode.go
+++ b/waku/v2/protocol/enr/localnode.go
@@ -91,7 +91,6 @@ func WithUDPPort(udpPort uint) ENROption {
 }
 
 func Update(localnode *enode.LocalNode, enrOptions ...ENROption) error {
-	localnode.SetFallbackIP(net.IP{127, 0, 0, 1})
 	for _, opt := range enrOptions {
 		err := opt(localnode)
 		if err != nil {

--- a/waku/v2/protocol/filter/client.go
+++ b/waku/v2/protocol/filter/client.go
@@ -424,9 +424,7 @@ func (wf *WakuFilterLightnode) UnsubscribeAll(ctx context.Context, opts ...Filte
 				wf.log.Error("could not unsubscribe from peer", logging.HostID("peerID", peerID), zap.Error(err))
 			}
 
-			wf.subscriptions.Lock()
 			delete(wf.subscriptions.items, peerID)
-			defer wf.subscriptions.Unlock()
 
 			resultChan <- WakuFilterPushResult{
 				Err:    err,

--- a/waku/v2/protocol/shard.go
+++ b/waku/v2/protocol/shard.go
@@ -53,8 +53,8 @@ func (rs RelayShards) Contains(cluster uint16, index uint16) bool {
 	}
 
 	found := false
-	for _, i := range rs.Indices {
-		if i == index {
+	for _, idx := range rs.Indices {
+		if idx == index {
 			found = true
 		}
 	}

--- a/waku/v2/protocol/topic.go
+++ b/waku/v2/protocol/topic.go
@@ -159,7 +159,6 @@ func (n StaticShardingPubsubTopic) String() string {
 
 func (s *StaticShardingPubsubTopic) Parse(topic string) error {
 	if !strings.HasPrefix(topic, StaticShardingPubsubTopicPrefix) {
-		fmt.Println(topic, StaticShardingPubsubTopicPrefix)
 		return ErrInvalidShardedTopicPrefix
 	}
 


### PR DESCRIPTION
- Shards in same cluster are advertised on ENR
- Store().Resume() was moved to app layer
- NoDefaultWakuTopic() was removed since it's the app that must determine whether it subscribes to the default waku topic or not
- Removed `Publish` from WakuNode (not really used and easy to implement in app layer if needed)