### PR TITLE
feat: sqlite vacuum and optional migrations

### DIFF
--- a/cmd/waku/flags.go
+++ b/cmd/waku/flags.go
@@ -288,6 +288,19 @@ var (
 		Destination: &options.Store.DatabaseURL,
 		EnvVars:     []string{"WAKUNODE2_STORE_MESSAGE_DB_URL"},
 	})
+	StoreMessageDBVacuum = altsrc.NewBoolFlag(&cli.BoolFlag{
+		Name:        "store-message-db-vacuum",
+		Usage:       "Enable database vacuuming at start. Only supported by SQLite database engine.",
+		Destination: &options.Store.Vacuum,
+		EnvVars:     []string{"WAKUNODE2_STORE_MESSAGE_DB_VACUUM"},
+	})
+	StoreMessageDBMigration = altsrc.NewBoolFlag(&cli.BoolFlag{
+		Name:        "store-message-db-migration",
+		Usage:       "Enable database migration at start.",
+		Destination: &options.Store.Migration,
+		Value:       true,
+		EnvVars:     []string{"WAKUNODE2_STORE_MESSAGE_DB_MIGRATION"},
+	})
 	StoreResumePeer = cliutils.NewGenericFlagMultiValue(&cli.GenericFlag{
 		Name:  "store-resume-peer",
 		Usage: "Peer multiaddress to resume the message store at boot. Option may be repeated",

--- a/cmd/waku/flags.go
+++ b/cmd/waku/flags.go
@@ -290,7 +290,7 @@ var (
 	})
 	StoreMessageDBVacuum = altsrc.NewBoolFlag(&cli.BoolFlag{
 		Name:        "store-message-db-vacuum",
-		Usage:       "Enable database vacuuming at start. Only supported by SQLite database engine.",
+		Usage:       "Enable database vacuuming at start.",
 		Destination: &options.Store.Vacuum,
 		EnvVars:     []string{"WAKUNODE2_STORE_MESSAGE_DB_VACUUM"},
 	})

--- a/cmd/waku/main.go
+++ b/cmd/waku/main.go
@@ -56,6 +56,8 @@ func main() {
 		StoreMessageDBURL,
 		StoreMessageRetentionTime,
 		StoreMessageRetentionCapacity,
+		StoreMessageDBVacuum,
+		StoreMessageDBMigration,
 		StoreResumePeer,
 		FilterFlag,
 		FilterNode,

--- a/cmd/waku/node.go
+++ b/cmd/waku/node.go
@@ -98,7 +98,7 @@ func Execute(options NodeOptions) {
 	var migrationFn func(*sql.DB) error
 	if requiresDB(options) && options.Store.Migration {
 		dbSettings := dbutils.DBSettings{
-			SQLiteVacuum: options.Store.Vacuum,
+			Vacuum: options.Store.Vacuum,
 		}
 		db, migrationFn, err = dbutils.ExtractDBAndMigration(options.Store.DatabaseURL, dbSettings, logger)
 		failOnErr(err, "Could not connect to DB")

--- a/cmd/waku/options.go
+++ b/cmd/waku/options.go
@@ -81,6 +81,8 @@ type StoreOptions struct {
 	RetentionMaxMessages int
 	ResumeNodes          []multiaddr.Multiaddr
 	Nodes                []multiaddr.Multiaddr
+	Vacuum               bool
+	Migration            bool
 }
 
 // DNSDiscoveryOptions are settings used for enabling DNS-based discovery

--- a/cmd/waku/rest/utils_test.go
+++ b/cmd/waku/rest/utils_test.go
@@ -12,7 +12,7 @@ import (
 
 func MemoryDB(t *testing.T) *persistence.DBStore {
 	var db *sql.DB
-	db, migration, err := sqlite.NewDB(":memory:")
+	db, migration, err := sqlite.NewDB(":memory:", false, utils.Logger())
 	require.NoError(t, err)
 
 	dbStore, err := persistence.NewDBStore(utils.Logger(), persistence.WithDB(db), persistence.WithMigrations(migration))

--- a/library/node.go
+++ b/library/node.go
@@ -131,7 +131,7 @@ func NewNode(configJSON string) error {
 	if *config.EnableStore {
 		var db *sql.DB
 		var migrationFn func(*sql.DB) error
-		db, migrationFn, err = dbutils.ExtractDBAndMigration(*config.DatabaseURL)
+		db, migrationFn, err = dbutils.ExtractDBAndMigration(*config.DatabaseURL, dbutils.DBSettings{SQLiteVacuum: true}, utils.Logger())
 		if err != nil {
 			return err
 		}

--- a/library/node.go
+++ b/library/node.go
@@ -131,7 +131,7 @@ func NewNode(configJSON string) error {
 	if *config.EnableStore {
 		var db *sql.DB
 		var migrationFn func(*sql.DB) error
-		db, migrationFn, err = dbutils.ExtractDBAndMigration(*config.DatabaseURL, dbutils.DBSettings{SQLiteVacuum: true}, utils.Logger())
+		db, migrationFn, err = dbutils.ExtractDBAndMigration(*config.DatabaseURL, dbutils.DBSettings{Vacuum: true}, utils.Logger())
 		if err != nil {
 			return err
 		}

--- a/waku/persistence/postgres/postgres.go
+++ b/waku/persistence/postgres/postgres.go
@@ -38,7 +38,7 @@ func WithDB(dburl string, migrate bool, shouldVacuum bool) persistence.DBOption 
 
 func executeVacuum(db *sql.DB, logger *zap.Logger) error {
 	logger.Info("starting PostgreSQL database vacuuming")
-	_, err := db.Exec("VACUUM")
+	_, err := db.Exec("VACUUM FULL")
 	if err != nil {
 		return err
 	}

--- a/waku/persistence/utils/db.go
+++ b/waku/persistence/utils/db.go
@@ -21,7 +21,7 @@ func validateDBUrl(val string) error {
 
 // DBSettings hold db specific configuration settings required during the db initialization
 type DBSettings struct {
-	SQLiteVacuum bool
+	Vacuum bool
 }
 
 // ExtractDBAndMigration will return a database connection, and migration function that should be used depending on a database connection string
@@ -49,9 +49,9 @@ func ExtractDBAndMigration(databaseURL string, dbSettings DBSettings, logger *za
 	dbParams := dbURLParts[1]
 	switch dbEngine {
 	case "sqlite3":
-		db, migrationFn, err = sqlite.NewDB(dbParams, dbSettings.SQLiteVacuum, logger)
+		db, migrationFn, err = sqlite.NewDB(dbParams, dbSettings.Vacuum, logger)
 	case "postgresql":
-		db, migrationFn, err = postgres.NewDB(dbURL)
+		db, migrationFn, err = postgres.NewDB(dbURL, dbSettings.Vacuum, logger)
 	default:
 		err = errors.New("unsupported database engine")
 	}

--- a/waku/v2/node/connectedness_test.go
+++ b/waku/v2/node/connectedness_test.go
@@ -69,7 +69,7 @@ func TestConnectionStatusChanges(t *testing.T) {
 	err = node2.Start(ctx)
 	require.NoError(t, err)
 
-	db, migration, err := sqlite.NewDB(":memory:")
+	db, migration, err := sqlite.NewDB(":memory:", false, utils.Logger())
 	require.NoError(t, err)
 	dbStore, err := persistence.NewDBStore(utils.Logger(), persistence.WithDB(db), persistence.WithMigrations(migration))
 	require.NoError(t, err)

--- a/waku/v2/node/wakunode2_test.go
+++ b/waku/v2/node/wakunode2_test.go
@@ -230,7 +230,7 @@ func TestDecoupledStoreFromRelay(t *testing.T) {
 	subs.Unsubscribe()
 
 	// NODE2: Filter Client/Store
-	db, migration, err := sqlite.NewDB(":memory:")
+	db, migration, err := sqlite.NewDB(":memory:", false, utils.Logger())
 	require.NoError(t, err)
 	dbStore, err := persistence.NewDBStore(utils.Logger(), persistence.WithDB(db), persistence.WithMigrations(migration))
 	require.NoError(t, err)

--- a/waku/v2/protocol/store/utils_test.go
+++ b/waku/v2/protocol/store/utils_test.go
@@ -12,7 +12,7 @@ import (
 
 func MemoryDB(t *testing.T) *persistence.DBStore {
 	var db *sql.DB
-	db, migration, err := sqlite.NewDB(":memory:")
+	db, migration, err := sqlite.NewDB(":memory:", false, utils.Logger())
 	require.NoError(t, err)
 
 	dbStore, err := persistence.NewDBStore(utils.Logger(), persistence.WithDB(db), persistence.WithMigrations(migration))

--- a/waku/v2/rendezvous/rendezvous_test.go
+++ b/waku/v2/rendezvous/rendezvous_test.go
@@ -47,7 +47,7 @@ func TestRendezvous(t *testing.T) {
 	require.NoError(t, err)
 
 	var db *sql.DB
-	db, migration, err := sqlite.NewDB(":memory:")
+	db, migration, err := sqlite.NewDB(":memory:", false, utils.Logger())
 	require.NoError(t, err)
 
 	err = migration(db)


### PR DESCRIPTION
# Description
This adds new flags already available in nwaku to allow users to execute the vacuum procedure on sqlite databases and choose whether they want to execute migrations or not

cc: @apentori 

# Changes

<!-- List of detailed changes -->

- [x] Adds new flags `--store-message-db-vacuum` and `--store-message-db-migrate`
- [x] Introduces a struct `DBSettings` that can be used to pass settings required for different RDBMS (might be refactored away in the future)
- [x] DB instantiation requires a logger

