### PR TITLE
fix: log enr only after it has been setup

### DIFF
--- a/waku/v2/node/localnode.go
+++ b/waku/v2/node/localnode.go
@@ -281,6 +281,8 @@ func (w *WakuNode) setupENR(ctx context.Context, addrs []ma.Multiaddr) error {
 		}
 	}
 
+	w.enrChangeCh <- struct{}{}
+
 	return nil
 
 }

--- a/waku/v2/node/wakunode2.go
+++ b/waku/v2/node/wakunode2.go
@@ -310,7 +310,6 @@ func (w *WakuNode) watchMultiaddressChanges(ctx context.Context) {
 			return
 		case <-first:
 			w.log.Info("listening", logging.MultiAddrs("multiaddr", addrs...))
-			w.enrChangeCh <- struct{}{}
 		case <-w.addressChangesSub.Out():
 			newAddrs := w.ListenAddresses()
 			diff := false
@@ -327,8 +326,10 @@ func (w *WakuNode) watchMultiaddressChanges(ctx context.Context) {
 			if diff {
 				addrs = newAddrs
 				w.log.Info("listening addresses update received", logging.MultiAddrs("multiaddr", addrs...))
-				_ = w.setupENR(ctx, addrs)
-				w.enrChangeCh <- struct{}{}
+				err := w.setupENR(ctx, addrs)
+				if err != nil {
+					w.log.Warn("could not update ENR", zap.Error(err))
+				}
 			}
 		}
 	}


### PR DESCRIPTION
# Description
The node's ENR was being displayed logged it had its information setup, rendering it useless. This PR changes that so the enr is shown after setupENR is executed
