### PR TITLE
refactor: keystore as a data type and store credentials into a map

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -9,3 +9,6 @@ plugins:
     #enabled: true
 exclude_patterns:
   - "."
+  - "**/*.pb.go"
+  - "**/rln/contracts/*.go"
+  - "**/bindata.go"

--- a/cmd/waku/flags_rln.go
+++ b/cmd/waku/flags_rln.go
@@ -6,6 +6,7 @@ package main
 import (
 	cli "github.com/urfave/cli/v2"
 	wcli "github.com/waku-org/go-waku/waku/cliutils"
+	"github.com/waku-org/go-waku/waku/v2/protocol/rln/keystore"
 )
 
 func rlnFlags() []cli.Flag {
@@ -17,10 +18,10 @@ func rlnFlags() []cli.Flag {
 			Destination: &options.RLNRelay.Enable,
 		},
 		&cli.UintFlag{
-			Name:        "rln-relay-membership-group-index",
+			Name:        "rln-relay-membership-index",
 			Value:       0,
-			Usage:       "the index of credentials to use, within a specific rln membership set",
-			Destination: &options.RLNRelay.MembershipGroupIndex,
+			Usage:       "the index of credentials to use",
+			Destination: &options.RLNRelay.MembershipIndex,
 		},
 		&cli.BoolFlag{
 			Name:        "rln-relay-dynamic",
@@ -30,12 +31,12 @@ func rlnFlags() []cli.Flag {
 		&cli.PathFlag{
 			Name:        "rln-relay-cred-path",
 			Usage:       "RLN relay membership credentials file",
-			Value:       "",
+			Value:       keystore.DefaultCredentialsFilename,
 			Destination: &options.RLNRelay.CredentialsPath,
 		},
 		&cli.StringFlag{
 			Name:        "rln-relay-cred-password",
-			Value:       "",
+			Value:       keystore.DefaultCredentialsPassword,
 			Usage:       "Password for encrypting RLN credentials",
 			Destination: &options.RLNRelay.CredentialsPassword,
 		},
@@ -44,12 +45,6 @@ func rlnFlags() []cli.Flag {
 			Value:       "",
 			Usage:       "Path to the RLN merkle tree sled db (https://github.com/spacejam/sled)",
 			Destination: &options.RLNRelay.TreePath,
-		},
-		&cli.UintFlag{
-			Name:        "rln-relay-membership-index",
-			Value:       0,
-			Usage:       "the index of credentials to use",
-			Destination: &options.RLNRelay.CredentialsIndex,
 		},
 		&cli.StringFlag{
 			Name:        "rln-relay-eth-client-address",

--- a/cmd/waku/node_rln.go
+++ b/cmd/waku/node_rln.go
@@ -17,17 +17,16 @@ func checkForRLN(logger *zap.Logger, options NodeOptions, nodeOpts *[]node.WakuN
 			failOnErr(errors.New("relay not available"), "Could not enable RLN Relay")
 		}
 		if !options.RLNRelay.Dynamic {
-			*nodeOpts = append(*nodeOpts, node.WithStaticRLNRelay(rln.MembershipIndex(options.RLNRelay.MembershipGroupIndex), nil))
+			*nodeOpts = append(*nodeOpts, node.WithStaticRLNRelay(rln.MembershipIndex(options.RLNRelay.MembershipIndex), nil))
 		} else {
 			// TODO: too many parameters in this function
 			// consider passing a config struct instead
 			*nodeOpts = append(*nodeOpts, node.WithDynamicRLNRelay(
 				options.RLNRelay.CredentialsPath,
 				options.RLNRelay.CredentialsPassword,
-				options.RLNRelay.CredentialsIndex,
 				options.RLNRelay.TreePath,
 				options.RLNRelay.MembershipContractAddress,
-				rln.MembershipIndex(options.RLNRelay.MembershipGroupIndex),
+				rln.MembershipIndex(options.RLNRelay.MembershipIndex),
 				nil,
 				options.RLNRelay.ETHClientAddress,
 			))

--- a/cmd/waku/options.go
+++ b/cmd/waku/options.go
@@ -37,9 +37,8 @@ type RLNRelayOptions struct {
 	Enable                    bool
 	CredentialsPath           string
 	CredentialsPassword       string
-	CredentialsIndex          uint
 	TreePath                  string
-	MembershipGroupIndex      uint
+	MembershipIndex           uint
 	Dynamic                   bool
 	ETHClientAddress          string
 	MembershipContractAddress common.Address

--- a/cmd/waku/rlngenerate/command_rln.go
+++ b/cmd/waku/rlngenerate/command_rln.go
@@ -103,27 +103,24 @@ func execute(ctx context.Context) error {
 	return nil
 }
 
-func persistCredentials(identityCredential *rln.IdentityCredential, membershipIndex rln.MembershipIndex, chainID *big.Int) error {
+func persistCredentials(identityCredential *rln.IdentityCredential, treeIndex rln.MembershipIndex, chainID *big.Int) error {
 	appKeystore, err := keystore.New(options.CredentialsPath, dynamic.RLNAppInfo, logger)
 	if err != nil {
 		return err
 	}
 
-	membershipGroup := keystore.MembershipGroup{
-		TreeIndex: membershipIndex,
-		MembershipContract: keystore.MembershipContract{
-			ChainID: fmt.Sprintf("0x%X", chainID.Int64()),
-			Address: options.MembershipContractAddress.String(),
-		},
+	membershipCredential := keystore.MembershipCredentials{
+		IdentityCredential:     identityCredential,
+		TreeIndex:              treeIndex,
+		MembershipContractInfo: keystore.NewMembershipContractInfo(chainID, options.MembershipContractAddress),
 	}
 
-	membershipGroupIndex, err := appKeystore.AddMembershipCredentials(identityCredential, membershipGroup, options.CredentialsPassword)
+	err = appKeystore.AddMembershipCredentials(membershipCredential, options.CredentialsPassword)
 	if err != nil {
 		return fmt.Errorf("failed to persist credentials: %w", err)
 	}
 
-	// TODO: obtain keystore index?
-	logger.Info("persisted credentials succesfully", zap.Uint("membershipGroupIndex", membershipGroupIndex))
+	logger.Info("persisted credentials succesfully")
 
 	return nil
 }

--- a/cmd/waku/rlngenerate/command_rln.go
+++ b/cmd/waku/rlngenerate/command_rln.go
@@ -28,13 +28,13 @@ var Command = cli.Command{
 	Name:  "generate-rln-credentials",
 	Usage: "Generate credentials for usage with RLN",
 	Action: func(cCtx *cli.Context) error {
-		err := verifyFlags()
-		if err != nil {
+		if options.ETHPrivateKey == nil {
+			err := errors.New("a private key must be specified")
 			logger.Error("validating option flags", zap.Error(err))
 			return cli.Exit(err, 1)
 		}
 
-		err = execute(context.Background())
+		err := execute(context.Background())
 		if err != nil {
 			logger.Error("registering RLN credentials", zap.Error(err))
 			return cli.Exit(err, 1)
@@ -43,24 +43,6 @@ var Command = cli.Command{
 		return nil
 	},
 	Flags: flags,
-}
-
-func verifyFlags() error {
-	if options.CredentialsPath == "" {
-		logger.Warn("keystore: no credentials path set, using default path", zap.String("path", keystore.RLN_CREDENTIALS_FILENAME))
-		options.CredentialsPath = keystore.RLN_CREDENTIALS_FILENAME
-	}
-
-	if options.CredentialsPassword == "" {
-		logger.Warn("keystore: no credentials password set, using default password", zap.String("password", keystore.RLN_CREDENTIALS_PASSWORD))
-		options.CredentialsPassword = keystore.RLN_CREDENTIALS_PASSWORD
-	}
-
-	if options.ETHPrivateKey == nil {
-		return errors.New("a private key must be specified")
-	}
-
-	return nil
 }
 
 func execute(ctx context.Context) error {
@@ -122,15 +104,20 @@ func execute(ctx context.Context) error {
 }
 
 func persistCredentials(identityCredential *rln.IdentityCredential, membershipIndex rln.MembershipIndex, chainID *big.Int) error {
+	appKeystore, err := keystore.New(options.CredentialsPath, dynamic.RLNAppInfo, logger)
+	if err != nil {
+		return err
+	}
+
 	membershipGroup := keystore.MembershipGroup{
 		TreeIndex: membershipIndex,
 		MembershipContract: keystore.MembershipContract{
-			ChainId: fmt.Sprintf("0x%X", chainID.Int64()),
+			ChainID: fmt.Sprintf("0x%X", chainID.Int64()),
 			Address: options.MembershipContractAddress.String(),
 		},
 	}
 
-	membershipGroupIndex, err := keystore.AddMembershipCredentials(options.CredentialsPath, identityCredential, membershipGroup, options.CredentialsPassword, dynamic.RLNAppInfo, keystore.DefaultSeparator)
+	membershipGroupIndex, err := appKeystore.AddMembershipCredentials(identityCredential, membershipGroup, options.CredentialsPassword)
 	if err != nil {
 		return fmt.Errorf("failed to persist credentials: %w", err)
 	}

--- a/cmd/waku/rlngenerate/flags.go
+++ b/cmd/waku/rlngenerate/flags.go
@@ -13,12 +13,12 @@ var flags = []cli.Flag{
 	&cli.PathFlag{
 		Name:        "cred-path",
 		Usage:       "RLN relay membership credentials file",
-		Value:       keystore.RLN_CREDENTIALS_FILENAME,
+		Value:       keystore.DefaultCredentialsFilename,
 		Destination: &options.CredentialsPath,
 	},
 	&cli.StringFlag{
 		Name:        "cred-password",
-		Value:       keystore.RLN_CREDENTIALS_PASSWORD,
+		Value:       keystore.DefaultCredentialsPassword,
 		Usage:       "Password for encrypting RLN credentials",
 		Destination: &options.CredentialsPassword,
 	},

--- a/examples/chat2/chat.go
+++ b/examples/chat2/chat.go
@@ -468,11 +468,7 @@ func (c *Chat) welcomeMessage() {
 		fmt.Println(err.Error())
 	}
 
-	idx, err := c.node.RLNRelay().MembershipIndex()
-	if err != nil {
-		c.ui.Quit()
-		fmt.Println(err.Error())
-	}
+	idx := c.node.RLNRelay().MembershipIndex()
 
 	idTrapdoor := credential.IDTrapdoor
 	idNullifier := credential.IDSecretHash

--- a/examples/chat2/exec.go
+++ b/examples/chat2/exec.go
@@ -52,7 +52,6 @@ func execute(options Options) {
 			opts = append(opts, node.WithDynamicRLNRelay(
 				options.RLNRelay.CredentialsPath,
 				options.RLNRelay.CredentialsPassword,
-				options.RLNRelay.CredentialsIndex,
 				"", // Will use default tree path
 				options.RLNRelay.MembershipContractAddress,
 				uint(options.RLNRelay.MembershipIndex),

--- a/examples/chat2/flags.go
+++ b/examples/chat2/flags.go
@@ -186,16 +186,10 @@ func getFlags() []cli.Flag {
 			Destination: &options.RLNRelay.Enable,
 		},
 		&cli.UintFlag{
-			Name:        "rln-relay-membership-group-index",
-			Value:       0,
-			Usage:       "the index of credentials to use, within a specific rln membership set",
-			Destination: &options.RLNRelay.MembershipGroupIndex,
-		},
-		&cli.UintFlag{
 			Name:        "rln-relay-membership-index",
 			Value:       0,
 			Usage:       "the index of credentials to use",
-			Destination: &options.RLNRelay.CredentialsIndex,
+			Destination: &options.RLNRelay.MembershipIndex,
 		},
 		&cli.BoolFlag{
 			Name:        "rln-relay-dynamic",

--- a/examples/chat2/options.go
+++ b/examples/chat2/options.go
@@ -31,8 +31,6 @@ type RLNRelayOptions struct {
 	Enable                    bool
 	CredentialsPath           string
 	CredentialsPassword       string
-	CredentialsIndex          uint
-	MembershipGroupIndex      uint
 	MembershipIndex           uint
 	Dynamic                   bool
 	ETHClientAddress          string

--- a/examples/rln/main.go
+++ b/examples/rln/main.go
@@ -29,8 +29,7 @@ const ethClientAddress = "wss://sepolia.infura.io/ws/v3/API_KEY_GOES_HERE"
 const contractAddress = "0x9C09146844C1326c2dBC41c451766C7138F88155"
 const keystorePath = ""     // Empty to store in current folder
 const keystorePassword = "" // Empty to use default
-const keystoreIndex = 0
-const membershipGroupIndex = 0
+const membershipIndex = 0
 
 var contentTopic = protocol.NewContentTopic("rln", 1, "test", "proto").String()
 var pubsubTopic = protocol.DefaultPubsubTopic()
@@ -63,14 +62,11 @@ func main() {
 		node.WithNTP(),
 		node.WithWakuRelay(),
 		node.WithDynamicRLNRelay(
-			pubsubTopic.String(),
-			contentTopic,
 			keystorePath,
 			keystorePassword,
-			keystoreIndex,
 			"", // Will use default tree path
 			common.HexToAddress(contractAddress),
-			membershipGroupIndex,
+			membershipIndex,
 			spamHandler,
 			ethClientAddress,
 		),

--- a/waku/v2/node/wakunode2.go
+++ b/waku/v2/node/wakunode2.go
@@ -70,7 +70,7 @@ type SpamHandler = func(message *pb.WakuMessage) error
 
 type RLNRelay interface {
 	IdentityCredential() (IdentityCredential, error)
-	MembershipIndex() (uint, error)
+	MembershipIndex() uint
 	AppendRLNProof(msg *pb.WakuMessage, senderEpochTime time.Time) error
 	Validator(spamHandler SpamHandler) func(ctx context.Context, peerID peer.ID, message *pubsub.Message) bool
 	Start(ctx context.Context) error

--- a/waku/v2/node/wakunode2_rln.go
+++ b/waku/v2/node/wakunode2_rln.go
@@ -12,6 +12,7 @@ import (
 	"github.com/waku-org/go-waku/waku/v2/protocol/rln"
 	"github.com/waku-org/go-waku/waku/v2/protocol/rln/group_manager/dynamic"
 	"github.com/waku-org/go-waku/waku/v2/protocol/rln/group_manager/static"
+	"github.com/waku-org/go-waku/waku/v2/protocol/rln/keystore"
 	r "github.com/waku-org/go-zerokit-rln/rln"
 )
 
@@ -44,14 +45,18 @@ func (w *WakuNode) setupRLNRelay() error {
 	} else {
 		w.log.Info("setting up waku-rln-relay in on-chain mode")
 
+		appKeystore, err := keystore.New(w.opts.keystorePath, dynamic.RLNAppInfo, w.log)
+		if err != nil {
+			return err
+		}
+
 		groupManager, err = dynamic.NewDynamicGroupManager(
 			w.opts.rlnETHClientAddress,
 			w.opts.rlnMembershipContractAddress,
 			w.opts.rlnRelayMemIndex,
-			w.opts.keystorePath,
+			appKeystore,
 			w.opts.keystorePassword,
 			w.opts.keystoreIndex,
-			true,
 			w.opts.prometheusReg,
 			w.log,
 		)

--- a/waku/v2/node/wakunode2_rln.go
+++ b/waku/v2/node/wakunode2_rln.go
@@ -56,7 +56,6 @@ func (w *WakuNode) setupRLNRelay() error {
 			w.opts.rlnRelayMemIndex,
 			appKeystore,
 			w.opts.keystorePassword,
-			w.opts.keystoreIndex,
 			w.opts.prometheusReg,
 			w.log,
 		)

--- a/waku/v2/node/wakuoptions.go
+++ b/waku/v2/node/wakuoptions.go
@@ -100,7 +100,6 @@ type WakuNodeParameters struct {
 	rlnETHClientAddress          string
 	keystorePath                 string
 	keystorePassword             string
-	keystoreIndex                uint
 	rlnTreePath                  string
 	rlnMembershipContractAddress common.Address
 

--- a/waku/v2/node/wakuoptions_rln.go
+++ b/waku/v2/node/wakuoptions_rln.go
@@ -23,17 +23,16 @@ func WithStaticRLNRelay(memberIndex r.MembershipIndex, spamHandler rln.SpamHandl
 
 // WithDynamicRLNRelay enables the Waku V2 RLN protocol in onchain mode.
 // Requires the `gowaku_rln` build constrain (or the env variable RLN=true if building go-waku)
-func WithDynamicRLNRelay(keystorePath string, keystorePassword string, keystoreIndex uint, treePath string, membershipContract common.Address, membershipGroupIndex uint, spamHandler rln.SpamHandler, ethClientAddress string) WakuNodeOption {
+func WithDynamicRLNRelay(keystorePath string, keystorePassword string, treePath string, membershipContract common.Address, membershipIndex uint, spamHandler rln.SpamHandler, ethClientAddress string) WakuNodeOption {
 	return func(params *WakuNodeParameters) error {
 		params.enableRLN = true
 		params.rlnRelayDynamic = true
 		params.keystorePassword = keystorePassword
 		params.keystorePath = keystorePath
-		params.keystoreIndex = keystoreIndex
 		params.rlnSpamHandler = spamHandler
 		params.rlnETHClientAddress = ethClientAddress
 		params.rlnMembershipContractAddress = membershipContract
-		params.rlnRelayMemIndex = membershipGroupIndex
+		params.rlnRelayMemIndex = membershipIndex
 		params.rlnTreePath = treePath
 		return nil
 	}

--- a/waku/v2/protocol/rln/group_manager/static/static.go
+++ b/waku/v2/protocol/rln/group_manager/static/static.go
@@ -14,7 +14,7 @@ type StaticGroupManager struct {
 	log *zap.Logger
 
 	identityCredential *rln.IdentityCredential
-	membershipIndex    *rln.MembershipIndex
+	membershipIndex    rln.MembershipIndex
 
 	group       []rln.IDCommitment
 	rootTracker *group_manager.MerkleRootTracker
@@ -36,7 +36,7 @@ func NewStaticGroupManager(
 		log:                log.Named("rln-static"),
 		group:              group,
 		identityCredential: &identityCredential,
-		membershipIndex:    &index,
+		membershipIndex:    index,
 	}, nil
 }
 
@@ -85,12 +85,8 @@ func (gm *StaticGroupManager) IdentityCredentials() (rln.IdentityCredential, err
 	return *gm.identityCredential, nil
 }
 
-func (gm *StaticGroupManager) MembershipIndex() (rln.MembershipIndex, error) {
-	if gm.membershipIndex == nil {
-		return 0, errors.New("membership index has not been setup")
-	}
-
-	return *gm.membershipIndex, nil
+func (gm *StaticGroupManager) MembershipIndex() rln.MembershipIndex {
+	return gm.membershipIndex
 }
 
 // Stop is a function created just to comply with the GroupManager interface (it does nothing)

--- a/waku/v2/protocol/rln/keystore/keystore.go
+++ b/waku/v2/protocol/rln/keystore/keystore.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"sort"
 
@@ -14,130 +13,49 @@ import (
 	"go.uber.org/zap"
 )
 
-const RLN_CREDENTIALS_FILENAME = "rlnKeystore.json"
-const RLN_CREDENTIALS_PASSWORD = "password"
+// DefaultCredentialsFilename is the default filename for the rln credentials keystore
+const DefaultCredentialsFilename = "rlnKeystore.json"
 
-type MembershipContract struct {
-	ChainId string `json:"chainId"`
-	Address string `json:"address"`
-}
+// DefaultCredentialsPassword contains the default password used when no password is specified
+const DefaultCredentialsPassword = "password"
 
-type MembershipGroup struct {
-	MembershipContract MembershipContract  `json:"membershipContract"`
-	TreeIndex          rln.MembershipIndex `json:"treeIndex"`
-}
+// New creates a new instance of a rln credentials keystore
+func New(keystorePath string, appInfo AppInfo, logger *zap.Logger) (*AppKeystore, error) {
+	logger = logger.Named("rln-keystore")
 
-type MembershipCredentials struct {
-	IdentityCredential *rln.IdentityCredential `json:"identityCredential"`
-	MembershipGroups   []MembershipGroup       `json:"membershipGroups"`
-}
-
-type AppInfo struct {
-	Application   string `json:"application"`
-	AppIdentifier string `json:"appIdentifier"`
-	Version       string `json:"version"`
-}
-
-type AppKeystore struct {
-	Application   string                  `json:"application"`
-	AppIdentifier string                  `json:"appIdentifier"`
-	Credentials   []AppKeystoreCredential `json:"credentials"`
-	Version       string                  `json:"version"`
-}
-
-type AppKeystoreCredential struct {
-	Crypto keystore.CryptoJSON `json:"crypto"`
-}
-
-const DefaultSeparator = "\n"
-
-func (m MembershipCredentials) Equals(other MembershipCredentials) bool {
-	if !rln.IdentityCredentialEquals(*m.IdentityCredential, *other.IdentityCredential) {
-		return false
-	}
-
-	for _, x := range m.MembershipGroups {
-		found := false
-		for _, y := range other.MembershipGroups {
-			if x.Equals(y) {
-				found = true
-				break
-			}
-		}
-		if !found {
-			return false
-		}
-	}
-
-	return true
-}
-
-func (m MembershipGroup) Equals(other MembershipGroup) bool {
-	return m.MembershipContract.Equals(other.MembershipContract) && m.TreeIndex == other.TreeIndex
-}
-
-func (m MembershipContract) Equals(other MembershipContract) bool {
-	return m.Address == other.Address && m.ChainId == other.ChainId
-}
-
-func CreateAppKeystore(path string, appInfo AppInfo, separator string) error {
-	if separator == "" {
-		separator = DefaultSeparator
-	}
-
-	keystore := AppKeystore{
-		Application:   appInfo.Application,
-		AppIdentifier: appInfo.AppIdentifier,
-		Version:       appInfo.Version,
-	}
-
-	b, err := json.Marshal(keystore)
-	if err != nil {
-		return err
-	}
-
-	b = append(b, []byte(separator)...)
-
-	buffer := new(bytes.Buffer)
-
-	err = json.Compact(buffer, b)
-	if err != nil {
-		return err
-	}
-
-	return ioutil.WriteFile(path, buffer.Bytes(), 0600)
-}
-
-func LoadAppKeystore(path string, appInfo AppInfo, separator string) (AppKeystore, error) {
-	if separator == "" {
-		separator = DefaultSeparator
+	path := keystorePath
+	if path == "" {
+		logger.Warn("keystore: no credentials path set, using default path", zap.String("path", DefaultCredentialsFilename))
+		path = DefaultCredentialsFilename
 	}
 
 	_, err := os.Stat(path)
 	if err != nil {
 		if os.IsNotExist(err) {
 			// If no keystore exists at path we create a new empty one with passed keystore parameters
-			err = CreateAppKeystore(path, appInfo, separator)
+			err = createAppKeystore(path, appInfo, defaultSeparator)
 			if err != nil {
-				return AppKeystore{}, err
+				return nil, err
 			}
 		} else {
-			return AppKeystore{}, err
+			return nil, err
 		}
 	}
 
 	src, err := os.ReadFile(path)
 	if err != nil {
-		return AppKeystore{}, err
+		return nil, err
 	}
 
-	for _, keystoreBytes := range bytes.Split(src, []byte(separator)) {
+	for _, keystoreBytes := range bytes.Split(src, []byte(defaultSeparator)) {
 		if len(keystoreBytes) == 0 {
 			continue
 		}
 
-		keystore := AppKeystore{}
-		err := json.Unmarshal(keystoreBytes, &keystore)
+		keystore := new(AppKeystore)
+		keystore.logger = logger
+		keystore.path = path
+		err := json.Unmarshal(keystoreBytes, keystore)
 		if err != nil {
 			continue
 		}
@@ -147,53 +65,15 @@ func LoadAppKeystore(path string, appInfo AppInfo, separator string) (AppKeystor
 		}
 	}
 
-	return AppKeystore{}, errors.New("no keystore found")
+	return nil, errors.New("no keystore found")
 }
 
-func filterCredential(credential MembershipCredentials, filterIdentityCredentials []MembershipCredentials, filterMembershipContracts []MembershipContract) *MembershipCredentials {
-	if len(filterIdentityCredentials) != 0 {
-		found := false
-		for _, filterCreds := range filterIdentityCredentials {
-			if filterCreds.Equals(credential) {
-				found = true
-			}
-		}
-		if !found {
-			return nil
-		}
-	}
-
-	if len(filterMembershipContracts) != 0 {
-		var membershipGroupsIntersection []MembershipGroup
-		for _, filterContract := range filterMembershipContracts {
-			for _, credentialGroups := range credential.MembershipGroups {
-				if filterContract.Equals(credentialGroups.MembershipContract) {
-					membershipGroupsIntersection = append(membershipGroupsIntersection, credentialGroups)
-				}
-			}
-		}
-		if len(membershipGroupsIntersection) != 0 {
-			// If we have a match on some groups, we return the credential with filtered groups
-			return &MembershipCredentials{
-				IdentityCredential: credential.IdentityCredential,
-				MembershipGroups:   membershipGroupsIntersection,
-			}
-		} else {
-			return nil
-		}
-	}
-
-	// We hit this return only if
-	// - filterIdentityCredentials.len() == 0 and filterMembershipContracts.len() == 0 (no filter)
-	// - filterIdentityCredentials.len() != 0 and filterMembershipContracts.len() == 0 (filter only on identity credential)
-	// Indeed, filterMembershipContracts.len() != 0 will have its exclusive return based on all values of membershipGroupsIntersection.len()
-	return &credential
-}
-
-func GetMembershipCredentials(logger *zap.Logger, credentialsPath string, password string, appInfo AppInfo, filterIdentityCredentials []MembershipCredentials, filterMembershipContracts []MembershipContract) ([]MembershipCredentials, error) {
-	k, err := LoadAppKeystore(credentialsPath, appInfo, DefaultSeparator)
-	if err != nil {
-		return nil, err
+// GetMembershipCredentials decrypts and retrieves membership credentials from the keystore applying filters
+func (k *AppKeystore) GetMembershipCredentials(keystorePassword string, filterIdentityCredentials []MembershipCredentials, filterMembershipContracts []MembershipContract) ([]MembershipCredentials, error) {
+	password := keystorePassword
+	if password == "" {
+		k.logger.Warn("keystore: no credentials password set, using default password", zap.String("password", DefaultCredentialsPassword))
+		password = DefaultCredentialsPassword
 	}
 
 	var result []MembershipCredentials
@@ -220,12 +100,7 @@ func GetMembershipCredentials(logger *zap.Logger, credentialsPath string, passwo
 }
 
 // AddMembershipCredentials inserts a membership credential to the keystore matching the application, appIdentifier and version filters.
-func AddMembershipCredentials(path string, newIdentityCredential *rln.IdentityCredential, newMembershipGroup MembershipGroup, password string, appInfo AppInfo, separator string) (membershipGroupIndex uint, err error) {
-	k, err := LoadAppKeystore(path, appInfo, DefaultSeparator)
-	if err != nil {
-		return 0, err
-	}
-
+func (k *AppKeystore) AddMembershipCredentials(newIdentityCredential *rln.IdentityCredential, newMembershipGroup MembershipGroup, password string) (membershipGroupIndex uint, err error) {
 	// A flag to tell us if the keystore contains a credential associated to the input identity credential, i.e. membershipCredential
 	found := false
 	for i, existingCredentials := range k.Credentials {
@@ -275,7 +150,7 @@ func AddMembershipCredentials(path string, newIdentityCredential *rln.IdentityCr
 			}
 
 			// we update the original credential field in keystoreCredentials
-			k.Credentials[i] = AppKeystoreCredential{Crypto: encryptedCredentials}
+			k.Credentials[i] = appKeystoreCredential{Crypto: encryptedCredentials}
 
 			found = true
 
@@ -309,28 +184,23 @@ func AddMembershipCredentials(path string, newIdentityCredential *rln.IdentityCr
 			return 0, err
 		}
 
-		k.Credentials = append(k.Credentials, AppKeystoreCredential{Crypto: encryptedCredentials})
+		k.Credentials = append(k.Credentials, appKeystoreCredential{Crypto: encryptedCredentials})
 
 		membershipGroupIndex = uint(len(newCredential.MembershipGroups) - 1)
 	}
 
-	return membershipGroupIndex, save(k, path, separator)
+	return membershipGroupIndex, save(k, k.path)
 }
 
-// Safely saves a Keystore's JsonNode to disk.
-// If exists, the destination file is renamed with extension .bkp; the file is written at its destination and the .bkp file is removed if write is successful, otherwise is restored
-func save(keystore AppKeystore, path string, separator string) error {
-	// We first backup the current keystore
-	_, err := os.Stat(path)
-	if err == nil {
-		err := os.Rename(path, path+".bkp")
-		if err != nil {
-			return err
-		}
+func createAppKeystore(path string, appInfo AppInfo, separator string) error {
+	if separator == "" {
+		separator = defaultSeparator
 	}
 
-	if separator == "" {
-		separator = DefaultSeparator
+	keystore := AppKeystore{
+		Application:   appInfo.Application,
+		AppIdentifier: appInfo.AppIdentifier,
+		Version:       appInfo.Version,
 	}
 
 	b, err := json.Marshal(keystore)
@@ -344,6 +214,75 @@ func save(keystore AppKeystore, path string, separator string) error {
 
 	err = json.Compact(buffer, b)
 	if err != nil {
+		return err
+	}
+
+	return os.WriteFile(path, buffer.Bytes(), 0600)
+}
+
+func filterCredential(credential MembershipCredentials, filterIdentityCredentials []MembershipCredentials, filterMembershipContracts []MembershipContract) *MembershipCredentials {
+	if len(filterIdentityCredentials) != 0 {
+		found := false
+		for _, filterCreds := range filterIdentityCredentials {
+			if filterCreds.Equals(credential) {
+				found = true
+			}
+		}
+		if !found {
+			return nil
+		}
+	}
+
+	if len(filterMembershipContracts) != 0 {
+		var membershipGroupsIntersection []MembershipGroup
+		for _, filterContract := range filterMembershipContracts {
+			for _, credentialGroups := range credential.MembershipGroups {
+				if filterContract.Equals(credentialGroups.MembershipContract) {
+					membershipGroupsIntersection = append(membershipGroupsIntersection, credentialGroups)
+				}
+			}
+		}
+		if len(membershipGroupsIntersection) != 0 {
+			// If we have a match on some groups, we return the credential with filtered groups
+			return &MembershipCredentials{
+				IdentityCredential: credential.IdentityCredential,
+				MembershipGroups:   membershipGroupsIntersection,
+			}
+		} else {
+			return nil
+		}
+	}
+
+	// We hit this return only if
+	// - filterIdentityCredentials.len() == 0 and filterMembershipContracts.len() == 0 (no filter)
+	// - filterIdentityCredentials.len() != 0 and filterMembershipContracts.len() == 0 (filter only on identity credential)
+	// Indeed, filterMembershipContracts.len() != 0 will have its exclusive return based on all values of membershipGroupsIntersection.len()
+	return &credential
+}
+
+// Safely saves a Keystore's JsonNode to disk.
+// If exists, the destination file is renamed with extension .bkp; the file is written at its destination and the .bkp file is removed if write is successful, otherwise is restored
+func save(keystore *AppKeystore, path string) error {
+	// We first backup the current keystore
+	_, err := os.Stat(path)
+	if err == nil {
+		err := os.Rename(path, path+".bkp")
+		if err != nil {
+			return err
+		}
+	}
+
+	b, err := json.Marshal(keystore)
+	if err != nil {
+		return err
+	}
+
+	b = append(b, []byte(defaultSeparator)...)
+
+	buffer := new(bytes.Buffer)
+
+	err = json.Compact(buffer, b)
+	if err != nil {
 		restoreErr := os.Rename(path, path+".bkp")
 		if restoreErr != nil {
 			return fmt.Errorf("could not restore backup file: %w", restoreErr)
@@ -351,7 +290,7 @@ func save(keystore AppKeystore, path string, separator string) error {
 		return err
 	}
 
-	err = ioutil.WriteFile(path, buffer.Bytes(), 0600)
+	err = os.WriteFile(path, buffer.Bytes(), 0600)
 	if err != nil {
 		restoreErr := os.Rename(path, path+".bkp")
 		if restoreErr != nil {

--- a/waku/v2/protocol/rln/keystore/types.go
+++ b/waku/v2/protocol/rln/keystore/types.go
@@ -1,59 +1,93 @@
 package keystore
 
 import (
+	"fmt"
+	"math/big"
+	"strings"
+
 	"github.com/ethereum/go-ethereum/accounts/keystore"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/waku-org/go-zerokit-rln/rln"
 	"go.uber.org/zap"
 )
 
-// MembershipContract contains information about a membership smart contract address and the chain in which it is deployed
-type MembershipContract struct {
-	ChainID string `json:"chainId"`
-	Address string `json:"address"`
+// MembershipContractInfo contains information about a membership smart contract address and the chain in which it is deployed
+type MembershipContractInfo struct {
+	ChainID ChainID         `json:"chainId"`
+	Address ContractAddress `json:"address"`
+}
+
+// NewMembershipContractInfo generates a new MembershipContract instance
+func NewMembershipContractInfo(chainID *big.Int, address common.Address) MembershipContractInfo {
+	return MembershipContractInfo{
+		ChainID: ChainID{
+			chainID,
+		},
+		Address: ContractAddress(address),
+	}
+}
+
+// ContractAddress is a common.Address created to comply with the expected marshalling for the credentials
+type ContractAddress common.Address
+
+// MarshalText is used to convert a ContractAddress into a valid value expected by the json encoder
+func (c ContractAddress) MarshalText() ([]byte, error) {
+	return []byte(common.Address(c).Hex()), nil
+}
+
+// UnmarshalText converts a byte slice into a ContractAddress
+func (c *ContractAddress) UnmarshalText(text []byte) error {
+	b, err := hexutil.Decode(string(text))
+	if err != nil {
+		return err
+	}
+	copy(c[:], b[:])
+	return nil
+}
+
+// ChainID is a helper struct created to comply with the expected marshalling for the credentials
+type ChainID struct {
+	*big.Int
+}
+
+// String returns a string with the expected chainId format for the credentials
+func (c ChainID) String() string {
+	return fmt.Sprintf(`"%s"`, hexutil.EncodeBig(c.Int))
+}
+
+// MarshalJSON is used to convert a ChainID into a valid value expected by the json encoder
+func (c ChainID) MarshalJSON() (text []byte, err error) {
+	return []byte(c.String()), nil
+}
+
+// UnmarshalJSON converts a byte slice into a ChainID
+func (c *ChainID) UnmarshalJSON(text []byte) error {
+	hexVal := strings.ReplaceAll(string(text), `"`, "")
+	b, err := hexutil.DecodeBig(hexVal)
+	if err != nil {
+		return err
+	}
+
+	c.Int = b
+	return nil
 }
 
 // Equals is used to compare MembershipContract
-func (m MembershipContract) Equals(other MembershipContract) bool {
-	return m.Address == other.Address && m.ChainID == other.ChainID
-}
-
-// MembershipGroup contains information about the index in which a credential is stored in the merkle tree and the contract associated to this credential
-type MembershipGroup struct {
-	MembershipContract MembershipContract  `json:"membershipContract"`
-	TreeIndex          rln.MembershipIndex `json:"treeIndex"`
-}
-
-// Equals is used to compare MembershipGroup
-func (m MembershipGroup) Equals(other MembershipGroup) bool {
-	return m.MembershipContract.Equals(other.MembershipContract) && m.TreeIndex == other.TreeIndex
+func (m MembershipContractInfo) Equals(other MembershipContractInfo) bool {
+	return m.Address == other.Address && m.ChainID.Int64() == other.ChainID.Int64()
 }
 
 // MembershipCredentials contains all the information about an RLN Identity Credential and membership group it belongs to
 type MembershipCredentials struct {
-	IdentityCredential *rln.IdentityCredential `json:"identityCredential"`
-	MembershipGroups   []MembershipGroup       `json:"membershipGroups"`
+	IdentityCredential     *rln.IdentityCredential `json:"identityCredential"`
+	MembershipContractInfo MembershipContractInfo  `json:"membershipContract"`
+	TreeIndex              rln.MembershipIndex     `json:"treeIndex"`
 }
 
 // Equals is used to compare MembershipCredentials
 func (m MembershipCredentials) Equals(other MembershipCredentials) bool {
-	if !rln.IdentityCredentialEquals(*m.IdentityCredential, *other.IdentityCredential) {
-		return false
-	}
-
-	for _, x := range m.MembershipGroups {
-		found := false
-		for _, y := range other.MembershipGroups {
-			if x.Equals(y) {
-				found = true
-				break
-			}
-		}
-		if !found {
-			return false
-		}
-	}
-
-	return true
+	return rln.IdentityCredentialEquals(*m.IdentityCredential, *other.IdentityCredential) && m.MembershipContractInfo.Equals(other.MembershipContractInfo) && m.TreeIndex == other.TreeIndex
 }
 
 // AppInfo is a helper structure that contains information about the application that uses these credentials
@@ -63,12 +97,15 @@ type AppInfo struct {
 	Version       string `json:"version"`
 }
 
+// Key is a helper type created to represent the key in a map of credentials
+type Key string
+
 // AppKeystore represents the membership credentials to be used in RLN
 type AppKeystore struct {
-	Application   string                  `json:"application"`
-	AppIdentifier string                  `json:"appIdentifier"`
-	Credentials   []appKeystoreCredential `json:"credentials"`
-	Version       string                  `json:"version"`
+	Application   string                        `json:"application"`
+	AppIdentifier string                        `json:"appIdentifier"`
+	Credentials   map[Key]appKeystoreCredential `json:"credentials"`
+	Version       string                        `json:"version"`
 
 	path   string
 	logger *zap.Logger

--- a/waku/v2/protocol/rln/keystore/types.go
+++ b/waku/v2/protocol/rln/keystore/types.go
@@ -1,0 +1,81 @@
+package keystore
+
+import (
+	"github.com/ethereum/go-ethereum/accounts/keystore"
+	"github.com/waku-org/go-zerokit-rln/rln"
+	"go.uber.org/zap"
+)
+
+// MembershipContract contains information about a membership smart contract address and the chain in which it is deployed
+type MembershipContract struct {
+	ChainID string `json:"chainId"`
+	Address string `json:"address"`
+}
+
+// Equals is used to compare MembershipContract
+func (m MembershipContract) Equals(other MembershipContract) bool {
+	return m.Address == other.Address && m.ChainID == other.ChainID
+}
+
+// MembershipGroup contains information about the index in which a credential is stored in the merkle tree and the contract associated to this credential
+type MembershipGroup struct {
+	MembershipContract MembershipContract  `json:"membershipContract"`
+	TreeIndex          rln.MembershipIndex `json:"treeIndex"`
+}
+
+// Equals is used to compare MembershipGroup
+func (m MembershipGroup) Equals(other MembershipGroup) bool {
+	return m.MembershipContract.Equals(other.MembershipContract) && m.TreeIndex == other.TreeIndex
+}
+
+// MembershipCredentials contains all the information about an RLN Identity Credential and membership group it belongs to
+type MembershipCredentials struct {
+	IdentityCredential *rln.IdentityCredential `json:"identityCredential"`
+	MembershipGroups   []MembershipGroup       `json:"membershipGroups"`
+}
+
+// Equals is used to compare MembershipCredentials
+func (m MembershipCredentials) Equals(other MembershipCredentials) bool {
+	if !rln.IdentityCredentialEquals(*m.IdentityCredential, *other.IdentityCredential) {
+		return false
+	}
+
+	for _, x := range m.MembershipGroups {
+		found := false
+		for _, y := range other.MembershipGroups {
+			if x.Equals(y) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+
+	return true
+}
+
+// AppInfo is a helper structure that contains information about the application that uses these credentials
+type AppInfo struct {
+	Application   string `json:"application"`
+	AppIdentifier string `json:"appIdentifier"`
+	Version       string `json:"version"`
+}
+
+// AppKeystore represents the membership credentials to be used in RLN
+type AppKeystore struct {
+	Application   string                  `json:"application"`
+	AppIdentifier string                  `json:"appIdentifier"`
+	Credentials   []appKeystoreCredential `json:"credentials"`
+	Version       string                  `json:"version"`
+
+	path   string
+	logger *zap.Logger
+}
+
+type appKeystoreCredential struct {
+	Crypto keystore.CryptoJSON `json:"crypto"`
+}
+
+const defaultSeparator = "\n"

--- a/waku/v2/protocol/rln/waku_rln_relay.go
+++ b/waku/v2/protocol/rln/waku_rln_relay.go
@@ -25,7 +25,7 @@ import (
 type GroupManager interface {
 	Start(ctx context.Context, rln *rln.RLN, rootTracker *group_manager.MerkleRootTracker) error
 	IdentityCredentials() (rln.IdentityCredential, error)
-	MembershipIndex() (rln.MembershipIndex, error)
+	MembershipIndex() rln.MembershipIndex
 	Stop() error
 }
 
@@ -356,10 +356,7 @@ func (rlnRelay *WakuRLNRelay) generateProof(input []byte, epoch rln.Epoch) (*pb.
 		return nil, err
 	}
 
-	membershipIndex, err := rlnRelay.groupManager.MembershipIndex()
-	if err != nil {
-		return nil, err
-	}
+	membershipIndex := rlnRelay.groupManager.MembershipIndex()
 
 	proof, err := rlnRelay.RLN.GenerateProof(input, identityCredentials, membershipIndex, epoch)
 	if err != nil {
@@ -381,6 +378,6 @@ func (rlnRelay *WakuRLNRelay) IdentityCredential() (rln.IdentityCredential, erro
 	return rlnRelay.groupManager.IdentityCredentials()
 }
 
-func (rlnRelay *WakuRLNRelay) MembershipIndex() (uint, error) {
+func (rlnRelay *WakuRLNRelay) MembershipIndex() uint {
 	return rlnRelay.groupManager.MembershipIndex()
 }


### PR DESCRIPTION
# Description
Extracts the rln keystore to be its own data type so the dynamic group manager does not have to worry about the keystore path and its existence. Also, uses the structure proposed in https://github.com/waku-org/nwaku/issues/1922#issuecomment-1692137198 and https://github.com/waku-org/nwaku/issues/1922#issuecomment-1692192077

# Changes
- [x] Extracts keystore functionality to an `AppKeystore struct`
- [x] Uses a map instead of an array to store credentials
- [x] Removes the flag `rln-relay-membership-index` from wakunode and chat2
- [x] Simplifies API of `GetMembershipCredentials` function
- [x] Ensures credentials can be used in both nwaku and go-waku