### PR TITLE
Fix panic in peer manager

### DIFF
--- a/waku/v2/peermanager/peer_manager.go
+++ b/waku/v2/peermanager/peer_manager.go
@@ -170,6 +170,10 @@ func (pm *PeerManager) connectToRelayPeers() {
 			numPeersToConnect = notConnectedPeers.Len() - 1
 		}
 
+		if numPeersToConnect <= 0 {
+			return
+		}
+
 		pm.connectToPeers(notConnectedPeers[0:numPeersToConnect])
 	} //Else: Should we raise some sort of unhealthy event??
 }

--- a/waku/v2/peermanager/peer_manager_test.go
+++ b/waku/v2/peermanager/peer_manager_test.go
@@ -151,3 +151,17 @@ func TestAdditionAndRemovalOfPeer(t *testing.T) {
 	_, err = pm.SelectPeer(protocol2, nil, utils.Logger())
 	require.Error(t, err, utils.ErrNoPeersAvailable)
 }
+
+func TestConnectToRelayPeers(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("TestConnectToRelayPeers panicked: %v", r)
+		}
+	}()
+
+	_, pm, deferFn := initTest(t)
+	defer deferFn()
+	
+	pm.connectToRelayPeers()
+
+}


### PR DESCRIPTION
# Description
This PR attempts to patch a panic we discovered in status-go.
The panic happens due to `slice bounds out of range [:-6]` 
I've added a non zero check to ensure we do not pass in negative values to slice and added a test that covers this specific case.

# Tests
- `TestConnectToRelayPeers` at `waku/v2/peermanager/peer_manager_test.go`

## Issue
closes #713
