### PR TITLE
feat: implement relay conenctivity loop

### DIFF
--- a/waku/v2/node/wakunode2.go
+++ b/waku/v2/node/wakunode2.go
@@ -243,8 +243,9 @@ func New(opts ...WakuNodeOption) (*WakuNode, error) {
 	if err != nil {
 		w.log.Error("creating localnode", zap.Error(err))
 	}
+
 	//Initialize peer manager.
-	w.peermanager = peermanager.NewPeerManager(uint(w.opts.maxPeerConnections), w.log)
+	w.peermanager = peermanager.NewPeerManager(w.opts.maxPeerConnections, w.log)
 	maxOutPeers := int(w.peermanager.OutRelayPeersTarget)
 
 	// Setup peer connection strategy
@@ -257,6 +258,7 @@ func New(opts ...WakuNodeOption) (*WakuNode, error) {
 	if err != nil {
 		w.log.Error("creating peer connection strategy", zap.Error(err))
 	}
+	w.peermanager.SetPeerConnector(w.peerConnector)
 
 	if w.opts.enableDiscV5 {
 		err := w.mountDiscV5()

--- a/waku/v2/peermanager/peer_connector.go
+++ b/waku/v2/peermanager/peer_connector.go
@@ -176,7 +176,7 @@ func (c *PeerConnectionStrategy) shouldDialPeers(ctx context.Context) {
 			return
 		case <-ticker.C:
 			isPaused := c.isPaused()
-			_, outRelayPeers, err := c.host.Peerstore().(wps.WakuPeerstore).GroupPeersByDirection()
+			_, outRelayPeers, err := c.pm.GroupPeersByDirection()
 			if err != nil {
 				c.logger.Info("Failed to get outRelayPeers from peerstore", zap.Error(err))
 				continue

--- a/waku/v2/peermanager/test/peer_manager_test.go
+++ b/waku/v2/peermanager/test/peer_manager_test.go
@@ -49,6 +49,12 @@ func TestServiceSlots(t *testing.T) {
 
 	peerId, err = pm.SelectPeer(protocol, nil, utils.Logger())
 	require.NoError(t, err)
+	if peerId == h2.ID() || peerId == h1.ID() {
+		//Test success
+		t.Log("Random peer selection per protocol successful")
+	} else {
+		t.FailNow()
+	}
 	require.Equal(t, peerId, h2.ID())
 
 	h1.Peerstore().AddAddrs(h3.ID(), h3.Network().ListenAddresses(), peerstore.PermanentAddrTTL)
@@ -64,7 +70,12 @@ func TestServiceSlots(t *testing.T) {
 	//Test peer selection from first added peer to serviceSlot
 	peerId, err = pm.SelectPeer(protocol, nil, utils.Logger())
 	require.NoError(t, err)
-	require.Equal(t, peerId, h2.ID())
+	if peerId == h2.ID() || peerId == h3.ID() {
+		//Test success
+		t.Log("Random peer selection per protocol successful")
+	} else {
+		t.FailNow()
+	}
 
 	//Test peer selection for specific protocol
 	peerId, err = pm.SelectPeer(protocol1, nil, utils.Logger())

--- a/waku/v2/peerstore/waku_peer_store.go
+++ b/waku/v2/peerstore/waku_peer_store.go
@@ -51,7 +51,6 @@ type WakuPeerstore interface {
 
 	SetDirection(p peer.ID, direction network.Direction) error
 	Direction(p peer.ID) (network.Direction, error)
-	GroupPeersByDirection() (inPeers peer.IDSlice, outPeers peer.IDSlice, err error)
 }
 
 // NewWakuPeerstore creates a new WakuPeerStore object
@@ -139,20 +138,4 @@ func (ps *WakuPeerstoreImpl) Direction(p peer.ID) (network.Direction, error) {
 	}
 
 	return result.(network.Direction), nil
-}
-
-// GroupPeersByDirection returns all the peers in peer store grouped by Inbound or outBound direction
-func (ps *WakuPeerstoreImpl) GroupPeersByDirection() (inPeers peer.IDSlice, outPeers peer.IDSlice, err error) {
-
-	for _, p := range ps.Peers() {
-		direction, err := ps.Direction(p)
-		if err == nil {
-			if direction == network.DirInbound {
-				inPeers = append(inPeers, p)
-			} else if direction == network.DirOutbound {
-				outPeers = append(outPeers, p)
-			}
-		}
-	}
-	return inPeers, outPeers, nil
 }


### PR DESCRIPTION
# Description
Implemented a relay connectivity loop similar to https://github.com/waku-org/nwaku/pull/1482/files.

# Changes

<!-- List of detailed changes -->

- Relay connectivity loop
- Updated relay peer connection target to have min of 10 outRelay connections ir-respective of max connections (similar to nwaku)
- Fixed connection pruning logic to only use connectedPeer count and peers which are using relay protocol.

# Tests

All unit tests passed.

