### PR TITLE
chore(rln-relay): rename keystore application to `waku-rln-relay`

### DIFF
--- a/waku/v2/protocol/rln/group_manager/dynamic/dynamic.go
+++ b/waku/v2/protocol/rln/group_manager/dynamic/dynamic.go
@@ -21,7 +21,7 @@ import (
 )
 
 var RLNAppInfo = keystore.AppInfo{
-	Application:   "nwaku-rln-relay",
+	Application:   "waku-rln-relay",
 	AppIdentifier: "01234567890abcdef",
 	Version:       "0.1",
 }


### PR DESCRIPTION
# Description
See https://github.com/waku-org/nwaku/issues/1903 for reasoning behind this change

## Issue

Part of #655

