### PR TITLE
Fix /health REST API panic

### DIFF
--- a/cmd/waku/server/rest/debug_api.yaml
+++ b/cmd/waku/server/rest/debug_api.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.3
 info:
-  title: Waku V2 node REST API 
+  title: Waku V2 node Debug REST API 
   version: 1.0.0
   contact:
     name: VAC Team

--- a/cmd/waku/server/rest/health.go
+++ b/cmd/waku/server/rest/health.go
@@ -30,19 +30,23 @@ func NewHealthService(node *node.WakuNode, m *chi.Mux) *HealthService {
 type HealthResponse string
 
 func (d *HealthService) getHealth(w http.ResponseWriter, r *http.Request) {
-	isReady, err := d.node.RLNRelay().IsReady(r.Context())
-	if err != nil {
-		if errors.Is(err, context.DeadlineExceeded) {
-			writeResponse(w, HealthResponse("Health check timed out"), http.StatusInternalServerError)
-		} else {
-			writeResponse(w, HealthResponse(err.Error()), http.StatusInternalServerError)
+	if d.node.RLNRelay() != nil {
+		isReady, err := d.node.RLNRelay().IsReady(r.Context())
+		if err != nil {
+			if errors.Is(err, context.DeadlineExceeded) {
+				writeResponse(w, HealthResponse("Health check timed out"), http.StatusInternalServerError)
+			} else {
+				writeResponse(w, HealthResponse(err.Error()), http.StatusInternalServerError)
+			}
+			return
 		}
-		return
-	}
 
-	if isReady {
-		writeResponse(w, HealthResponse("Node is healthy"), http.StatusOK)
+		if isReady {
+			writeResponse(w, HealthResponse("Node is healthy"), http.StatusOK)
+		} else {
+			writeResponse(w, HealthResponse("Node is not ready"), http.StatusInternalServerError)
+		}
 	} else {
-		writeResponse(w, HealthResponse("Node is not ready"), http.StatusInternalServerError)
+		writeResponse(w, HealthResponse("Non RLN healthcheck is not implemented"), http.StatusNotImplemented)
 	}
 }

--- a/cmd/waku/server/rest/health_api.yaml
+++ b/cmd/waku/server/rest/health_api.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.3
 info:
-  title: Waku V2 node REST API
+  title: Waku V2 node Health REST API
   version: 1.0.0
   contact:
     name: VAC Team

--- a/cmd/waku/server/rest/relay_api.yaml
+++ b/cmd/waku/server/rest/relay_api.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.3
 info:
-  title: Waku V2 node REST API 
+  title: Waku V2 node Relay REST API 
   version: 1.0.0
   contact:
     name: VAC Team

--- a/cmd/waku/server/rest/store_api.yaml
+++ b/cmd/waku/server/rest/store_api.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.3
 info:
-  title: Waku V2 node REST API
+  title: Waku V2 node Store REST API
   version: 1.0.0
   contact:
     name: VAC Team


### PR DESCRIPTION
# Description
Noticed following panic when triggering health API without rln initialization. 

```
2023/09/21 16:34:48 "GET http://127.0.0.1:8645/health HTTP/1.1" from 127.0.0.1:61835 - 000 0B in 56.458µs
2023/09/21 16:34:48 http: panic serving 127.0.0.1:61835: runtime error: invalid memory address or nil pointer dereference
goroutine 761 [running]:
net/http.(*conn).serve.func1()
	/usr/local/go/src/net/http/server.go:1854 +0xb0
panic({0x106fe0a60, 0x107c8cf30})
	/usr/local/go/src/runtime/panic.go:890 +0x258
github.com/waku-org/go-waku/cmd/waku/server/rest.(*HealthService).getHealth(0x14001289890?, {0x1300b05e0, 0x14001114cc0}, 0x7?)
	/Users/prem/Code/go-waku/cmd/waku/server/rest/health.go:33 +0x50
net/http.HandlerFunc.ServeHTTP(0x106fd1700?, {0x1300b05e0?, 0x14001114cc0?}, 0x1400165d33c?)
	/usr/local/go/src/net/http/server.go:2122 +0x38
github.com/go-chi/chi/v5.(*Mux).routeHTTP(0x1400055f8c0, {0x1300b05e0, 0x14001114cc0}, 0x140010e7600)
	/Users/prem/go/pkg/mod/github.com/go-chi/chi/v5@v5.0.0/mux.go:436 +0x218
net/http.HandlerFunc.ServeHTTP(0x140004718c8?, {0x1300b05e0?, 0x14001114cc0?}, 0x7?)
	/usr/local/go/src/net/http/server.go:2122 +0x38
github.com/go-chi/chi/v5/middleware.NoCache.func1({0x1300b05e0, 0x14001114cc0}, 0x140010e7600)
	/Users/prem/go/pkg/mod/github.com/go-chi/chi/v5@v5.0.0/middleware/nocache.go:54 +0x228
net/http.HandlerFunc.ServeHTTP(0x140010e7500?, {0x1300b05e0?, 0x14001114cc0?}, 0x10447cc18?)
	/usr/local/go/src/net/http/server.go:2122 +0x38
github.com/go-chi/chi/v5/middleware.RequestLogger.func1.1({0x10721a5a0, 0x14000a3e620}, 0x140010e7500)
	/Users/prem/go/pkg/mod/github.com/go-chi/chi/v5@v5.0.0/middleware/logger.go:57 +0x120
net/http.HandlerFunc.ServeHTTP(0x10721be90?, {0x10721a5a0?, 0x14000a3e620?}, 0x107c8c440?)
	/usr/local/go/src/net/http/server.go:2122 +0x38
github.com/go-chi/chi/v5.(*Mux).ServeHTTP(0x1400055f8c0, {0x10721a5a0, 0x14000a3e620}, 0x140010e7400)
	/Users/prem/go/pkg/mod/github.com/go-chi/chi/v5@v5.0.0/mux.go:87 +0x2e4
net/http.serverHandler.ServeHTTP({0x14000920090?}, {0x10721a5a0, 0x14000a3e620}, 0x140010e7400)
	/usr/local/go/src/net/http/server.go:2936 +0x2d8
net/http.(*conn).serve(0x14000984870, {0x10721bf38, 0x14000690150})
	/usr/local/go/src/net/http/server.go:1995 +0x560
created by net/http.(*Server).Serve
	/usr/local/go/src/net/http/server.go:3089 +0x520
```

# Changes

<!-- List of detailed changes -->

- [ ] Fix panic in health REST API endpoint if rln is not initialized/compiled
- [ ] Update REST API yml files title. cc @NagyZoltanPeter , this has to be done across all files.

# Tests

<!-- List down any tests that were executed specifically for this pull-request -->


