### PR TITLE
fix: log output and encoding

### DIFF
--- a/cmd/waku/node.go
+++ b/cmd/waku/node.go
@@ -83,6 +83,10 @@ const dialTimeout = 7 * time.Second
 
 // Execute starts a go-waku node with settings determined by the Options parameter
 func Execute(options NodeOptions) {
+	// Set encoding for logs (console, json, ...)
+	// Note that libp2p reads the encoding from GOLOG_LOG_FMT env var.
+	utils.InitLogger(options.LogEncoding, options.LogOutput)
+
 	hostAddr, err := net.ResolveTCPAddr("tcp", fmt.Sprintf("%s:%d", options.Address, options.Port))
 	failOnErr(err, "invalid host address")
 


### PR DESCRIPTION
# Description
Adds back code that I deleted by mistake in https://github.com/waku-org/go-waku/commit/61cba076bb0a585a33b8fc3187c3b780b0e611b1#diff-1365cc75829d0357d9c3adbd9fbc213f47e9ad86aa02e9e24f1513d84e7de037L109


## Issue

closes #649

