### PR TITLE
feat: force unreachability

### DIFF
--- a/cmd/waku/flags.go
+++ b/cmd/waku/flags.go
@@ -171,6 +171,14 @@ var (
 		Destination: &options.CircuitRelay,
 		EnvVars:     []string{"WAKUNODE2_CIRCUIT_RELAY"},
 	})
+	ForceUnreachable = altsrc.NewBoolFlag(&cli.BoolFlag{
+		Name:        "unreachable",
+		Usage:       "Force the node to be unreachable. WARNING: This flag is created for testing circuit relay and is not meant to be used in production",
+		Value:       false,
+		Hidden:      true,
+		Destination: &options.ForceUnreachable,
+		EnvVars:     []string{"WAKUNODE2_UNREACHABLE"},
+	})
 	ResourceScalingMemoryPercent = altsrc.NewFloat64Flag(&cli.Float64Flag{
 		Name:        "resource-scaling-memory-percentage",
 		Usage:       "Determines the percentage of total accessible memory that wil be dedicated to go-waku. A dedicated node with a lot of RAM could allocate 25% or more memory to go-waku",

--- a/cmd/waku/main.go
+++ b/cmd/waku/main.go
@@ -41,6 +41,7 @@ func main() {
 		ExtMultiaddresses,
 		ShowAddresses,
 		CircuitRelay,
+		ForceUnreachable,
 		ResourceScalingMemoryPercent,
 		ResourceScalingFDPercent,
 		LogLevel,

--- a/cmd/waku/node.go
+++ b/cmd/waku/node.go
@@ -169,6 +169,12 @@ func Execute(options NodeOptions) {
 		libp2pOpts = append(libp2pOpts, libp2p.EnableRelayService())
 	}
 
+	if options.ForceUnreachable {
+		logger.Warn("node forced to be unreachable!")
+		libp2pOpts = append(libp2pOpts, libp2p.EnableRelay(), libp2p.ForceReachabilityPrivate())
+		nodeOpts = append(nodeOpts, node.WithCircuitRelayParams(2*time.Second, 2*time.Second))
+	}
+
 	if options.UserAgent != "" {
 		libp2pOpts = append(libp2pOpts, libp2p.UserAgent(options.UserAgent))
 	}

--- a/cmd/waku/options.go
+++ b/cmd/waku/options.go
@@ -157,6 +157,7 @@ type NodeOptions struct {
 	AdvertiseAddresses           []multiaddr.Multiaddr
 	ShowAddresses                bool
 	CircuitRelay                 bool
+	ForceUnreachable             bool
 	ResourceScalingMemoryPercent float64
 	ResourceScalingFDPercent     float64
 	LogLevel                     string

--- a/waku/v2/node/wakunode2.go
+++ b/waku/v2/node/wakunode2.go
@@ -237,7 +237,8 @@ func New(opts ...WakuNodeOption) (*WakuNode, error) {
 			}()
 			return r
 		},
-		autorelay.WithMinInterval(2*time.Second),
+		autorelay.WithMinInterval(params.circuitRelayMinInterval),
+		autorelay.WithBootDelay(params.circuitRelayBootDelay),
 	))
 
 	if params.enableNTP {
@@ -754,12 +755,12 @@ func (w *WakuNode) connect(ctx context.Context, info peer.AddrInfo) error {
 		// host.Connect adds the addresses with a TempAddressTTL
 		// however, identify will filter out all non IP addresses
 		// and expire all temporary addrs. So in the meantime, let's
-		// store dns4 addresses with a connectedAddressTTL, otherwise
+		// store dns4 addresses with a RecentlyConnectedAddrTTL, otherwise
 		// it will have trouble with the status fleet circuit relay addresses
 		// See https://github.com/libp2p/go-libp2p/issues/2550
 		_, err := addr.ValueForProtocol(ma.P_DNS4)
 		if err == nil {
-			w.host.Peerstore().AddAddrs(info.ID, info.Addrs, peerstore.ConnectedAddrTTL)
+			w.host.Peerstore().AddAddrs(info.ID, info.Addrs, peerstore.RecentlyConnectedAddrTTL)
 		}
 	}
 

--- a/waku/v2/node/wakuoptions.go
+++ b/waku/v2/node/wakuoptions.go
@@ -55,6 +55,9 @@ type WakuNodeParameters struct {
 	peerstore      peerstore.Peerstore
 	prometheusReg  prometheus.Registerer
 
+	circuitRelayMinInterval time.Duration
+	circuitRelayBootDelay   time.Duration
+
 	enableNTP bool
 	ntpURLs   []string
 
@@ -119,6 +122,7 @@ type WakuNodeOption func(*WakuNodeParameters) error
 var DefaultWakuNodeOptions = []WakuNodeOption{
 	WithPrometheusRegisterer(prometheus.NewRegistry()),
 	WithMaxPeerConnections(50),
+	WithCircuitRelayParams(2*time.Second, 3*time.Minute),
 }
 
 // MultiAddresses return the list of multiaddresses configured in the node
@@ -513,6 +517,14 @@ func WithSecureWebsockets(address string, port int, certPath string, keyPath str
 			MinVersion:   tls.VersionTLS12,
 		}
 
+		return nil
+	}
+}
+
+func WithCircuitRelayParams(minInterval time.Duration, bootDelay time.Duration) WakuNodeOption {
+	return func(params *WakuNodeParameters) error {
+		params.circuitRelayBootDelay = bootDelay
+		params.circuitRelayMinInterval = minInterval
 		return nil
 	}
 }

--- a/waku/v2/peermanager/peer_manager.go
+++ b/waku/v2/peermanager/peer_manager.go
@@ -103,7 +103,7 @@ func (pm *PeerManager) peerEventLoop(ctx context.Context) {
 				err := wps.AddPubSubTopic(peerID, peerEvt.Topic)
 				if err != nil {
 					pm.logger.Error("failed to add pubSubTopic for peer",
-						logging.HostID("peerID", peerID), zap.Error(err))
+						logging.HostID("peerID", peerID), zap.String("topic", peerEvt.Topic), zap.Error(err))
 				}
 			} else if peerEvt.State == relay.PEER_LEFT {
 				err := wps.RemovePubSubTopic(peerID, peerEvt.Topic)

--- a/waku/v2/peerstore/waku_peer_store.go
+++ b/waku/v2/peerstore/waku_peer_store.go
@@ -1,6 +1,7 @@
 package peerstore
 
 import (
+	"errors"
 	"sync"
 
 	"github.com/ethereum/go-ethereum/p2p/enode"
@@ -183,7 +184,11 @@ func (ps *WakuPeerstoreImpl) SetPubSubTopics(p peer.ID, topics []string) error {
 func (ps *WakuPeerstoreImpl) PubSubTopics(p peer.ID) ([]string, error) {
 	result, err := ps.peerStore.Get(p, peerPubSubTopics)
 	if err != nil {
-		return nil, err
+		if errors.Is(err, peerstore.ErrNotFound) {
+			return nil, nil
+		} else {
+			return nil, err
+		}
 	}
 	return result.([]string), nil
 }


### PR DESCRIPTION
# Description
Adds a hidden `--force-unreachable` flag that will force the node to use circuit relay. After some seconds the node will have negotiated a circuit relay address if a circuit relay node is added as static node:
```
./build/waku --unreachable --staticnode=/dns4/node-01.do-ams3.go-waku.test.statusim.net/tcp/30303/p2p/16Uiu2HAm9vnvCQgCDrynDK1h7GJoEZVGvnuzq84RyDQ3DEdXmcX7 --wss --wss-key=/path/to/key/file --wss-cert=/path/to/cert/file
```

While testing the functionality with @danisharora099 we noticed that when using an nwaku fleet node, and having wss enabled, the node gets dropped as a peer hence for now I recommend using a node from the gowaku fleet, however the gowaku fleet is returning IP addresses in the list of multiaddresses, so a search/replace must be done to replace the /ip4 address returned by a /dns4 value

This PR also fixes an issue with adding pubsub topics to the peer store that happens when adding a peer for the first time, and changes the TTL for addresses being added to the store since addresses with a ConnectedAddrTTL still had a chance of being removed by identify