### PR TITLE
update wakuv2 fleet DNS discovery enrtree

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ nix develop
 docker run -i -t -p 60000:60000 -p 9000:9000/udp \
   wakuorg/go-waku:latest \ # or, the image:tag of your choice
     --dns-discovery:true \
-    --dns-discovery-url:enrtree://AOGECG2SPND25EEFMAJ5WF3KSGJNSGV356DSTL2YVLLZWIV6SAYBM@prod.waku.nodes.status.im \
+    --dns-discovery-url:enrtree://ANEDLO25QVUGJOUTQFRYKWX6P4Z4GKVESBMHML7DZ6YK4LGS5FC5O@prod.wakuv2.nodes.status.im \
     --discv5-discovery
 ```
 

--- a/docs/api/dnsdisc.md
+++ b/docs/api/dnsdisc.md
@@ -30,7 +30,7 @@ import (
 )
 
 func main() {
-	discoveryURL := "enrtree://AOGECG2SPND25EEFMAJ5WF3KSGJNSGV356DSTL2YVLLZWIV6SAYBM@test.waku.nodes.status.im"
+	discoveryURL := "enrtree://AO47IDOLBKH72HIZZOXQP6NMRESAN7CHYWIBNXDXWRJRZWLODKII6@test.wakuv2.nodes.status.im"
 	nodes, err := dnsdisc.RetrieveNodes(context.Background(), discoveryURL)
 	if err != nil {
 		panic(err)

--- a/docs/operators/how-to/configure-dns-disc.md
+++ b/docs/operators/how-to/configure-dns-disc.md
@@ -24,7 +24,7 @@ A node will attempt connection to all discovered nodes.
 
 This can be used, for example, to connect to one of the existing fleets.
 Current URLs for the published fleet lists:
-- production fleet: `enrtree://AOGECG2SPND25EEFMAJ5WF3KSGJNSGV356DSTL2YVLLZWIV6SAYBM@prod.waku.nodes.status.im`
-- test fleet: `enrtree://AOGECG2SPND25EEFMAJ5WF3KSGJNSGV356DSTL2YVLLZWIV6SAYBM@test.waku.nodes.status.im`
+- production fleet: `enrtree://ANEDLO25QVUGJOUTQFRYKWX6P4Z4GKVESBMHML7DZ6YK4LGS5FC5O@prod.wakuv2.nodes.status.im`
+- test fleet: `enrtree://AO47IDOLBKH72HIZZOXQP6NMRESAN7CHYWIBNXDXWRJRZWLODKII6@test.wakuv2.nodes.status.im`
 
 See the [separate tutorial](../../tutorial/dns-disc.md) for a complete guide to DNS discovery.

--- a/docs/operators/how-to/run.md
+++ b/docs/operators/how-to/run.md
@@ -138,7 +138,7 @@ Discovery v5 will attempt to extract the ENRs of the discovered nodes as bootstr
 ```sh
 ./build/waku \
   --dns-discovery=true \
-  --dns-discovery-url=enrtree://ANTL4SLG2COUILKAPE7EF2BYNL2SHSHVCHLRD5J7ZJLN5R3PRJD2Y@prod.waku.nodes.status.im \
+  --dns-discovery-url=enrtree://ANEDLO25QVUGJOUTQFRYKWX6P4Z4GKVESBMHML7DZ6YK4LGS5FC5O@prod.wakuv2.nodes.status.im \
   --discv5-discovery=true
 ```
 
@@ -150,7 +150,7 @@ Discovery v5 will attempt to extract the ENRs of the discovered nodes as bootstr
 ```sh
 ./build/waku \
   --dns-discovery=true \
-  --dns-discovery-url=enrtree://AOGECG2SPND25EEFMAJ5WF3KSGJNSGV356DSTL2YVLLZWIV6SAYBM@test.waku.nodes.status.im \
+  --dns-discovery-url=enrtree://AO47IDOLBKH72HIZZOXQP6NMRESAN7CHYWIBNXDXWRJRZWLODKII6@test.wakuv2.nodes.status.im \
   --discv5-discovery=true
 ```
 
@@ -169,7 +169,7 @@ appears below.
   --db-path=/mnt/go-waku/data/db1/ \
   --store-capacity=150000 \
   --dns-discovery=true \
