### PR TITLE
fix: race condition in peermgt initialization reported by race detector

### DIFF
--- a/waku/v2/node/wakunode2.go
+++ b/waku/v2/node/wakunode2.go
@@ -384,6 +384,7 @@ func (w *WakuNode) Start(ctx context.Context) error {
 	}
 
 	w.peerConnector.SetHost(host)
+	w.peermanager.SetHost(host)
 	w.peerConnector.SetPeerManager(w.peermanager)
 	err = w.peerConnector.Start(ctx)
 	if err != nil {
@@ -398,7 +399,6 @@ func (w *WakuNode) Start(ctx context.Context) error {
 	}
 
 	w.relay.SetHost(host)
-	w.peermanager.SetHost(host)
 
 	if w.opts.enableRelay {
 		err := w.relay.Start(ctx)


### PR DESCRIPTION
# Description
Ran tests with race detector enabled which reported 2 race conditions (given below).
Fix done for the same by ordering initialization.

# Changes

- [ ] Set peermanager host before starting peer connector

# Tests
Executed all unit tests with and without race condition.


# Race conditions Reported 
```

==================
WARNING: DATA RACE
Read at 0x00c001db9fb0 by goroutine 2437:
  github.com/waku-org/go-waku/waku/v2/peermanager.(*PeerManager).GroupPeersByDirection()
      /Users/prem/Code/go-waku/waku/v2/peermanager/peer_manager.go:106 +0x3c
  github.com/waku-org/go-waku/waku/v2/peermanager.(*PeerConnectionStrategy).shouldDialPeers()
      /Users/prem/Code/go-waku/waku/v2/peermanager/peer_connector.go:188 +0x228
  github.com/waku-org/go-waku/waku/v2/peermanager.(*PeerConnectionStrategy).Start.func1()
      /Users/prem/Code/go-waku/waku/v2/peermanager/peer_connector.go:141 +0x4c

Previous write at 0x00c001db9fb0 by goroutine 2233:
  github.com/waku-org/go-waku/waku/v2/peermanager.(*PeerManager).SetHost()
      /Users/prem/Code/go-waku/waku/v2/peermanager/peer_manager.go:75 +0xebc
  github.com/waku-org/go-waku/waku/v2/node.(*WakuNode).Start()
      /Users/prem/Code/go-waku/waku/v2/node/wakunode2.go:401 +0xea0
  github.com/waku-org/go-waku/waku/v2/node.Test500()
      /Users/prem/Code/go-waku/waku/v2/node/wakunode2_test.go:136 +0x3d0
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1576 +0x188
  testing.(*T).Run.func1()
      /usr/local/go/src/testing/testing.go:1629 +0x40

Goroutine 2437 (running) created at:
  github.com/waku-org/go-waku/waku/v2/peermanager.(*PeerConnectionStrategy).Start()
      /Users/prem/Code/go-waku/waku/v2/peermanager/peer_connector.go:141 +0x25c
  github.com/waku-org/go-waku/waku/v2/node.(*WakuNode).Start()
      /Users/prem/Code/go-waku/waku/v2/node/wakunode2.go:388 +0xe0c
  github.com/waku-org/go-waku/waku/v2/node.Test500()
      /Users/prem/Code/go-waku/waku/v2/node/wakunode2_test.go:136 +0x3d0
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1576 +0x188
  testing.(*T).Run.func1()
      /usr/local/go/src/testing/testing.go:1629 +0x40

Goroutine 2233 (running) created at:
  testing.(*T).Run()
      /usr/local/go/src/testing/testing.go:1629 +0x5e4
  testing.runTests.func1()
      /usr/local/go/src/testing/testing.go:2036 +0x80
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1576 +0x188
  testing.runTests()
      /usr/local/go/src/testing/testing.go:2034 +0x700
  testing.(*M).Run()
      /usr/local/go/src/testing/testing.go:1906 +0x950
  main.main()
      _testmain.go:61 +0x300
==================


==================
WARNING: DATA RACE
Read at 0x00c003412570 by goroutine 3296:
  github.com/waku-org/go-waku/waku/v2/peermanager.(*PeerManager).GroupPeersByDirection()
      /Users/prem/Code/go-waku/waku/v2/peermanager/peer_manager.go:106 +0x3c
  github.com/waku-org/go-waku/waku/v2/peermanager.(*PeerConnectionStrategy).shouldDialPeers()
      /Users/prem/Code/go-waku/waku/v2/peermanager/peer_connector.go:188 +0x228
  github.com/waku-org/go-waku/waku/v2/peermanager.(*PeerConnectionStrategy).Start.func1()
      /Users/prem/Code/go-waku/waku/v2/peermanager/peer_connector.go:141 +0x4c

Previous write at 0x00c003412570 by goroutine 3064:
  github.com/waku-org/go-waku/waku/v2/peermanager.(*PeerManager).SetHost()
      /Users/prem/Code/go-waku/waku/v2/peermanager/peer_manager.go:75 +0xebc
  github.com/waku-org/go-waku/waku/v2/node.(*WakuNode).Start()
      /Users/prem/Code/go-waku/waku/v2/node/wakunode2.go:401 +0xea0
  github.com/waku-org/go-waku/waku/v2/node.TestDecoupledStoreFromRelay()
      /Users/prem/Code/go-waku/waku/v2/node/wakunode2_test.go:247 +0x6b4
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1576 +0x188
  testing.(*T).Run.func1()
      /usr/local/go/src/testing/testing.go:1629 +0x40

Goroutine 3296 (running) created at:
  github.com/waku-org/go-waku/waku/v2/peermanager.(*PeerConnectionStrategy).Start()
      /Users/prem/Code/go-waku/waku/v2/peermanager/peer_connector.go:141 +0x25c
  github.com/waku-org/go-waku/waku/v2/node.(*WakuNode).Start()
      /Users/prem/Code/go-waku/waku/v2/node/wakunode2.go:388 +0xe0c
  github.com/waku-org/go-waku/waku/v2/node.TestDecoupledStoreFromRelay()
      /Users/prem/Code/go-waku/waku/v2/node/wakunode2_test.go:247 +0x6b4
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1576 +0x188
  testing.(*T).Run.func1()
      /usr/local/go/src/testing/testing.go:1629 +0x40

Goroutine 3064 (running) created at:
  testing.(*T).Run()
      /usr/local/go/src/testing/testing.go:1629 +0x5e4
  testing.runTests.func1()
      /usr/local/go/src/testing/testing.go:2036 +0x80
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1576 +0x188
  testing.runTests()
      /usr/local/go/src/testing/testing.go:2034 +0x700
  testing.(*M).Run()
      /usr/local/go/src/testing/testing.go:1906 +0x950
  main.main()
      _testmain.go:61 +0x300
==================


```