### PR TITLE
ci: use wakuorg Docker Hub organization

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,7 @@ coverage:
 
 # build a docker image for the fleet
 docker-image: DOCKER_IMAGE_TAG ?= latest
-docker-image: DOCKER_IMAGE_NAME ?= statusteam/go-waku:$(DOCKER_IMAGE_TAG)
+docker-image: DOCKER_IMAGE_NAME ?= wakuorg/go-waku:$(DOCKER_IMAGE_TAG)
 docker-image:
 	docker build --tag $(DOCKER_IMAGE_NAME) \
 		--build-arg="GIT_COMMIT=$(shell git rev-parse HEAD)" .
@@ -191,7 +191,7 @@ install-gomobile: install-xtools
 	${GOBIN} install golang.org/x/mobile/cmd/gobind@v0.0.0-20220518205345-8578da9835fd
 
 build-linux-pkg:
-	docker build --build-arg UID=${UID} --build-arg GID=${GID} -f ./scripts/linux/Dockerfile -t statusteam/gowaku-linux-pkgs:latest .
+	docker build --build-arg UID=${UID} --build-arg GID=${GID} -f ./scripts/linux/Dockerfile -t wakuorg/gowaku-linux-pkgs:latest .
 	./scripts/linux/docker-run.sh
 	ls -la ./build/*.rpm ./build/*.deb
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ nix develop
 #### Docker
 ```
 docker run -i -t -p 60000:60000 -p 9000:9000/udp \
-  statusteam/go-waku:latest \ # or, the image:tag of your choice
+  wakuorg/go-waku:latest \ # or, the image:tag of your choice
     --dns-discovery:true \
     --dns-discovery-url:enrtree://AOGECG2SPND25EEFMAJ5WF3KSGJNSGV356DSTL2YVLLZWIV6SAYBM@prod.waku.nodes.status.im \
     --discv5-discovery
@@ -47,9 +47,9 @@ docker run -i -t -p 60000:60000 -p 9000:9000/udp \
 or build and run the image with:
 
 ```
-docker build -t statusteam/go-waku:latest .
+docker build -t wakuorg/go-waku:latest .
 
-docker run statusteam/go-waku:latest --help
+docker run wakuorg/go-waku:latest --help
 ```
 
 #### Building on windows

--- a/ci/Jenkinsfile.docker
+++ b/ci/Jenkinsfile.docker
@@ -11,13 +11,18 @@ pipeline {
     )
     string(
       name: 'IMAGE_NAME',
-      defaultValue: 'statusteam/go-waku',
       description: 'Docker image name.',
+      defaultValue: params.IMAGE_NAME ?: 'wakuorg/go-waku',
     )
     string(
       name: 'IMAGE_TAG',
-      defaultValue: env.JOB_BASE_NAME == 'release' ? 'stable' : 'deploy-test',
       description: 'Docker image tag.',
+      defaultValue: env.JOB_BASE_NAME == 'release' ? 'stable' : 'deploy-test',
+    )
+    string(
+      name: 'DOCKER_CRED',
+      description: 'Name of Docker Hub credential.',
+      defaultValue: params.DOCKER_CRED ?: 'dockerhub-vacorgbot-api-token',
     )
   }
 
@@ -46,7 +51,7 @@ pipeline {
     stage('Push') {
       steps { script {
         withDockerRegistry([
-          credentialsId: "dockerhub-statusteam-auto", url: ""
+          credentialsId: params.DOCKER_CRED, url: ""
         ]) {
           image.push()
         }
@@ -56,7 +61,7 @@ pipeline {
     stage('Deploy') {
       steps { script {
         withDockerRegistry([
-          credentialsId: "dockerhub-statusteam-auto", url: ""
+          credentialsId: params.DOCKER_CRED, url: ""
         ]) {
           image.push(env.IMAGE_TAG)
         }

--- a/docs/operators/how-to/run-with-rln.md
+++ b/docs/operators/how-to/run-with-rln.md
@@ -48,7 +48,7 @@ export SEPOLIA_WS_NODE_ADDRESS=<WS RPC URL to a Sepolia Node>
 export RLN_RELAY_CONTRACT_ADDRESS="0xF471d71E9b1455bBF4b85d475afb9BB0954A29c4" # Replace this with any compatible implementation
 docker run -i -t -p 60000:60000 -p 9000:9000/udp \
   -v /absolute/path/to/your/rlnKeystore.json:/rlnKeystore.json:ro \
-  statusteam/go-waku:latest \
+  wakuorg/go-waku:latest \
   --dns-discovery=true \
   --dns-discovery-url="$WAKU_FLEET" \
   --discv5-discovery \

--- a/docs/operators/quickstart.md
+++ b/docs/operators/quickstart.md
@@ -8,7 +8,7 @@ For a more advanced configuration see our [configuration guides](./how-to/config
 
 [Build the go-waku node](./how-to/build.md)
 or download a precompiled binary from our [releases page](https://github.com/waku-org/go-waku/releases).
-<!-- Docker images are published to [statusteam/go-waku](https://hub.docker.com/r/statusteam/go-waku/tags) on DockerHub. -->
+<!-- Docker images are published to [wakuorg/go-waku](https://hub.docker.com/r/wakuorg/go-waku/tags) on DockerHub. -->
 <!-- TODO: more advanced explanation on finding and using docker images -->
 
 ## 2. Run

--- a/scripts/linux/README.md
+++ b/scripts/linux/README.md
@@ -7,5 +7,5 @@ This script is used to build .deb and .rpm packages
 ## Linux
 
 ```
-docker build -t statusteam/gowaku-linux-pkgs:latest .
+docker build -t wakuorg/gowaku-linux-pkgs:latest .
 ```

--- a/scripts/linux/docker-run.sh
+++ b/scripts/linux/docker-run.sh
@@ -7,5 +7,5 @@ docker run -it --rm \
   -u  jenkins:$(id -g) \
   -v "${PWD}:/go-waku" \
   -w /go-waku \
-  statusteam/gowaku-linux-pkgs:latest \
+  wakuorg/gowaku-linux-pkgs:latest \
   /go-waku/scripts/linux/build-pkgs.sh


### PR DESCRIPTION
We've been using `statusteam` Docker Hub org for a while now which was never intended for public use, and we should be using `wakuorg` instead.

I've also updated references to `statusteam` in documentation and scripts.