### PR TITLE
ci: drop pushing commit tags for Docker

### DIFF
--- a/ci/Jenkinsfile.docker
+++ b/ci/Jenkinsfile.docker
@@ -37,12 +37,8 @@ pipeline {
   stages {
     stage('Build') {
       steps { script {
-        def imageTag = GIT_COMMIT.take(8)
-        if (env.JOB_BASE_NAME == 'release') {
-          imageTag = params.GIT_REF
-        }
         image = docker.build(
-          "${params.IMAGE_NAME}:${imageTag}",
+          "${params.IMAGE_NAME}:${params.IMAGE_TAG}",
           "--build-arg='GIT_COMMIT=${GIT_COMMIT.take(8)}' ."
         )
       } }
@@ -51,19 +47,13 @@ pipeline {
     stage('Push') {
       steps { script {
         withDockerRegistry([
-          credentialsId: params.DOCKER_CRED, url: ""
+          credentialsId: params.DOCKER_CRED, url: ''
         ]) {
           image.push()
-        }
-      } }
-    }
-
-    stage('Deploy') {
-      steps { script {
-        withDockerRegistry([
-          credentialsId: params.DOCKER_CRED, url: ""
-        ]) {
-          image.push(env.IMAGE_TAG)
+          /* If Git ref is a tag push it as Docker tag too. */
+          if (env.GIT_BRANCH ==~ /v\d+\.\d+\.\d+.*/) {
+            image.push(params.GIT_REF)
+          }
         }
       } }
     }


### PR DESCRIPTION
Nobody is using them and we are just cluttering up the repo.