### PR TITLE
chore(rln-relay): use the only key from keystore if only 1 exists

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,12 +1,12 @@
 plugins:
-  golint:
-    enabled: true
+#  golint:
+#    enabled: true
   gofmt:
     enabled: true
   govet:
     enabled: true
-    #  golangci-lint:
-    #enabled: true
+#  golangci-lint:
+#    enabled: true
 exclude_patterns:
   - "."
   - "**/*.pb.go"

--- a/cmd/waku/flags_rln.go
+++ b/cmd/waku/flags_rln.go
@@ -17,11 +17,12 @@ func rlnFlags() []cli.Flag {
 			Usage:       "Enable spam protection through rln-relay",
 			Destination: &options.RLNRelay.Enable,
 		},
-		&cli.UintFlag{
-			Name:        "rln-relay-membership-index",
-			Value:       0,
-			Usage:       "the index of credentials to use",
-			Destination: &options.RLNRelay.MembershipIndex,
+		&cli.GenericFlag{
+			Name:  "rln-relay-cred-index",
+			Usage: "the index of the onchain commitment to use",
+			Value: &wcli.OptionalUint{
+				Value: &options.RLNRelay.MembershipIndex,
+			},
 		},
 		&cli.BoolFlag{
 			Name:        "rln-relay-dynamic",

--- a/cmd/waku/node_rln.go
+++ b/cmd/waku/node_rln.go
@@ -17,7 +17,7 @@ func checkForRLN(logger *zap.Logger, options NodeOptions, nodeOpts *[]node.WakuN
 			failOnErr(errors.New("relay not available"), "Could not enable RLN Relay")
 		}
 		if !options.RLNRelay.Dynamic {
-			*nodeOpts = append(*nodeOpts, node.WithStaticRLNRelay(rln.MembershipIndex(options.RLNRelay.MembershipIndex), nil))
+			*nodeOpts = append(*nodeOpts, node.WithStaticRLNRelay((*rln.MembershipIndex)(options.RLNRelay.MembershipIndex), nil))
 		} else {
 			// TODO: too many parameters in this function
 			// consider passing a config struct instead
@@ -26,7 +26,7 @@ func checkForRLN(logger *zap.Logger, options NodeOptions, nodeOpts *[]node.WakuN
 				options.RLNRelay.CredentialsPassword,
 				options.RLNRelay.TreePath,
 				options.RLNRelay.MembershipContractAddress,
-				rln.MembershipIndex(options.RLNRelay.MembershipIndex),
+				options.RLNRelay.MembershipIndex,
 				nil,
 				options.RLNRelay.ETHClientAddress,
 			))

--- a/cmd/waku/options.go
+++ b/cmd/waku/options.go
@@ -40,7 +40,7 @@ type RLNRelayOptions struct {
 	CredentialsPath           string
 	CredentialsPassword       string
 	TreePath                  string
-	MembershipIndex           uint
+	MembershipIndex           *uint
 	Dynamic                   bool
 	ETHClientAddress          string
 	MembershipContractAddress common.Address

--- a/examples/chat2/exec.go
+++ b/examples/chat2/exec.go
@@ -54,13 +54,13 @@ func execute(options Options) {
 				options.RLNRelay.CredentialsPassword,
 				"", // Will use default tree path
 				options.RLNRelay.MembershipContractAddress,
-				uint(options.RLNRelay.MembershipIndex),
+				options.RLNRelay.MembershipIndex,
 				spamHandler,
 				options.RLNRelay.ETHClientAddress,
 			))
 		} else {
 			opts = append(opts, node.WithStaticRLNRelay(
-				uint(options.RLNRelay.MembershipIndex),
+				options.RLNRelay.MembershipIndex,
 				spamHandler))
 		}
 	}