-  --dns-discovery-url=enrtree://AOGECG2SPND25EEFMAJ5WF3KSGJNSGV356DSTL2YVLLZWIV6SAYBM@test.waku.nodes.status.im \
+  --dns-discovery-url=enrtree://AO47IDOLBKH72HIZZOXQP6NMRESAN7CHYWIBNXDXWRJRZWLODKII6@test.wakuv2.nodes.status.im \
   --discv5-discovery=true
 ```
 

--- a/examples/c-bindings/main.c
+++ b/examples/c-bindings/main.c
@@ -106,7 +106,7 @@ int main(int argc, char *argv[])
   WAKU_CALL(waku_connect("/dns4/node-01.gc-us-central1-a.wakuv2.test.statusim.net/tcp/30303/p2p/16Uiu2HAmJb2e28qLXxT5kZxVUUoJt72EMzNGXB47Rxx5hw3q4YjS", 0, handle_error)); // Connect to a node
 
   // To use dns discovery, and retrieve nodes from a enrtree url
- WAKU_CALL( waku_dns_discovery("enrtree://AOGECG2SPND25EEFMAJ5WF3KSGJNSGV356DSTL2YVLLZWIV6SAYBM@test.waku.nodes.status.im", "", 0, handle_ok, handle_error)); // Discover Nodes
+ WAKU_CALL( waku_dns_discovery("enrtree://AO47IDOLBKH72HIZZOXQP6NMRESAN7CHYWIBNXDXWRJRZWLODKII6@test.wakuv2.nodes.status.im", "", 0, handle_ok, handle_error)); // Discover Nodes
   printf("Discovered nodes: %s\n", result);
   
   WAKU_CALL(waku_default_pubsub_topic(handle_ok));

--- a/examples/chat2/chat.go
+++ b/examples/chat2/chat.go
@@ -494,10 +494,10 @@ func (c *Chat) discoverNodes(connectionWg *sync.WaitGroup) {
 	var dnsDiscoveryUrl string
 	if options.Fleet != fleetNone {
 		if options.Fleet == fleetTest {
-			dnsDiscoveryUrl = "enrtree://AOGECG2SPND25EEFMAJ5WF3KSGJNSGV356DSTL2YVLLZWIV6SAYBM@test.waku.nodes.status.im"
+			dnsDiscoveryUrl = "enrtree://AO47IDOLBKH72HIZZOXQP6NMRESAN7CHYWIBNXDXWRJRZWLODKII6@test.wakuv2.nodes.status.im"
 		} else {
 			// Connect to prod by default
-			dnsDiscoveryUrl = "enrtree://AOGECG2SPND25EEFMAJ5WF3KSGJNSGV356DSTL2YVLLZWIV6SAYBM@prod.waku.nodes.status.im"
+			dnsDiscoveryUrl = "enrtree://ANEDLO25QVUGJOUTQFRYKWX6P4Z4GKVESBMHML7DZ6YK4LGS5FC5O@prod.wakuv2.nodes.status.im"
 		}
 	}
 

--- a/examples/noise/main.go
+++ b/examples/noise/main.go
@@ -129,7 +129,7 @@ func main() {
 func discoverFleetNodes(wakuNode *node.WakuNode) error {
 	log.Info("Connecting to test fleet...")
 
-	dnsDiscoveryUrl := "enrtree://AOGECG2SPND25EEFMAJ5WF3KSGJNSGV356DSTL2YVLLZWIV6SAYBM@test.waku.nodes.status.im"
+	dnsDiscoveryUrl := "enrtree://AO47IDOLBKH72HIZZOXQP6NMRESAN7CHYWIBNXDXWRJRZWLODKII6@test.wakuv2.nodes.status.im"
 	nodes, err := dnsdisc.RetrieveNodes(context.Background(), dnsDiscoveryUrl)
 	if err != nil {
 		return err

--- a/waku/v2/dnsdisc/enr_test.go
+++ b/waku/v2/dnsdisc/enr_test.go
@@ -10,7 +10,7 @@ import (
 // TestRetrieveNodes uses a live connection, so it could be
 // flaky, it should though pay for itself and should be fairly stable
 func TestRetrieveNodes(t *testing.T) {
-	url := "enrtree://AOGECG2SPND25EEFMAJ5WF3KSGJNSGV356DSTL2YVLLZWIV6SAYBM@test.waku.nodes.status.im"
+	url := "enrtree://AO47IDOLBKH72HIZZOXQP6NMRESAN7CHYWIBNXDXWRJRZWLODKII6@test.wakuv2.nodes.status.im"
 
 	nodes, err := RetrieveNodes(context.Background(), url)
 	require.NoError(t, err)

--- a/waku/v2/node/wakunode2_test.go
+++ b/waku/v2/node/wakunode2_test.go
@@ -71,7 +71,7 @@ func TestUpAndDown(t *testing.T) {
 	key1, _ := tests.RandomHex(32)
 	prvKey1, _ := crypto.HexToECDSA(key1)
 
-	nodes, err := dnsdisc.RetrieveNodes(context.Background(), "enrtree://AOGECG2SPND25EEFMAJ5WF3KSGJNSGV356DSTL2YVLLZWIV6SAYBM@prod.waku.nodes.status.im")
+	nodes, err := dnsdisc.RetrieveNodes(context.Background(), "enrtree://ANEDLO25QVUGJOUTQFRYKWX6P4Z4GKVESBMHML7DZ6YK4LGS5FC5O@prod.wakuv2.nodes.status.im")
 	require.NoError(t, err)
 
 	var bootnodes []*enode.Node


### PR DESCRIPTION
Enrtrees were regenerated. Need to update the old one.
DNS discoverty should continue to work.