### PR TITLE
feat: allow running rln with no credentials

### DIFF
--- a/cmd/waku/flags_rln.go
+++ b/cmd/waku/flags_rln.go
@@ -6,7 +6,6 @@ package main
 import (
 	cli "github.com/urfave/cli/v2"
 	wcli "github.com/waku-org/go-waku/waku/cliutils"
-	"github.com/waku-org/go-waku/waku/v2/protocol/rln/keystore"
 )
 
 func rlnFlags() []cli.Flag {
@@ -32,12 +31,12 @@ func rlnFlags() []cli.Flag {
 		&cli.PathFlag{
 			Name:        "rln-relay-cred-path",
 			Usage:       "RLN relay membership credentials file",
-			Value:       keystore.DefaultCredentialsFilename,
+			Value:       "",
 			Destination: &options.RLNRelay.CredentialsPath,
 		},
 		&cli.StringFlag{
 			Name:        "rln-relay-cred-password",
-			Value:       keystore.DefaultCredentialsPassword,
+			Value:       "",
 			Usage:       "Password for encrypting RLN credentials",
 			Destination: &options.RLNRelay.CredentialsPassword,
 		},

--- a/cmd/waku/rlngenerate/flags.go
+++ b/cmd/waku/rlngenerate/flags.go
@@ -6,14 +6,13 @@ package rlngenerate
 import (
 	cli "github.com/urfave/cli/v2"
 	wcli "github.com/waku-org/go-waku/waku/cliutils"
-	"github.com/waku-org/go-waku/waku/v2/protocol/rln/keystore"
 )
 
 var flags = []cli.Flag{
 	&cli.PathFlag{
 		Name:        "cred-path",
 		Usage:       "RLN relay membership credentials file",
-		Value:       keystore.DefaultCredentialsFilename,
+		Value:       "./rlnKeystore.json",
 		Destination: &options.CredentialsPath,
 	},
 	&cli.StringFlag{

--- a/waku/v2/node/wakunode2.go
+++ b/waku/v2/node/wakunode2.go
@@ -273,6 +273,8 @@ func New(opts ...WakuNodeOption) (*WakuNode, error) {
 
 	w.rendezvous = rendezvous.NewRendezvous(w.opts.rendezvousDB, w.peerConnector, w.log)
 
+	w.relay = relay.NewWakuRelay(w.bcaster, w.opts.minRelayPeersToPublish, w.timesource, w.opts.prometheusReg, w.log, w.opts.pubsubOpts...)
+
 	if w.opts.enableRelay {
 		err = w.setupRLNRelay()
 		if err != nil {
@@ -280,7 +282,6 @@ func New(opts ...WakuNodeOption) (*WakuNode, error) {
 		}
 	}
 
-	w.relay = relay.NewWakuRelay(w.bcaster, w.opts.minRelayPeersToPublish, w.timesource, w.opts.prometheusReg, w.log, w.opts.pubsubOpts...)
 	w.legacyFilter = legacy_filter.NewWakuFilter(w.bcaster, w.opts.isLegacyFilterFullNode, w.timesource, w.opts.prometheusReg, w.log, w.opts.legacyFilterOpts...)
 	w.filterFullNode = filter.NewWakuFilterFullNode(w.timesource, w.opts.prometheusReg, w.log, w.opts.filterOpts...)
 	w.filterLightNode = filter.NewWakuFilterLightNode(w.bcaster, w.peermanager, w.timesource, w.opts.prometheusReg, w.log)

--- a/waku/v2/node/wakunode2_rln.go
+++ b/waku/v2/node/wakunode2_rln.go
@@ -59,9 +59,12 @@ func (w *WakuNode) setupRLNRelay() error {
 	} else {
 		w.log.Info("setting up waku-rln-relay in on-chain mode")
 
-		appKeystore, err := keystore.New(w.opts.keystorePath, dynamic.RLNAppInfo, w.log)
-		if err != nil {
-			return err
+		var appKeystore *keystore.AppKeystore
+		if w.opts.keystorePath != "" {
+			appKeystore, err = keystore.New(w.opts.keystorePath, dynamic.RLNAppInfo, w.log)
+			if err != nil {
+				return err
+			}
 		}
 
 		groupManager, err = dynamic.NewDynamicGroupManager(

--- a/waku/v2/protocol/rln/group_manager/dynamic/dynamic.go
+++ b/waku/v2/protocol/rln/group_manager/dynamic/dynamic.go
@@ -182,6 +182,10 @@ func (gm *DynamicGroupManager) Start(ctx context.Context) error {
 }
 
 func (gm *DynamicGroupManager) loadCredential(ctx context.Context) error {
+	if gm.appKeystore == nil {
+		gm.log.Warn("no credentials were loaded. Node will only validate messages, but wont be able to generate proofs and attach them to messages")
+		return nil
+	}
 	start := time.Now()
 
 	credentials, err := gm.appKeystore.GetMembershipCredentials(

--- a/waku/v2/protocol/rln/keystore/keystore.go
+++ b/waku/v2/protocol/rln/keystore/keystore.go
@@ -15,20 +15,9 @@ import (
 	"go.uber.org/zap"
 )
 
-// DefaultCredentialsFilename is the suggested default filename for the rln credentials keystore
-const DefaultCredentialsFilename = "./rlnKeystore.json"
-
-// DefaultCredentialsPassword is the suggested default password for the rln credentials store
-const DefaultCredentialsPassword = "password"
-
 // New creates a new instance of a rln credentials keystore
 func New(path string, appInfo AppInfo, logger *zap.Logger) (*AppKeystore, error) {
 	logger = logger.Named("rln-keystore")
-
-	if path == "" {
-		logger.Warn("keystore: no credentials path set, using default path", zap.String("path", DefaultCredentialsFilename))
-		path = DefaultCredentialsFilename
-	}
 
 	_, err := os.Stat(path)
 	if err != nil {


### PR DESCRIPTION
# Description
It's not necessary to have credentials to be a relayer. 

# Changes

<!-- List of detailed changes -->

- [x] Remove default keystore password and path from config flags
- [x] Instantiate relay before rlnRelay
- [x] Keystore is optional for creating a dynamic group manager

## Issue

Part of #655