--- a/examples/chat2/flags.go
+++ b/examples/chat2/flags.go
@@ -36,8 +36,7 @@ func getFlags() []cli.Flag {
 
 	testCT, err := protocol.NewContentTopic("toy-chat", 3, "mingde", "proto")
 	if err != nil {
-		fmt.Println("Invalid contentTopic")
-		return nil
+		panic("invalid contentTopic")
 	}
 	testnetContentTopic := testCT.String()
 
@@ -190,11 +189,12 @@ func getFlags() []cli.Flag {
 			Usage:       "Enable spam protection through rln-relay",
 			Destination: &options.RLNRelay.Enable,
 		},
-		&cli.UintFlag{
-			Name:        "rln-relay-membership-index",
-			Value:       0,
-			Usage:       "the index of credentials to use",
-			Destination: &options.RLNRelay.MembershipIndex,
+		&cli.GenericFlag{
+			Name:  "rln-relay-cred-index",
+			Usage: "the index of the onchain commitment to use",
+			Value: &wcli.OptionalUint{
+				Value: &options.RLNRelay.MembershipIndex,
+			},
 		},
 		&cli.BoolFlag{
 			Name:        "rln-relay-dynamic",

--- a/examples/chat2/options.go
+++ b/examples/chat2/options.go
@@ -31,7 +31,7 @@ type RLNRelayOptions struct {
 	Enable                    bool
 	CredentialsPath           string
 	CredentialsPassword       string
-	MembershipIndex           uint
+	MembershipIndex           *uint
 	Dynamic                   bool
 	ETHClientAddress          string
 	MembershipContractAddress common.Address

--- a/waku/cliutils/cli.go
+++ b/waku/cliutils/cli.go
@@ -4,6 +4,7 @@ import (
 	"crypto/ecdsa"
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -72,4 +73,34 @@ func (v *ChoiceValue) String() string {
 		return ""
 	}
 	return *v.Value
+}
+
+// OptionalUint represents a urfave/cli flag to store uint values that can be
+// optionally set and not have any default value assigned to it
+type OptionalUint struct {
+	Value **uint
+}
+
+// Set assigns a value to the flag only if it represents a valid uint value
+func (v *OptionalUint) Set(value string) error {
+	if value != "" {
+		uintVal, err := strconv.ParseUint(value, 10, 0)
+		if err != nil {
+			return err
+		}
+		uVal := uint(uintVal)
+		*v.Value = &uVal
+	} else {
+		v.Value = nil
+	}
+
+	return nil
+}
+
+// String returns the string representation of the OptionalUint flag, if set
+func (v *OptionalUint) String() string {
+	if v.Value == nil {
+		return ""
+	}
+	return fmt.Sprintf("%d", *v.Value)
 }

--- a/waku/v2/node/wakunode2_rln.go
+++ b/waku/v2/node/wakunode2_rln.go
@@ -38,14 +38,18 @@ func (w *WakuNode) setupRLNRelay() error {
 	if !w.opts.rlnRelayDynamic {
 		w.log.Info("setting up waku-rln-relay in off-chain mode")
 
+		index := uint(0)
+		if w.opts.rlnRelayMemIndex != nil {
+			index = *w.opts.rlnRelayMemIndex
+		}
+
 		// set up rln relay inputs
-		groupKeys, idCredential, err := static.Setup(w.opts.rlnRelayMemIndex)
+		groupKeys, idCredential, err := static.Setup(index)
 		if err != nil {
 			return err
 		}
 
-		groupManager, err = static.NewStaticGroupManager(groupKeys, idCredential, w.opts.rlnRelayMemIndex, rlnInstance,
-			rootTracker, w.log)
+		groupManager, err = static.NewStaticGroupManager(groupKeys, idCredential, index, rlnInstance, rootTracker, w.log)
 		if err != nil {
 			return err
 		}

--- a/waku/v2/node/wakuoptions.go
+++ b/waku/v2/node/wakuoptions.go
@@ -94,7 +94,7 @@ type WakuNodeParameters struct {
 	enablePeerExchange bool
 
 	enableRLN                    bool
-	rlnRelayMemIndex             uint
+	rlnRelayMemIndex             *uint
 	rlnRelayDynamic              bool
 	rlnSpamHandler               func(message *pb.WakuMessage) error
 	rlnETHClientAddress          string

--- a/waku/v2/node/wakuoptions_rln.go
+++ b/waku/v2/node/wakuoptions_rln.go
@@ -11,7 +11,7 @@ import (
 
 // WithStaticRLNRelay enables the Waku V2 RLN protocol in offchain mode
 // Requires the `gowaku_rln` build constrain (or the env variable RLN=true if building go-waku)
-func WithStaticRLNRelay(memberIndex r.MembershipIndex, spamHandler rln.SpamHandler) WakuNodeOption {
+func WithStaticRLNRelay(memberIndex *r.MembershipIndex, spamHandler rln.SpamHandler) WakuNodeOption {
 	return func(params *WakuNodeParameters) error {
 		params.enableRLN = true
 		params.rlnRelayDynamic = false
@@ -23,7 +23,7 @@ func WithStaticRLNRelay(memberIndex r.MembershipIndex, spamHandler rln.SpamHandl
 
 // WithDynamicRLNRelay enables the Waku V2 RLN protocol in onchain mode.
 // Requires the `gowaku_rln` build constrain (or the env variable RLN=true if building go-waku)
-func WithDynamicRLNRelay(keystorePath string, keystorePassword string, treePath string, membershipContract common.Address, membershipIndex uint, spamHandler rln.SpamHandler, ethClientAddress string) WakuNodeOption {
+func WithDynamicRLNRelay(keystorePath string, keystorePassword string, treePath string, membershipContract common.Address, membershipIndex *uint, spamHandler rln.SpamHandler, ethClientAddress string) WakuNodeOption {
 	return func(params *WakuNodeParameters) error {
 		params.enableRLN = true
 		params.rlnRelayDynamic = true

--- a/waku/v2/protocol/rln/onchain_test.go
+++ b/waku/v2/protocol/rln/onchain_test.go
@@ -149,7 +149,7 @@ func (s *WakuRLNRelayDynamicSuite) TestDynamicGroupManagement() {
 
 	membershipIndex := s.register(appKeystore, u1Credentials, s.u1PrivKey)
 
-	gm, err := dynamic.NewDynamicGroupManager(s.web3Config.ETHClientAddress, s.web3Config.RegistryContract.Address, membershipIndex, appKeystore, keystorePassword, prometheus.DefaultRegisterer, rlnInstance, rt, utils.Logger())
+	gm, err := dynamic.NewDynamicGroupManager(s.web3Config.ETHClientAddress, s.web3Config.RegistryContract.Address, &membershipIndex, appKeystore, keystorePassword, prometheus.DefaultRegisterer, rlnInstance, rt, utils.Logger())
 	s.Require().NoError(err)
 
 	// initialize the WakuRLNRelay
@@ -236,7 +236,7 @@ func (s *WakuRLNRelayDynamicSuite) TestMerkleTreeConstruction() {
 	rlnInstance, rootTracker, err := GetRLNInstanceAndRootTracker(s.tmpRLNDBPath())
 	s.Require().NoError(err)
 	// mount the rln relay protocol in the on-chain/dynamic mode
-	gm, err := dynamic.NewDynamicGroupManager(s.web3Config.ETHClientAddress, s.web3Config.RegistryContract.Address, membershipIndex, appKeystore, keystorePassword, prometheus.DefaultRegisterer, rlnInstance, rootTracker, utils.Logger())
+	gm, err := dynamic.NewDynamicGroupManager(s.web3Config.ETHClientAddress, s.web3Config.RegistryContract.Address, &membershipIndex, appKeystore, keystorePassword, prometheus.DefaultRegisterer, rlnInstance, rootTracker, utils.Logger())
 	s.Require().NoError(err)
 
 	rlnRelay := New(group_manager.Details{
@@ -275,7 +275,7 @@ func (s *WakuRLNRelayDynamicSuite) TestCorrectRegistrationOfPeers() {
 	// mount the rln relay protocol in the on-chain/dynamic mode
 	rootInstance, rootTracker, err := GetRLNInstanceAndRootTracker(s.tmpRLNDBPath())
 	s.Require().NoError(err)
-	gm1, err := dynamic.NewDynamicGroupManager(s.web3Config.ETHClientAddress, s.web3Config.RegistryContract.Address, membershipGroupIndex, appKeystore, keystorePassword, prometheus.DefaultRegisterer, rootInstance, rootTracker, utils.Logger())
+	gm1, err := dynamic.NewDynamicGroupManager(s.web3Config.ETHClientAddress, s.web3Config.RegistryContract.Address, &membershipGroupIndex, appKeystore, keystorePassword, prometheus.DefaultRegisterer, rootInstance, rootTracker, utils.Logger())
 	s.Require().NoError(err)
 
 	rlnRelay1 := New(group_manager.Details{
@@ -299,7 +299,7 @@ func (s *WakuRLNRelayDynamicSuite) TestCorrectRegistrationOfPeers() {
 	// mount the rln relay protocol in the on-chain/dynamic mode
 	rootInstance, rootTracker, err = GetRLNInstanceAndRootTracker(s.tmpRLNDBPath())
 	s.Require().NoError(err)
-	gm2, err := dynamic.NewDynamicGroupManager(s.web3Config.ETHClientAddress, s.web3Config.RegistryContract.Address, membershipGroupIndex, appKeystore2, keystorePassword, prometheus.DefaultRegisterer, rootInstance, rootTracker, utils.Logger())
+	gm2, err := dynamic.NewDynamicGroupManager(s.web3Config.ETHClientAddress, s.web3Config.RegistryContract.Address, &membershipGroupIndex, appKeystore2, keystorePassword, prometheus.DefaultRegisterer, rootInstance, rootTracker, utils.Logger())
 	s.Require().NoError(err)
 
 	rlnRelay2 := New(group_manager.Details{


### PR DESCRIPTION
# Description
See https://github.com/waku-org/nwaku/pull/1984 for reasoning behind this change

# Changes

<!-- List of detailed changes -->

- [x] Created a custom flag type for optional uint values with no default 0 value
- [x] Load a credential automagically if there is only a single credential available on keystore
- [x] Test chat2


## Issue
Part of #655