### PR TITLE
fix: panic when removing pubsub topic

### DIFF
--- a/waku/v2/peerstore/waku_peer_store.go
+++ b/waku/v2/peerstore/waku_peer_store.go
@@ -165,6 +165,11 @@ func (ps *WakuPeerstoreImpl) RemovePubSubTopic(p peer.ID, topic string) error {
 	if err != nil {
 		return err
 	}
+
+	if len(existingTopics) == 0 {
+		return nil
+	}
+
 	for i := range existingTopics {
 		existingTopics = append(existingTopics[:i], existingTopics[i+1:]...)
 	}


### PR DESCRIPTION
# Description
Fixes this error:
```
panic: runtime error: slice bounds out of range [2:1]

goroutine 291 [running]:
github.com/waku-org/go-waku/waku/v2/peerstore.(*WakuPeerstoreImpl).RemovePubSubTopic(0xc000018b40, {0xc00088a360, 0x27}, {0x0?, 0x11?})
	/home/richard/waku-org/go-waku/waku/v2/peerstore/waku_peer_store.go:169 +0x1dc
github.com/waku-org/go-waku/waku/v2/peermanager.(*PeerManager).peerEventLoop(0xc0003f0c60, {0x26de4d0, 0xc00046e8c0})
	/home/richard/waku-org/go-waku/waku/v2/peermanager/peer_manager.go:109 +0x25c
created by github.com/waku-org/go-waku/waku/v2/peermanager.(*PeerManager).Start
```
