### PR TITLE
fix: panic during removePubSubTopic

### DIFF
--- a/waku/v2/peerstore/waku_peer_store.go
+++ b/waku/v2/peerstore/waku_peer_store.go
@@ -171,8 +171,12 @@ func (ps *WakuPeerstoreImpl) RemovePubSubTopic(p peer.ID, topic string) error {
 	}
 
 	for i := range existingTopics {
-		existingTopics = append(existingTopics[:i], existingTopics[i+1:]...)
+		if existingTopics[i] == topic {
+			existingTopics = append(existingTopics[:i], existingTopics[i+1:]...)
+			break
+		}
 	}
+
 	err = ps.SetPubSubTopics(p, existingTopics)
 	if err != nil {
 		return err


### PR DESCRIPTION
# Description
Fix panic during RemovePubSubTopics in specific case where there are only 2 elements in slice and last one is being removed.

