### PR TITLE
Fix deleting pubsub topics; only allow adding unique topics

### DIFF
--- a/waku/v2/peerstore/waku_peer_store.go
+++ b/waku/v2/peerstore/waku_peer_store.go
@@ -155,6 +155,11 @@ func (ps *WakuPeerstoreImpl) AddPubSubTopic(p peer.ID, topic string) error {
 	if err != nil {
 		return err
 	}
+	for _, t := range existingTopics {
+		if t == topic {
+			return nil
+		}
+	}
 	existingTopics = append(existingTopics, topic)
 	return ps.peerStore.Put(p, peerPubSubTopics, existingTopics)
 }


### PR DESCRIPTION
Fix issue introduced in https://github.com/waku-org/go-waku/pull/759

Context: https://github.com/waku-org/go-waku/pull/762#issuecomment-1731212779

**EDIT**: i see that it was independently fixed in https://github.com/waku-org/go-waku/pull/765

@chaitanyaprem can you please review this and decide if the uniqueness check is still worth it?