### PR TITLE
Check nils when deleting subscription

### DIFF
--- a/waku/v2/protocol/filter/client.go
+++ b/waku/v2/protocol/filter/client.go
@@ -379,7 +379,7 @@ func (wf *WakuFilterLightNode) Unsubscribe(ctx context.Context, contentFilter Co
 	localWg.Wait()
 	close(resultChan)
 	for _, peerID := range peersUnsubscribed {
-		if len(wf.subscriptions.items[peerID].subscriptionsPerTopic) == 0 {
+		if wf.subscriptions != nil && wf.subscriptions.items != nil && wf.subscriptions.items[peerID] != nil && len(wf.subscriptions.items[peerID].subscriptionsPerTopic) == 0 {
 			delete(wf.subscriptions.items, peerID)
 		}
 	}


### PR DESCRIPTION
A bug reported during testing of the latest go waku, probably we should have some more linting/testing in place to catch these issues? 