### PR TITLE
feat: register for local node's reachability change

### DIFF
--- a/waku/v2/node/localnode.go
+++ b/waku/v2/node/localnode.go
@@ -350,7 +350,7 @@ func (w *WakuNode) registerAndMonitorReachability(ctx context.Context) {
 	var myEventSub event.Subscription
 	var err error
 	if myEventSub, err = w.host.EventBus().Subscribe(new(event.EvtLocalReachabilityChanged)); err != nil {
-		w.log.Error("Failed to register with libp2p for reachability status")
+		w.log.Error("failed to register with libp2p for reachability status", zap.Error(err))
 		return
 	}
 	w.wg.Add(1)
@@ -362,8 +362,7 @@ func (w *WakuNode) registerAndMonitorReachability(ctx context.Context) {
 			select {
 			case evt := <-myEventSub.Out():
 				reachability := evt.(event.EvtLocalReachabilityChanged).Reachability
-				w.log.Info("Node Reachabilitiy Changed to",
-					zap.String("NewReachabilitiy", reachability.String()))
+				w.log.Info("Node reachability changed", zap.Stringer("newReachability", reachability))
 			case <-ctx.Done():
 				return
 			}

--- a/waku/v2/node/localnode.go
+++ b/waku/v2/node/localnode.go
@@ -346,11 +346,12 @@ func (w *WakuNode) watchTopicShards(ctx context.Context) error {
 	return nil
 }
 
-func (w *WakuNode) RegisterAndMonitorReachability(ctx context.Context) error {
+func (w *WakuNode) registerAndMonitorReachability(ctx context.Context) {
 	var myEventSub event.Subscription
 	var err error
 	if myEventSub, err = w.host.EventBus().Subscribe(new(event.EvtLocalReachabilityChanged)); err != nil {
-		return err
+		w.log.Error("Failed to register with libp2p for reachability status")
+		return
 	}
 	w.wg.Add(1)
 	go func() {
@@ -368,5 +369,4 @@ func (w *WakuNode) RegisterAndMonitorReachability(ctx context.Context) error {
 			}
 		}
 	}()
-	return nil
 }

--- a/waku/v2/node/wakunode2.go
+++ b/waku/v2/node/wakunode2.go
@@ -406,7 +406,7 @@ func (w *WakuNode) Start(ctx context.Context) error {
 			return err
 		}
 		w.peermanager.Start(ctx)
-		w.RegisterAndMonitorReachability(ctx)
+		w.registerAndMonitorReachability(ctx)
 	}
 
 	w.store = w.storeFactory(w)

--- a/waku/v2/node/wakunode2.go
+++ b/waku/v2/node/wakunode2.go
@@ -406,6 +406,7 @@ func (w *WakuNode) Start(ctx context.Context) error {
 			return err
 		}
 		w.peermanager.Start(ctx)
+		w.RegisterAndMonitorReachability(ctx)
 	}
 
 	w.store = w.storeFactory(w)


### PR DESCRIPTION
# Description
Register to listen for local Node reachability status and log when there are changes to it(Similar to https://github.com/waku-org/nwaku/pull/1472. ). Reachability is determined with help of AutoNAT service.
Note that some deviations would be there due to go-libp2p implementation of AutoNAT.
 
# Changes

<!-- List of detailed changes -->

- [x] Register to go-libp2p's EvtLocalReachabilityChanged event and monitor for changes and write info log.
