### PR TITLE
chore: add config to limit peerstore capacity

### DIFF
--- a/cmd/waku/flags.go
+++ b/cmd/waku/flags.go
@@ -32,6 +32,12 @@ var (
 		Destination: &options.MaxPeerConnections,
 		EnvVars:     []string{"WAKUNODE2_MAX_CONNECTIONS"},
 	})
+	PeerStoreCapacity = altsrc.NewIntFlag(&cli.IntFlag{
+		Name:        "peer-store-capacity",
+		Usage:       "Maximum stored peers in the peerstore.",
+		Destination: &options.PeerStoreCapacity,
+		EnvVars:     []string{"WAKUNODE2_PEERSTORE_CAPACITY"},
+	})
 	WebsocketSupport = altsrc.NewBoolFlag(&cli.BoolFlag{
 		Name:        "websocket-support",
 		Aliases:     []string{"ws"},

--- a/cmd/waku/main.go
+++ b/cmd/waku/main.go
@@ -22,6 +22,7 @@ func main() {
 		TcpPort,
 		Address,
 		MaxPeerConnections,
+		PeerStoreCapacity,
 		WebsocketSupport,
 		WebsocketPort,
 		WebsocketSecurePort,

--- a/cmd/waku/node.go
+++ b/cmd/waku/node.go
@@ -129,6 +129,7 @@ func Execute(options NodeOptions) {
 		node.WithKeepAlive(options.KeepAlive),
 		node.WithMaxPeerConnections(options.MaxPeerConnections),
 		node.WithPrometheusRegisterer(prometheus.DefaultRegisterer),
+		node.WithPeerStoreCapacity(options.PeerStoreCapacity),
 	}
 	if len(options.AdvertiseAddresses) != 0 {
 		nodeOpts = append(nodeOpts, node.WithAdvertiseAddresses(options.AdvertiseAddresses...))

--- a/cmd/waku/options.go
+++ b/cmd/waku/options.go
@@ -169,6 +169,7 @@ type NodeOptions struct {
 	UserAgent                    string
 	PProf                        bool
 	MaxPeerConnections           int
+	PeerStoreCapacity            int
 
 	PeerExchange PeerExchangeOptions
 	Websocket    WSOptions

--- a/waku/v2/node/wakunode2.go
+++ b/waku/v2/node/wakunode2.go
@@ -253,7 +253,7 @@ func New(opts ...WakuNodeOption) (*WakuNode, error) {
 	}
 
 	//Initialize peer manager.
-	w.peermanager = peermanager.NewPeerManager(w.opts.maxPeerConnections, w.log)
+	w.peermanager = peermanager.NewPeerManager(w.opts.maxPeerConnections, w.opts.peerStoreCapacity, w.log)
 
 	w.peerConnector, err = peermanager.NewPeerConnectionStrategy(w.peermanager, discoveryConnectTimeout, w.log)
 	if err != nil {

--- a/waku/v2/node/wakuoptions.go
+++ b/waku/v2/node/wakuoptions.go
@@ -88,6 +88,7 @@ type WakuNodeParameters struct {
 	rendezvousDB          *rendezvous.DB
 
 	maxPeerConnections int
+	peerStoreCapacity  int
 
 	enableDiscV5     bool
 	udpPort          uint
@@ -352,6 +353,13 @@ func WithWakuRelayAndMinPeers(minRelayPeersToPublish int, opts ...pubsub.Option)
 func WithMaxPeerConnections(maxPeers int) WakuNodeOption {
 	return func(params *WakuNodeParameters) error {
 		params.maxPeerConnections = maxPeers
+		return nil
+	}
+}
+
+func WithPeerStoreCapacity(capacity int) WakuNodeOption {
+	return func(params *WakuNodeParameters) error {
+		params.peerStoreCapacity = capacity
 		return nil
 	}
 }

--- a/waku/v2/peermanager/peer_manager.go
+++ b/waku/v2/peermanager/peer_manager.go
@@ -69,7 +69,7 @@ func NewPeerManager(maxConnections int, maxPeers int, logger *zap.Logger) *PeerM
 	inRelayPeersTarget, outRelayPeersTarget := inAndOutRelayPeers(maxRelayPeers)
 
 	if maxPeers == 0 || maxConnections > maxPeers {
-		maxPeers = 5 * maxConnections
+		maxPeers = maxConnsToPeerRatio * maxConnections
 	}
 
 	pm := &PeerManager{

--- a/waku/v2/peermanager/peer_manager.go
+++ b/waku/v2/peermanager/peer_manager.go
@@ -45,6 +45,7 @@ type PeerManager struct {
 
 const peerConnectivityLoopSecs = 15
 const relayOptimalPeersPerShard = 6
+const maxConnsToPeerRatio = 5
 
 // 80% relay peers 20% service peers
 func relayAndServicePeers(maxConnections int) (int, int) {

--- a/waku/v2/peermanager/peer_manager.go
+++ b/waku/v2/peermanager/peer_manager.go
@@ -262,7 +262,7 @@ func (pm *PeerManager) pruneInRelayConns(inRelayPeers peer.IDSlice) {
 // TODO: It maybe good to set in service-slots based on services supported in the ENR
 func (pm *PeerManager) AddDiscoveredPeer(p PeerData, connectNow bool) {
 	//Doing this check again inside addPeer, in order to avoid additional complexity of rollingBack other changes.
-	if pm.maxPeers < pm.host.Peerstore().Peers().Len() {
+	if pm.maxPeers <= pm.host.Peerstore().Peers().Len() {
 		return
 	}
 	//Check if the peer is already present, if so skip adding
@@ -308,7 +308,7 @@ func (pm *PeerManager) AddDiscoveredPeer(p PeerData, connectNow bool) {
 // addPeer adds peer to only the peerStore.
 // It also sets additional metadata such as origin, ENR and supported protocols
 func (pm *PeerManager) addPeer(ID peer.ID, addrs []ma.Multiaddr, origin wps.Origin, pubSubTopics []string, protocols ...protocol.ID) error {
-	if pm.maxPeers < pm.host.Peerstore().Peers().Len() {
+	if pm.maxPeers <= pm.host.Peerstore().Peers().Len() {
 		return errors.New("peer store capacity reached")
 	}
 	pm.logger.Info("adding peer to peerstore", logging.HostID("peer", ID))

--- a/waku/v2/peermanager/peer_manager_test.go
+++ b/waku/v2/peermanager/peer_manager_test.go
@@ -31,7 +31,7 @@ func initTest(t *testing.T) (context.Context, *PeerManager, func()) {
 	defer h1.Close()
 
 	// host 1 is used by peer manager
-	pm := NewPeerManager(10, utils.Logger())
+	pm := NewPeerManager(10, 20, utils.Logger())
 	pm.SetHost(h1)
 
 	return ctx, pm, func() {


### PR DESCRIPTION
# Description

go-libp2p doesn't provide an option to limit peer-store capacity which may cause it to grow unbounded.
This PR includes a config flag which is already there in nwaku to set peerStore capacity. If not set, set it to 5*maxConnections flag.

Ref https://github.com/waku-org/nwaku/pull/1525 

# Changes

- [ ] New config flag for peer-store-capacity
- [ ] Fail adding peers in case this capacity is breached.

# Tests

Ran all unit tests.
Ran service-node with and without setting peer-store-capacity flag to confirm values are set appropriately.

Did not add any new unit tests as changes seem trivial.
