### PR TITLE
fix: allow mixing named and static shards

### DIFF
--- a/waku/v2/discv5/discover.go
+++ b/waku/v2/discv5/discover.go
@@ -453,8 +453,15 @@ func (d *DiscoveryV5) peerLoop(ctx context.Context) error {
 		}
 
 		nodeRS, err := wenr.RelaySharding(n.Record())
-		if err != nil || nodeRS == nil {
+		if err != nil {
 			return false
+		}
+
+		if nodeRS == nil {
+			// TODO: Node has no shard registered.
+			// Since for now, status-go uses both mixed static and named shards, we assume the node is valid
+			// Once status-go uses only static shards, we can't return true anymore.
+			return true
 		}
 
 		if nodeRS.Cluster != localRS.Cluster {

--- a/waku/v2/protocol/shard.go
+++ b/waku/v2/protocol/shard.go
@@ -20,8 +20,8 @@ const ClusterIndex = 1
 const GenerationZeroShardsCount = 8
 
 type RelayShards struct {
-	Cluster uint16
-	Indices []uint16
+	Cluster uint16   `json:"cluster"`
+	Indices []uint16 `json:"indices"`
 }
 
 func NewRelayShards(cluster uint16, indices ...uint16) (RelayShards, error) {


### PR DESCRIPTION
# Description
In https://github.com/status-im/status-go/pull/3944 sharding is introduced for communities,  however 1:1 and group chats use the DefaultPubsubTopic for now. In https://github.com/waku-org/go-waku/pull/696#issuecomment-1700823077 @chaitanyaprem noticed that the current logic of go-waku would not set the shards if there's a mix of static and named sharding. This PR 'fixes' this problem, since currently on status-go we do have a mix of named and static shards.

Once status-go uses static sharding only, then we can remove the option to allow both static and named shards at the same time

## Issue
Part of https://github.com/waku-org/go-waku/issues/634

