### PR TITLE
fix: loop counter for writing multiaddresses in enr

### DIFF
--- a/waku/v2/protocol/enr/localnode.go
+++ b/waku/v2/protocol/enr/localnode.go
@@ -35,7 +35,7 @@ func WithMultiaddress(multiaddrs ...multiaddr.Multiaddr) ENROption {
 		failedOnceWritingENR := false
 		couldWriteENRatLeastOnce := false
 		successIdx := -1
-		for i := len(multiaddrs) - 1; i >= 0; i-- {
+		for i := len(multiaddrs); i > 0; i-- {
 			err = writeMultiaddressField(localnode, multiaddrs[0:i])
 			if err == nil {
 				couldWriteENRatLeastOnce = true


### PR DESCRIPTION
# Description
Writing multiaddresses on the ENR `multiaddr` key worked only when there was more than one multiaddress field that should be stored on that field. Most of the time that wasn't a problem, specially since desktop does not use websocket addresses and always has at least 2 circuit relay addresses

