### PR TITLE
fix(filter2): add requestID to pings and remove unneeded log

### DIFF
--- a/waku/v2/protocol/filter/client.go
+++ b/waku/v2/protocol/filter/client.go
@@ -362,7 +362,7 @@ func (wf *WakuFilterLightNode) Ping(ctx context.Context, peerID peer.ID) error {
 
 	return wf.request(
 		ctx,
-		&FilterSubscribeParameters{selectedPeer: peerID},
+		&FilterSubscribeParameters{selectedPeer: peerID, requestID: protocol.GenerateRequestID()},
 		pb.FilterSubscribeRequest_SUBSCRIBER_PING,
 		ContentFilter{})
 }

--- a/waku/v2/utils/peer.go
+++ b/waku/v2/utils/peer.go
@@ -12,7 +12,6 @@ import (
 	"github.com/libp2p/go-libp2p/core/protocol"
 	"github.com/libp2p/go-libp2p/p2p/protocol/ping"
 	"github.com/multiformats/go-multiaddr"
-	"github.com/waku-org/go-waku/logging"
 	"go.uber.org/zap"
 )
 
@@ -62,7 +61,6 @@ func SelectRandomPeer(peers peer.IDSlice, log *zap.Logger) (peer.ID, error) {
 	if len(peers) >= 1 {
 		peerID := peers[rand.Intn(len(peers))]
 		// TODO: proper heuristic here that compares peer scores and selects "best" one. For now a random peer for the given protocol is returned
-		log.Info("Got random peer from peerstore", logging.HostID("peer", peerID))
 		return peerID, nil // nolint: gosec
 	}
 


### PR DESCRIPTION
Fixes this errors that appears on the fleet while doing a ping:
```
    "(kind: MissingRequiredField, field: "request_id")"
    Failed to decode filter subscribe request
```