### PR TITLE
feat(rln-relay): ensure execution order for pubsub validators

### DIFF
--- a/examples/chat2/exec.go
+++ b/examples/chat2/exec.go
@@ -43,7 +43,7 @@ func execute(options Options) {
 	}
 
 	if options.RLNRelay.Enable {
-		spamHandler := func(message *pb.WakuMessage) error {
+		spamHandler := func(message *pb.WakuMessage, topic string) error {
 			return nil
 		}
 

--- a/waku/v2/node/wakunode2.go
+++ b/waku/v2/node/wakunode2.go
@@ -10,7 +10,6 @@ import (
 	backoffv4 "github.com/cenkalti/backoff/v4"
 	golog "github.com/ipfs/go-log/v2"
 	"github.com/libp2p/go-libp2p"
-	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	"go.uber.org/zap"
 
 	"github.com/ethereum/go-ethereum/crypto"
@@ -66,13 +65,13 @@ type IdentityCredential = struct {
 	IDCommitment byte32 `json:"idCommitment"`
 }
 
-type SpamHandler = func(message *pb.WakuMessage) error
+type SpamHandler = func(message *pb.WakuMessage, topic string) error
 
 type RLNRelay interface {
 	IdentityCredential() (IdentityCredential, error)
 	MembershipIndex() uint
 	AppendRLNProof(msg *pb.WakuMessage, senderEpochTime time.Time) error
-	Validator(spamHandler SpamHandler) func(ctx context.Context, peerID peer.ID, message *pubsub.Message) bool
+	Validator(spamHandler SpamHandler) func(ctx context.Context, message *pb.WakuMessage, topic string) bool
 	Start(ctx context.Context) error
 	Stop() error
 }

--- a/waku/v2/node/wakunode2_rln.go
+++ b/waku/v2/node/wakunode2_rln.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"errors"
 
-	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	"github.com/waku-org/go-waku/waku/v2/protocol/rln"
 	"github.com/waku-org/go-waku/waku/v2/protocol/rln/group_manager"
 	"github.com/waku-org/go-waku/waku/v2/protocol/rln/group_manager/dynamic"
@@ -27,6 +26,10 @@ func (w *WakuNode) setupRLNRelay() error {
 
 	if !w.opts.enableRLN {
 		return nil
+	}
+
+	if !w.opts.enableRelay {
+		return errors.New("rln requires relay")
 	}
 
 	var groupManager group_manager.GroupManager
@@ -85,8 +88,7 @@ func (w *WakuNode) setupRLNRelay() error {
 
 	w.rlnRelay = rlnRelay
 
-	// Adding RLN as a default validator
-	w.opts.pubsubOpts = append(w.opts.pubsubOpts, pubsub.WithDefaultValidator(rlnRelay.Validator(w.opts.rlnSpamHandler)))
+	w.Relay().RegisterDefaultValidator(w.rlnRelay.Validator(w.opts.rlnSpamHandler))
 
 	return nil
 }

--- a/waku/v2/node/wakuoptions.go
+++ b/waku/v2/node/wakuoptions.go
@@ -96,7 +96,7 @@ type WakuNodeParameters struct {
 	enableRLN                    bool
 	rlnRelayMemIndex             *uint
 	rlnRelayDynamic              bool
-	rlnSpamHandler               func(message *pb.WakuMessage) error
+	rlnSpamHandler               func(message *pb.WakuMessage, topic string) error
 	rlnETHClientAddress          string
 	keystorePath                 string
 	keystorePassword             string

--- a/waku/v2/protocol/envelope.go
+++ b/waku/v2/protocol/envelope.go
@@ -20,12 +20,12 @@ type Envelope struct {
 // as well as generating a hash based on the bytes that compose the message
 func NewEnvelope(msg *wpb.WakuMessage, receiverTime int64, pubSubTopic string) *Envelope {
 	messageHash := msg.Hash(pubSubTopic)
-	hash := hash.SHA256([]byte(msg.ContentTopic), msg.Payload)
+	digest := hash.SHA256([]byte(msg.ContentTopic), msg.Payload)
 	return &Envelope{
 		msg:  msg,
 		hash: messageHash,
 		index: &pb.Index{
-			Digest:       hash[:],
+			Digest:       digest[:],
 			ReceiverTime: receiverTime,
 			SenderTime:   msg.Timestamp,
 			PubsubTopic:  pubSubTopic,

--- a/waku/v2/protocol/relay/waku_relay_test.go
+++ b/waku/v2/protocol/relay/waku_relay_test.go
@@ -79,10 +79,6 @@ func TestGossipsubScore(t *testing.T) {
 	relay := make([]*WakuRelay, 5)
 	for i := 0; i < 5; i++ {
 		hosts[i], relay[i] = createRelayNode(t)
-		if i == 0 {
-			// This is a hack to remove the default validator from the list of default options
-			relay[i].opts = relay[i].opts[:len(relay[i].opts)-1]
-		}
 		err := relay[i].Start(context.Background())
 		require.NoError(t, err)
 	}
@@ -119,6 +115,11 @@ func TestGossipsubScore(t *testing.T) {
 	// We obtain the go-libp2p topic directly because we normally can't publish anything other than WakuMessages
 	pubsubTopic, err := relay[0].upsertTopic(testTopic)
 	require.NoError(t, err)
+
+	// Removing validator from relayer0 to allow it to send invalid messages
+	err = relay[0].pubsub.UnregisterTopicValidator(testTopic)
+	require.NoError(t, err)
+
 	for i := 0; i < 50; i++ {
 		buf := make([]byte, 1000)
 		_, err := rand.Read(buf)

--- a/waku/v2/protocol/rln/common.go
+++ b/waku/v2/protocol/rln/common.go
@@ -26,7 +26,7 @@ const acceptableRootWindowSize = 5
 
 type RegistrationHandler = func(tx *types.Transaction)
 
-type SpamHandler = func(message *pb.WakuMessage) error
+type SpamHandler = func(msg *pb.WakuMessage, topic string) error
 
 func toRLNSignal(wakuMessage *pb.WakuMessage) []byte {
 	if wakuMessage == nil {


### PR DESCRIPTION
# Description
This PR guarantees that validators are executed in the order they're appended, that RLN validator is executed as the last validator, and that unmarshalling the WakuMessage is only done once

## Issue

Part of #655

