### PR TITLE
refactor: remove unused function and simplify code related to creating db and migrations

### DIFF
--- a/cmd/waku/rest/utils_test.go
+++ b/cmd/waku/rest/utils_test.go
@@ -12,10 +12,10 @@ import (
 
 func MemoryDB(t *testing.T) *persistence.DBStore {
 	var db *sql.DB
-	db, migration, err := sqlite.NewDB(":memory:", false, utils.Logger())
+	db, err := sqlite.NewDB(":memory:", false, utils.Logger())
 	require.NoError(t, err)
 
-	dbStore, err := persistence.NewDBStore(utils.Logger(), persistence.WithDB(db), persistence.WithMigrations(migration))
+	dbStore, err := persistence.NewDBStore(utils.Logger(), persistence.WithDB(db), persistence.WithMigrations(sqlite.Migrations))
 	require.NoError(t, err)
 
 	return dbStore

--- a/waku/persistence/store.go
+++ b/waku/persistence/store.go
@@ -121,9 +121,11 @@ func WithRetentionPolicy(maxMessages int, maxDuration time.Duration) DBOption {
 	}
 }
 
+type MigrationFn func(db *sql.DB) error
+
 // WithMigrations is a DBOption used to determine if migrations should
 // be executed, and what driver to use
-func WithMigrations(migrationFn func(db *sql.DB) error) DBOption {
+func WithMigrations(migrationFn MigrationFn) DBOption {
 	return func(d *DBStore) error {
 		d.enableMigrations = true
 		d.migrationFn = migrationFn

--- a/waku/persistence/utils/db.go
+++ b/waku/persistence/utils/db.go
@@ -49,9 +49,11 @@ func ExtractDBAndMigration(databaseURL string, dbSettings DBSettings, logger *za
 	dbParams := dbURLParts[1]
 	switch dbEngine {
 	case "sqlite3":
-		db, migrationFn, err = sqlite.NewDB(dbParams, dbSettings.Vacuum, logger)
+		db, err = sqlite.NewDB(dbParams, dbSettings.Vacuum, logger)
+		migrationFn = sqlite.Migrations
 	case "postgresql":
-		db, migrationFn, err = postgres.NewDB(dbURL, dbSettings.Vacuum, logger)
+		db, err = postgres.NewDB(dbURL, dbSettings.Vacuum, logger)
+		migrationFn = postgres.Migrations
 	default:
 		err = errors.New("unsupported database engine")
 	}

--- a/waku/v2/node/connectedness_test.go
+++ b/waku/v2/node/connectedness_test.go
@@ -69,9 +69,9 @@ func TestConnectionStatusChanges(t *testing.T) {
 	err = node2.Start(ctx)
 	require.NoError(t, err)
 
-	db, migration, err := sqlite.NewDB(":memory:", false, utils.Logger())
+	db, err := sqlite.NewDB(":memory:", false, utils.Logger())
 	require.NoError(t, err)
-	dbStore, err := persistence.NewDBStore(utils.Logger(), persistence.WithDB(db), persistence.WithMigrations(migration))
+	dbStore, err := persistence.NewDBStore(utils.Logger(), persistence.WithDB(db), persistence.WithMigrations(sqlite.Migrations))
 	require.NoError(t, err)
 
 	// Node3: Relay + Store

--- a/waku/v2/node/wakunode2_test.go
+++ b/waku/v2/node/wakunode2_test.go
@@ -230,9 +230,9 @@ func TestDecoupledStoreFromRelay(t *testing.T) {
 	subs.Unsubscribe()
 
 	// NODE2: Filter Client/Store
-	db, migration, err := sqlite.NewDB(":memory:", false, utils.Logger())
+	db, err := sqlite.NewDB(":memory:", false, utils.Logger())
 	require.NoError(t, err)
-	dbStore, err := persistence.NewDBStore(utils.Logger(), persistence.WithDB(db), persistence.WithMigrations(migration))
+	dbStore, err := persistence.NewDBStore(utils.Logger(), persistence.WithDB(db), persistence.WithMigrations(sqlite.Migrations))
 	require.NoError(t, err)
 
 	hostAddr2, err := net.ResolveTCPAddr("tcp", "0.0.0.0:0")

--- a/waku/v2/protocol/store/utils_test.go
+++ b/waku/v2/protocol/store/utils_test.go
@@ -12,10 +12,10 @@ import (
 
 func MemoryDB(t *testing.T) *persistence.DBStore {
 	var db *sql.DB
-	db, migration, err := sqlite.NewDB(":memory:", false, utils.Logger())
+	db, err := sqlite.NewDB(":memory:", false, utils.Logger())
 	require.NoError(t, err)
 
-	dbStore, err := persistence.NewDBStore(utils.Logger(), persistence.WithDB(db), persistence.WithMigrations(migration))
+	dbStore, err := persistence.NewDBStore(utils.Logger(), persistence.WithDB(db), persistence.WithMigrations(sqlite.Migrations))
 	require.NoError(t, err)
 
 	return dbStore

--- a/waku/v2/rendezvous/rendezvous_test.go
+++ b/waku/v2/rendezvous/rendezvous_test.go
@@ -3,7 +3,6 @@ package rendezvous
 import (
 	"context"
 	"crypto/rand"
-	"database/sql"
 	"fmt"
 	"sync"
 	"testing"
@@ -46,11 +45,10 @@ func TestRendezvous(t *testing.T) {
 	host1, err := tests.MakeHost(ctx, port1, rand.Reader)
 	require.NoError(t, err)
 
-	var db *sql.DB
-	db, migration, err := sqlite.NewDB(":memory:", false, utils.Logger())
+	db, err := sqlite.NewDB(":memory:", false, utils.Logger())
 	require.NoError(t, err)
 
-	err = migration(db)
+	err = sqlite.Migrations(db)
 	require.NoError(t, err)
 
 	rdb := NewDB(ctx, db, utils.Logger())


### PR DESCRIPTION
# Description
Minor refactor that removes the functions `WithDB` specific to each RDBMS, that are not used at all, and whose behavior can still be achieved by using `persistence.WithDB`; and reduce the number of returned parameters from `NewDB` while also reducing the responsibility of this function, as there is already a `Migrations` function that can be called, in case we want to obtain the migrations for postgresql/sqlite

# Changes



- [x] Removes `postgre.WithDB`
- [x] Removes `sqlite.WithDB`
- [x] `NewDB` will not return the migrations associated to the RDBMS
- [x] Renames `Migrate` to `Migrations` so the name of the functions reads better. i.e: `persistence.WithMigrations(sqlite.Migrations)` vs `persistence.WithMigrations(sqlite.Migrate)`
