### PR TITLE
chore: add tls/ws to address factory

### DIFF
--- a/waku/v2/node/wakuoptions.go
+++ b/waku/v2/node/wakuoptions.go
@@ -190,8 +190,11 @@ func WithDns4Domain(dns4Domain string) WakuNodeOption {
 
 			if params.enableWS || params.enableWSS {
 				if params.enableWSS {
+					// WSS is deprecated in https://github.com/multiformats/multiaddr/pull/109
 					wss, _ := multiaddr.NewMultiaddr(fmt.Sprintf("/tcp/%d/wss", params.wssPort))
 					addresses = append(addresses, hostAddrMA.Encapsulate(wss))
+					tlsws, _ := multiaddr.NewMultiaddr(fmt.Sprintf("/tcp/%d/tls/ws", params.wssPort))
+					addresses = append(addresses, hostAddrMA.Encapsulate(tlsws))
 				} else {
 					ws, _ := multiaddr.NewMultiaddr(fmt.Sprintf("/tcp/%d/ws", params.wsPort))
 					addresses = append(addresses, hostAddrMA.Encapsulate(ws))


### PR DESCRIPTION
# Description
Since `wss` is deprecated, this PR adds `tls/ws` to the list of multiaddresses returned by the address factory when using dns4+wss. In the future once js-libp2p adds support to `tls/ws`, we can drop support for `wss` entirely
