### PR TITLE
fix(filterV2): requestID and log request type

### DIFF
--- a/waku/v2/protocol/filter/client.go
+++ b/waku/v2/protocol/filter/client.go
@@ -254,6 +254,7 @@ func (wf *WakuFilterLightNode) FilterSubscription(peerID peer.ID, contentFilter 
 func (wf *WakuFilterLightNode) getUnsubscribeParameters(opts ...FilterUnsubscribeOption) (*FilterUnsubscribeParameters, error) {
 	params := new(FilterUnsubscribeParameters)
 	params.log = wf.log
+	opts = append(DefaultUnsubscribeOptions(), opts...)
 	for _, opt := range opts {
 		opt(params)
 	}
@@ -353,7 +354,7 @@ func (wf *WakuFilterLightNode) Unsubscribe(ctx context.Context, contentFilter Co
 			defer localWg.Done()
 			err := wf.request(
 				ctx,
-				&FilterSubscribeParameters{selectedPeer: peerID},
+				&FilterSubscribeParameters{selectedPeer: peerID, requestID: params.requestID},
 				pb.FilterSubscribeRequest_UNSUBSCRIBE,
 				contentFilter)
 			if err != nil {
@@ -422,7 +423,7 @@ func (wf *WakuFilterLightNode) UnsubscribeAll(ctx context.Context, opts ...Filte
 			defer localWg.Done()
 			err := wf.request(
 				ctx,
-				&FilterSubscribeParameters{selectedPeer: peerID},
+				&FilterSubscribeParameters{selectedPeer: peerID, requestID: params.requestID},
 				pb.FilterSubscribeRequest_UNSUBSCRIBE_ALL,
 				ContentFilter{})
 			if err != nil {

--- a/waku/v2/protocol/filter/server.go
+++ b/waku/v2/protocol/filter/server.go
@@ -118,7 +118,7 @@ func (wf *WakuFilterFullNode) onRequest(ctx context.Context) func(s network.Stre
 
 		wf.metrics.RecordRequest(subscribeRequest.FilterSubscribeType.String(), time.Since(start))
 
-		logger.Info("received request")
+		logger.Info("received request", zap.String("requestType", subscribeRequest.FilterSubscribeType.String()))
 	}
 }
 
@@ -298,7 +298,7 @@ func (wf *WakuFilterFullNode) pushMessage(ctx context.Context, peerID peer.ID, e
 		} else {
 			wf.metrics.RecordError(writeResponseFailure)
 		}
-		logger.Error("pushing messages to peer", zap.Error(err))
+		logger.Error("pushing messages to peer", logging.HexBytes("envelopeHash", env.Hash()), zap.String("pubsubTopic", env.PubsubTopic()), zap.String("contentTopic", env.Message().ContentTopic), zap.Error(err))
 		wf.subscriptions.FlagAsFailure(peerID)
 		return nil
 	}


### PR DESCRIPTION
# Description
The requestID was not being populated when unsubscribing from filter.
I also added the request type to the logs since it's useful for debugging