### PR TITLE
fix(rln-relay): flush_interval incorrectly set

### DIFF
--- a/examples/basic2/go.mod
+++ b/examples/basic2/go.mod
@@ -107,7 +107,7 @@ require (
 	github.com/tklauser/numcpus v0.2.2 // indirect
 	github.com/waku-org/go-discover v0.0.0-20221209174356-61c833f34d98 // indirect
 	github.com/waku-org/go-libp2p-rendezvous v0.0.0-20230628220917-7b4e5ae4c0e7 // indirect
-	github.com/waku-org/go-zerokit-rln v0.1.14-0.20230821163754-8167006b94e3 // indirect
+	github.com/waku-org/go-zerokit-rln v0.1.14-0.20230823150836-a706089284fe // indirect
 	github.com/waku-org/go-zerokit-rln-apple v0.0.0-20230821155521-70f1ff564bae // indirect
 	github.com/waku-org/go-zerokit-rln-arm v0.0.0-20230807124929-ea702b1b4305 // indirect
 	github.com/waku-org/go-zerokit-rln-x86_64 v0.0.0-20230807124913-ea636e5b4005 // indirect

--- a/examples/basic2/go.sum
+++ b/examples/basic2/go.sum
@@ -644,8 +644,8 @@ github.com/waku-org/go-discover v0.0.0-20221209174356-61c833f34d98 h1:xwY0kW5XZF
 github.com/waku-org/go-discover v0.0.0-20221209174356-61c833f34d98/go.mod h1:eBHgM6T4EG0RZzxpxKy+rGz/6Dw2Nd8DWxS0lm9ESDw=
 github.com/waku-org/go-libp2p-rendezvous v0.0.0-20230628220917-7b4e5ae4c0e7 h1:0e1h+p84yBp0IN7AqgbZlV7lgFBjm214lgSOE7CeJmE=
 github.com/waku-org/go-libp2p-rendezvous v0.0.0-20230628220917-7b4e5ae4c0e7/go.mod h1:pFvOZ9YTFsW0o5zJW7a0B5tr1owAijRWJctXJ2toL04=
-github.com/waku-org/go-zerokit-rln v0.1.14-0.20230821163754-8167006b94e3 h1:hdQ4rzJk+btnPYGcu1LTNqMF+aBUxY8CkatoNohto3g=
-github.com/waku-org/go-zerokit-rln v0.1.14-0.20230821163754-8167006b94e3/go.mod h1:aAlHP2G8TiZX5nKvsPpnOL+IGLlkYA567h5xrGCz7s8=
+github.com/waku-org/go-zerokit-rln v0.1.14-0.20230823150836-a706089284fe h1:t2KJU5HRgmRHo94cFwSa7BDwVioj+LCjJIK1H4p2lBA=
+github.com/waku-org/go-zerokit-rln v0.1.14-0.20230823150836-a706089284fe/go.mod h1:aAlHP2G8TiZX5nKvsPpnOL+IGLlkYA567h5xrGCz7s8=
 github.com/waku-org/go-zerokit-rln-apple v0.0.0-20230821155521-70f1ff564bae h1:VXgstV6RFUs6L/x0Xad4s0BIJ8hVEv1pyrByYzvZdT0=
 github.com/waku-org/go-zerokit-rln-apple v0.0.0-20230821155521-70f1ff564bae/go.mod h1:KYykqtdApHVYZ3G0spwMnoxc5jH5eI3jyO9SwsSfi48=
 github.com/waku-org/go-zerokit-rln-arm v0.0.0-20230807124929-ea702b1b4305 h1:33LEcvkC5eRdCIKt0bTG6G6DYZRNQGcpdoScA1ZFgRI=

--- a/examples/chat2/go.mod
+++ b/examples/chat2/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/multiformats/go-multiaddr v0.10.1
 	github.com/urfave/cli/v2 v2.24.4
 	github.com/waku-org/go-waku v0.2.3-0.20221109195301-b2a5a68d28ba
-	github.com/waku-org/go-zerokit-rln v0.1.14-0.20230821163754-8167006b94e3
+	github.com/waku-org/go-zerokit-rln v0.1.14-0.20230823150836-a706089284fe
 	golang.org/x/crypto v0.12.0
 	golang.org/x/term v0.11.0
 	google.golang.org/protobuf v1.31.0

--- a/examples/chat2/go.sum
+++ b/examples/chat2/go.sum
@@ -679,8 +679,8 @@ github.com/waku-org/go-discover v0.0.0-20221209174356-61c833f34d98 h1:xwY0kW5XZF
 github.com/waku-org/go-discover v0.0.0-20221209174356-61c833f34d98/go.mod h1:eBHgM6T4EG0RZzxpxKy+rGz/6Dw2Nd8DWxS0lm9ESDw=
 github.com/waku-org/go-libp2p-rendezvous v0.0.0-20230628220917-7b4e5ae4c0e7 h1:0e1h+p84yBp0IN7AqgbZlV7lgFBjm214lgSOE7CeJmE=
 github.com/waku-org/go-libp2p-rendezvous v0.0.0-20230628220917-7b4e5ae4c0e7/go.mod h1:pFvOZ9YTFsW0o5zJW7a0B5tr1owAijRWJctXJ2toL04=
-github.com/waku-org/go-zerokit-rln v0.1.14-0.20230821163754-8167006b94e3 h1:hdQ4rzJk+btnPYGcu1LTNqMF+aBUxY8CkatoNohto3g=
-github.com/waku-org/go-zerokit-rln v0.1.14-0.20230821163754-8167006b94e3/go.mod h1:aAlHP2G8TiZX5nKvsPpnOL+IGLlkYA567h5xrGCz7s8=
+github.com/waku-org/go-zerokit-rln v0.1.14-0.20230823150836-a706089284fe h1:t2KJU5HRgmRHo94cFwSa7BDwVioj+LCjJIK1H4p2lBA=
+github.com/waku-org/go-zerokit-rln v0.1.14-0.20230823150836-a706089284fe/go.mod h1:aAlHP2G8TiZX5nKvsPpnOL+IGLlkYA567h5xrGCz7s8=
 github.com/waku-org/go-zerokit-rln-apple v0.0.0-20230821155521-70f1ff564bae h1:VXgstV6RFUs6L/x0Xad4s0BIJ8hVEv1pyrByYzvZdT0=
 github.com/waku-org/go-zerokit-rln-apple v0.0.0-20230821155521-70f1ff564bae/go.mod h1:KYykqtdApHVYZ3G0spwMnoxc5jH5eI3jyO9SwsSfi48=
 github.com/waku-org/go-zerokit-rln-arm v0.0.0-20230807124929-ea702b1b4305 h1:33LEcvkC5eRdCIKt0bTG6G6DYZRNQGcpdoScA1ZFgRI=

--- a/examples/filter2/go.mod
+++ b/examples/filter2/go.mod
@@ -106,7 +106,7 @@ require (
 	github.com/tklauser/numcpus v0.2.2 // indirect
 	github.com/waku-org/go-discover v0.0.0-20221209174356-61c833f34d98 // indirect
 	github.com/waku-org/go-libp2p-rendezvous v0.0.0-20230628220917-7b4e5ae4c0e7 // indirect
-	github.com/waku-org/go-zerokit-rln v0.1.14-0.20230821163754-8167006b94e3 // indirect
+	github.com/waku-org/go-zerokit-rln v0.1.14-0.20230823150836-a706089284fe // indirect
 	github.com/waku-org/go-zerokit-rln-apple v0.0.0-20230821155521-70f1ff564bae // indirect
 	github.com/waku-org/go-zerokit-rln-arm v0.0.0-20230807124929-ea702b1b4305 // indirect
 	github.com/waku-org/go-zerokit-rln-x86_64 v0.0.0-20230807124913-ea636e5b4005 // indirect

--- a/examples/filter2/go.sum
+++ b/examples/filter2/go.sum
@@ -644,8 +644,8 @@ github.com/waku-org/go-discover v0.0.0-20221209174356-61c833f34d98 h1:xwY0kW5XZF
 github.com/waku-org/go-discover v0.0.0-20221209174356-61c833f34d98/go.mod h1:eBHgM6T4EG0RZzxpxKy+rGz/6Dw2Nd8DWxS0lm9ESDw=
 github.com/waku-org/go-libp2p-rendezvous v0.0.0-20230628220917-7b4e5ae4c0e7 h1:0e1h+p84yBp0IN7AqgbZlV7lgFBjm214lgSOE7CeJmE=
 github.com/waku-org/go-libp2p-rendezvous v0.0.0-20230628220917-7b4e5ae4c0e7/go.mod h1:pFvOZ9YTFsW0o5zJW7a0B5tr1owAijRWJctXJ2toL04=
-github.com/waku-org/go-zerokit-rln v0.1.14-0.20230821163754-8167006b94e3 h1:hdQ4rzJk+btnPYGcu1LTNqMF+aBUxY8CkatoNohto3g=
-github.com/waku-org/go-zerokit-rln v0.1.14-0.20230821163754-8167006b94e3/go.mod h1:aAlHP2G8TiZX5nKvsPpnOL+IGLlkYA567h5xrGCz7s8=
+github.com/waku-org/go-zerokit-rln v0.1.14-0.20230823150836-a706089284fe h1:t2KJU5HRgmRHo94cFwSa7BDwVioj+LCjJIK1H4p2lBA=
+github.com/waku-org/go-zerokit-rln v0.1.14-0.20230823150836-a706089284fe/go.mod h1:aAlHP2G8TiZX5nKvsPpnOL+IGLlkYA567h5xrGCz7s8=
 github.com/waku-org/go-zerokit-rln-apple v0.0.0-20230821155521-70f1ff564bae h1:VXgstV6RFUs6L/x0Xad4s0BIJ8hVEv1pyrByYzvZdT0=
 github.com/waku-org/go-zerokit-rln-apple v0.0.0-20230821155521-70f1ff564bae/go.mod h1:KYykqtdApHVYZ3G0spwMnoxc5jH5eI3jyO9SwsSfi48=
 github.com/waku-org/go-zerokit-rln-arm v0.0.0-20230807124929-ea702b1b4305 h1:33LEcvkC5eRdCIKt0bTG6G6DYZRNQGcpdoScA1ZFgRI=

--- a/examples/noise/go.mod
+++ b/examples/noise/go.mod
@@ -109,7 +109,7 @@ require (
 	github.com/tklauser/numcpus v0.2.2 // indirect
 	github.com/waku-org/go-discover v0.0.0-20221209174356-61c833f34d98 // indirect
 	github.com/waku-org/go-libp2p-rendezvous v0.0.0-20230628220917-7b4e5ae4c0e7 // indirect
-	github.com/waku-org/go-zerokit-rln v0.1.14-0.20230821163754-8167006b94e3 // indirect
+	github.com/waku-org/go-zerokit-rln v0.1.14-0.20230823150836-a706089284fe // indirect
 	github.com/waku-org/go-zerokit-rln-apple v0.0.0-20230821155521-70f1ff564bae // indirect
 	github.com/waku-org/go-zerokit-rln-arm v0.0.0-20230807124929-ea702b1b4305 // indirect
 	github.com/waku-org/go-zerokit-rln-x86_64 v0.0.0-20230807124913-ea636e5b4005 // indirect

--- a/examples/noise/go.sum
+++ b/examples/noise/go.sum
@@ -646,8 +646,8 @@ github.com/waku-org/go-libp2p-rendezvous v0.0.0-20230628220917-7b4e5ae4c0e7 h1:0
 github.com/waku-org/go-libp2p-rendezvous v0.0.0-20230628220917-7b4e5ae4c0e7/go.mod h1:pFvOZ9YTFsW0o5zJW7a0B5tr1owAijRWJctXJ2toL04=
 github.com/waku-org/go-noise v0.0.4 h1:ZfQDcCw8pazm89EBl5SXY7GGAnzDQb9AHFXlw3Ktbvk=
 github.com/waku-org/go-noise v0.0.4/go.mod h1:+PWRfs2eSOVwKrPcQlfhwDngSh3faL/1QoxvoqggEKc=
-github.com/waku-org/go-zerokit-rln v0.1.14-0.20230821163754-8167006b94e3 h1:hdQ4rzJk+btnPYGcu1LTNqMF+aBUxY8CkatoNohto3g=
-github.com/waku-org/go-zerokit-rln v0.1.14-0.20230821163754-8167006b94e3/go.mod h1:aAlHP2G8TiZX5nKvsPpnOL+IGLlkYA567h5xrGCz7s8=
+github.com/waku-org/go-zerokit-rln v0.1.14-0.20230823150836-a706089284fe h1:t2KJU5HRgmRHo94cFwSa7BDwVioj+LCjJIK1H4p2lBA=
+github.com/waku-org/go-zerokit-rln v0.1.14-0.20230823150836-a706089284fe/go.mod h1:aAlHP2G8TiZX5nKvsPpnOL+IGLlkYA567h5xrGCz7s8=
 github.com/waku-org/go-zerokit-rln-apple v0.0.0-20230821155521-70f1ff564bae h1:VXgstV6RFUs6L/x0Xad4s0BIJ8hVEv1pyrByYzvZdT0=
 github.com/waku-org/go-zerokit-rln-apple v0.0.0-20230821155521-70f1ff564bae/go.mod h1:KYykqtdApHVYZ3G0spwMnoxc5jH5eI3jyO9SwsSfi48=
 github.com/waku-org/go-zerokit-rln-arm v0.0.0-20230807124929-ea702b1b4305 h1:33LEcvkC5eRdCIKt0bTG6G6DYZRNQGcpdoScA1ZFgRI=

--- a/examples/rln/go.mod
+++ b/examples/rln/go.mod
@@ -107,7 +107,7 @@ require (
 	github.com/tklauser/numcpus v0.2.2 // indirect
 	github.com/waku-org/go-discover v0.0.0-20221209174356-61c833f34d98 // indirect
 	github.com/waku-org/go-libp2p-rendezvous v0.0.0-20230628220917-7b4e5ae4c0e7 // indirect
-	github.com/waku-org/go-zerokit-rln v0.1.14-0.20230821163754-8167006b94e3 // indirect
+	github.com/waku-org/go-zerokit-rln v0.1.14-0.20230823150836-a706089284fe // indirect
 	github.com/waku-org/go-zerokit-rln-apple v0.0.0-20230821155521-70f1ff564bae // indirect
 	github.com/waku-org/go-zerokit-rln-arm v0.0.0-20230807124929-ea702b1b4305 // indirect
 	github.com/waku-org/go-zerokit-rln-x86_64 v0.0.0-20230807124913-ea636e5b4005 // indirect

--- a/examples/rln/go.sum
+++ b/examples/rln/go.sum
@@ -644,8 +644,8 @@ github.com/waku-org/go-discover v0.0.0-20221209174356-61c833f34d98 h1:xwY0kW5XZF
 github.com/waku-org/go-discover v0.0.0-20221209174356-61c833f34d98/go.mod h1:eBHgM6T4EG0RZzxpxKy+rGz/6Dw2Nd8DWxS0lm9ESDw=
 github.com/waku-org/go-libp2p-rendezvous v0.0.0-20230628220917-7b4e5ae4c0e7 h1:0e1h+p84yBp0IN7AqgbZlV7lgFBjm214lgSOE7CeJmE=
 github.com/waku-org/go-libp2p-rendezvous v0.0.0-20230628220917-7b4e5ae4c0e7/go.mod h1:pFvOZ9YTFsW0o5zJW7a0B5tr1owAijRWJctXJ2toL04=
-github.com/waku-org/go-zerokit-rln v0.1.14-0.20230821163754-8167006b94e3 h1:hdQ4rzJk+btnPYGcu1LTNqMF+aBUxY8CkatoNohto3g=
-github.com/waku-org/go-zerokit-rln v0.1.14-0.20230821163754-8167006b94e3/go.mod h1:aAlHP2G8TiZX5nKvsPpnOL+IGLlkYA567h5xrGCz7s8=
+github.com/waku-org/go-zerokit-rln v0.1.14-0.20230823150836-a706089284fe h1:t2KJU5HRgmRHo94cFwSa7BDwVioj+LCjJIK1H4p2lBA=
+github.com/waku-org/go-zerokit-rln v0.1.14-0.20230823150836-a706089284fe/go.mod h1:aAlHP2G8TiZX5nKvsPpnOL+IGLlkYA567h5xrGCz7s8=
 github.com/waku-org/go-zerokit-rln-apple v0.0.0-20230821155521-70f1ff564bae h1:VXgstV6RFUs6L/x0Xad4s0BIJ8hVEv1pyrByYzvZdT0=
 github.com/waku-org/go-zerokit-rln-apple v0.0.0-20230821155521-70f1ff564bae/go.mod h1:KYykqtdApHVYZ3G0spwMnoxc5jH5eI3jyO9SwsSfi48=
 github.com/waku-org/go-zerokit-rln-arm v0.0.0-20230807124929-ea702b1b4305 h1:33LEcvkC5eRdCIKt0bTG6G6DYZRNQGcpdoScA1ZFgRI=

--- a/flake.nix
+++ b/flake.nix
@@ -28,7 +28,7 @@
           ];
           doCheck = false;
           # FIXME: This needs to be manually changed when updating modules.
-          vendorSha256 = "sha256-GwOUtYCg157Gtx33LsHBKW6rsPWWix1MlIR5skplpiY=";
+          vendorSha256 = "sha256-falqe2Gm9b43NU/QWwhySSlB2nE9OgEfgF138iMMuI4=";
           # Fix for 'nix run' trying to execute 'go-waku'.
           meta = { mainProgram = "waku"; };
         };

--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,7 @@ require (
 	github.com/jackc/pgx/v5 v5.4.1
 	github.com/waku-org/go-libp2p-rendezvous v0.0.0-20230628220917-7b4e5ae4c0e7
 	github.com/waku-org/go-noise v0.0.4
-	github.com/waku-org/go-zerokit-rln v0.1.14-0.20230821163754-8167006b94e3
+	github.com/waku-org/go-zerokit-rln v0.1.14-0.20230823150836-a706089284fe
 	github.com/wk8/go-ordered-map v1.0.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1535,8 +1535,8 @@ github.com/waku-org/go-libp2p-rendezvous v0.0.0-20230628220917-7b4e5ae4c0e7 h1:0
 github.com/waku-org/go-libp2p-rendezvous v0.0.0-20230628220917-7b4e5ae4c0e7/go.mod h1:pFvOZ9YTFsW0o5zJW7a0B5tr1owAijRWJctXJ2toL04=
 github.com/waku-org/go-noise v0.0.4 h1:ZfQDcCw8pazm89EBl5SXY7GGAnzDQb9AHFXlw3Ktbvk=
 github.com/waku-org/go-noise v0.0.4/go.mod h1:+PWRfs2eSOVwKrPcQlfhwDngSh3faL/1QoxvoqggEKc=
-github.com/waku-org/go-zerokit-rln v0.1.14-0.20230821163754-8167006b94e3 h1:hdQ4rzJk+btnPYGcu1LTNqMF+aBUxY8CkatoNohto3g=
-github.com/waku-org/go-zerokit-rln v0.1.14-0.20230821163754-8167006b94e3/go.mod h1:aAlHP2G8TiZX5nKvsPpnOL+IGLlkYA567h5xrGCz7s8=
+github.com/waku-org/go-zerokit-rln v0.1.14-0.20230823150836-a706089284fe h1:t2KJU5HRgmRHo94cFwSa7BDwVioj+LCjJIK1H4p2lBA=
+github.com/waku-org/go-zerokit-rln v0.1.14-0.20230823150836-a706089284fe/go.mod h1:aAlHP2G8TiZX5nKvsPpnOL+IGLlkYA567h5xrGCz7s8=
 github.com/waku-org/go-zerokit-rln-apple v0.0.0-20230821155521-70f1ff564bae h1:VXgstV6RFUs6L/x0Xad4s0BIJ8hVEv1pyrByYzvZdT0=
 github.com/waku-org/go-zerokit-rln-apple v0.0.0-20230821155521-70f1ff564bae/go.mod h1:KYykqtdApHVYZ3G0spwMnoxc5jH5eI3jyO9SwsSfi48=
 github.com/waku-org/go-zerokit-rln-arm v0.0.0-20230807124929-ea702b1b4305 h1:33LEcvkC5eRdCIKt0bTG6G6DYZRNQGcpdoScA1ZFgRI=

--- a/waku/v2/protocol/rln/waku_rln_relay.go
+++ b/waku/v2/protocol/rln/waku_rln_relay.go
@@ -69,7 +69,7 @@ func New(
 		CacheCapacity: 15000,
 		Mode:          rln.HighThroughput,
 		Compression:   false,
-		FlushInterval: 500,
+		FlushInterval: 500 * time.Millisecond,
 		Path:          treePath,
 	})
 	if err != nil {


### PR DESCRIPTION
# Description
See https://github.com/waku-org/nwaku/pull/1933 for motivation behind this change

# Changes

<!-- List of detailed changes -->

- [ ] Updates go-zerokit-rln to a version that uses `flush_every_ms` instead of `flush_interval`
- [ ] Uses a `time.Duration` to set the interval instead of an `uint`
