### PR TITLE
chore: revert change in c-bindings to not use callbacks

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
-[submodule "waku/v2/protocol/rln/contracts/waku-rln-contract"]
-	path = waku/v2/protocol/rln/contracts/waku-rln-contract
+[submodule "libs/waku-rln-contract"]
+	path = libs/waku-rln-contract
 	url = https://github.com/waku-org/waku-rln-contract.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "waku/v2/protocol/rln/contracts/waku-rln-contract"]
 	path = waku/v2/protocol/rln/contracts/waku-rln-contract
-	url = git@github.com:waku-org/waku-rln-contract.git
+	url = https://github.com/waku-org/waku-rln-contract.git

--- a/Makefile
+++ b/Makefile
@@ -137,11 +137,6 @@ static-library:
 		-o ./build/lib/libgowaku.a \
 		./library/c/
 	@echo "Static library built:"
-ifeq ($(detected_OS),Darwin)
-	sed -i '' -e "s/#include <cgo_utils.h>//gi" ./build/lib/libgowaku.h
-else
-	sed -i "s/#include <cgo_utils.h>//gi" ./build/lib/libgowaku.h
-endif
 	@ls -la ./build/lib/libgowaku.*
 
 dynamic-library:
@@ -152,11 +147,6 @@ dynamic-library:
 		-tags="${BUILD_TAGS} gowaku_no_rln" \
 		-o ./build/lib/libgowaku.$(GOBIN_SHARED_LIB_EXT) \
 		./library/c/
-ifeq ($(detected_OS),Darwin)
-	sed -i '' -e "s/#include <cgo_utils.h>//gi" ./build/lib/libgowaku.h
-else
-	sed -i "s/#include <cgo_utils.h>//gi" ./build/lib/libgowaku.h
-endif
 ifeq ($(detected_OS),Linux)
 	cd ./build/lib && \
 	mv ./libgowaku.$(GOBIN_SHARED_LIB_EXT) ./libgowaku.$(GOBIN_SHARED_LIB_EXT).0 && \

--- a/examples/c-bindings/main.c
+++ b/examples/c-bindings/main.c
@@ -8,7 +8,6 @@
 
 #include "libgowaku.h"
 #include "nxjson.c"
-#include "base64.h"
 #include "main.h"
 
 char *alicePrivKey = "0x4f012057e1a1458ce34189cb27daedbbe434f3df0825c1949475dec786e2c64e";
@@ -17,24 +16,7 @@ char *alicePubKey = "0x0440f05847c4c7166f57ae8ecaaf72d31bddcbca345e26713ca9e26c9
 char *bobPrivKey = "0xb91d6b2df8fb6ef8b53b51b2b30a408c49d5e2b530502d58ac8f94e5c5de1453";
 char *bobPubKey = "0x045eef61a98ba1cf44a2736fac91183ea2bd86e67de20fe4bff467a71249a8a0c05f795dd7f28ced7c15eaa69c89d4212cc4f526ca5e9a62e88008f506d850cccd";
 
-
-char* result = NULL;
-char* contentTopic;
-
-void handle_ok(const char* msg, size_t len) {
-    if (result != NULL) {
-        free(result);
-    }
-    result = malloc(len * sizeof(char) + 1);
-    strcpy(result, msg);
-}
-
-void handle_error(const char* msg, size_t len) {
-    printf("Error: %s\n", msg);
-    exit(1);
-}
-
-void callBack(const char* signal, size_t len_0)
+void callBack(char *signal)
 {
   // This callback will be executed each time a new message is received
 
@@ -54,34 +36,22 @@ void callBack(const char* signal, size_t len_0)
       }
     }*/
 
-  const nx_json *json = nx_json_parse((char*) signal, 0);
+  const nx_json *json = nx_json_parse(signal, 0);
   const char *type = nx_json_get(json, "type")->text_value;
 
   if (strcmp(type, "message") == 0)
   {
-    const nx_json *wakuMsgJson = nx_json_get(nx_json_get(json, "event"), "wakuMessage");
-    const char *contentTopic = nx_json_get(wakuMsgJson, "contentTopic")->text_value;
+    char* msg = utils_extract_wakumessage_from_signal(json);
+    char *decodedMsg =  waku_decode_asymmetric(msg, bobPrivKey);
+    free(msg);
 
-    if (strcmp(contentTopic, contentTopic) == 0)
-    {
-      char* msg = utils_extract_wakumessage_from_signal(wakuMsgJson);
-      WAKU_CALL(waku_decode_asymmetric(msg, bobPrivKey, handle_ok, handle_error));
-
-      char *decodedMsg = strdup(result);
-
-      const nx_json *dataJson = nx_json_parse(decodedMsg, 0);
-
-      const char *pubkey = nx_json_get(dataJson, "pubkey")->text_value;
-      const char *base64data = nx_json_get(dataJson, "data")->text_value;
-          
-      size_t data_len = b64_decoded_size(base64data);
-      char *data = malloc(data_len);
-    
-      b64_decode(base64data,  (unsigned char *)data, data_len) ;
-
-      printf(">>> Received \"%s\" from %s\n", data, pubkey);
-      fflush(stdout);
+    if(isError(decodedMsg)) {
+      free(decodedMsg);
+      return;
     }
+
+    printf(">>> Received msg from");
+    fflush(stdout);
   }
 
   nx_json_free(json);
@@ -89,39 +59,50 @@ void callBack(const char* signal, size_t len_0)
 
 int main(int argc, char *argv[])
 {
+  char *response;
   waku_set_event_callback(callBack);
 
   char *configJSON = "{\"host\": \"0.0.0.0\", \"port\": 60000, \"logLevel\":\"error\", \"store\":true}";
-  WAKU_CALL( waku_new(configJSON, handle_error) );  // configJSON can be NULL too to use defaults
+  response = waku_new(configJSON); // configJSON can be NULL too to use defaults
+  if (isError(response))
+    return 1;
 
-  WAKU_CALL(waku_start(handle_error) ); // Start the node, enabling the waku protocols
+  response = waku_start(); // Start the node, enabling the waku protocols
+  if (isError(response))
+    return 1;
 
-  WAKU_CALL(waku_peerid(handle_ok, handle_error)); // Obtain the node peerID
-  char *peerID = strdup(result);
-  printf("PeerID: %s\n", result);
+  response = waku_peerid(); // Obtain the node peerID
+  if (isError(response))
+    return 1;
+  char *nodePeerID = utils_get_str(response);
+  printf("PeerID: %s\n", nodePeerID);
 
-  WAKU_CALL(waku_content_topic("example", 1, "default", "rfc26", handle_ok));
-  contentTopic = strdup(result);
   
-  WAKU_CALL(waku_connect("/dns4/node-01.gc-us-central1-a.wakuv2.test.statusim.net/tcp/30303/p2p/16Uiu2HAmJb2e28qLXxT5kZxVUUoJt72EMzNGXB47Rxx5hw3q4YjS", 0, handle_error)); // Connect to a node
+  response =  waku_connect("/dns4/node-01.gc-us-central1-a.wakuv2.test.statusim.net/tcp/30303/p2p/16Uiu2HAmJb2e28qLXxT5kZxVUUoJt72EMzNGXB47Rxx5hw3q4YjS", 0); // Connect to a node
+  if (isError(response))
+    printf("Could not connect to node: %s\n", response);
 
-  // To use dns discovery, and retrieve nodes from a enrtree url
- WAKU_CALL( waku_dns_discovery("enrtree://AOGECG2SPND25EEFMAJ5WF3KSGJNSGV356DSTL2YVLLZWIV6SAYBM@test.waku.nodes.status.im", "", 0, handle_ok, handle_error)); // Discover Nodes
-  printf("Discovered nodes: %s\n", result);
-  
-  WAKU_CALL(waku_default_pubsub_topic(handle_ok));
-  char *pubsubTopic = strdup(result);
-  printf("Default pubsub topic: %s\n", pubsubTopic);
 
-  // To see a store query in action:
   /*
-  char query[1000];
-  sprintf(query, "{\"pubsubTopic\":\"%s\", \"pagingOptions\":{\"pageSize\": 40, \"forward\":false}}", pubsubTopic);
-  WAKU_CALL(waku_store_query(query, NULL, 0, handle_ok, handle_error));
-  printf("%s\n",result);
+  // To use dns discovery, and retrieve nodes from a enrtree url
+  response = waku_dns_discovery("enrtree://AOGECG2SPND25EEFMAJ5WF3KSGJNSGV356DSTL2YVLLZWIV6SAYBM@test.waku.nodes.status.im", "", 0); // Discover Nodes
+  if (isError(response))
+    return 1;
+  printf("Discovered nodes: %s\n", response);
   */
-
-  WAKU_CALL( waku_relay_subscribe(NULL, handle_error));
+  
+  /*
+  // To see a store query in action:
+  char query[1000];
+  sprintf(query, "{\"pubsubTopic\":\"%s\", \"pagingOptions\":{\"pageSize\": 40, \"forward\":false}}", waku_default_pubsub_topic());
+  response = waku_store_query(query, NULL, 0);
+  if (isError(response))
+    return 1;
+  printf("%s\n",response);
+  */
+  response = waku_relay_subscribe(NULL);
+  if (isError(response))
+    return 1;
 
   int i = 0;
   int version = 1;
@@ -130,22 +111,18 @@ int main(int argc, char *argv[])
     i++;
 
     char wakuMsg[1000];
-    char *msgPayload = b64_encode("Hello World!", 12);
+    char *contentTopic = waku_content_topic("example", 1, "default", "rfc26");
+    sprintf(wakuMsg, "{\"payload\":\"SGVsbG8gV29ybGQh\",\"contentTopic\":\"%s\",\"timestamp\":%d}", contentTopic, i);
+    free(contentTopic);
 
-    sprintf(wakuMsg, "{\"payload\":\"%s\",\"contentTopic\":\"%s\",\"timestamp\":%"PRIu64"}", msgPayload, contentTopic, nowInNanosecs());
-    free(msgPayload);
 
-
-    WAKU_CALL(waku_encode_asymmetric(wakuMsg, bobPubKey, alicePrivKey, handle_ok, handle_error));
-    char *encodedMessage = strdup(result);
-
-    WAKU_CALL(waku_relay_publish(encodedMessage, NULL, 0, handle_ok, handle_error)); // Broadcast via waku relay
-    printf("C\n");
-
-    char *messageID = strdup(result);
-    printf("MessageID: %s\n",messageID);
-
-    free(messageID);
+    response = waku_relay_publish(wakuMsg, NULL, 0); // Broadcast via waku relay a message encrypting it with Bob's PubK, and signing it with Alice PrivK
+    // response = waku_lightpush_publish_enc_asymmetric(wakuMsg, NULL, NULL, bobPubKey, alicePrivKey, 0); // Broadcast via waku lightpush a message encrypting it with Bob's PubK, and signing it with Alice PrivK
+    if (isError(response))
+      return 1;
+    
+    // char *messageID = utils_get_str(response);
+    // free(messageID);
 
     sleep(1);
   }
@@ -154,12 +131,16 @@ int main(int argc, char *argv[])
   // To retrieve messages from local store, set store:true in the node config, and use waku_store_local_query
   /*
   char query[1000];
-  sprintf(query, "{\"pubsubTopic\":\"%s\", \"pagingOptions\":{\"pageSize\": 40, \"forward\":false}}", pubsubTopic);
-  WAKU_CALL(waku_store_local_query(query, handle_ok, handle_error));
-  printf("%s\n",result);
+  sprintf(query, "{\"pubsubTopic\":\"%s\", \"pagingOptions\":{\"pageSize\": 40, \"forward\":false}}", waku_default_pubsub_topic());
+  response = waku_store_local_query(query);
+  if (isError(response))
+    return 1;
+  printf("%s\n",response);
   */
 
-  WAKU_CALL(waku_stop(handle_error));
-  
+  response = waku_stop();
+  if (isError(response))
+    return 1;
+
   return 0;
 }

--- a/examples/c-bindings/main.h
+++ b/examples/c-bindings/main.h
@@ -7,14 +7,6 @@
 /// Convert seconds to nanoseconds
 #define SEC_TO_NS(sec) ((sec)*1000000000)
 
-#define WAKU_CALL(call)                                                        \
-do {                                                                           \
-  int ret = call;                                                              \
-  if (ret != 0) {                                                              \
-    printf("Failed the call to: %s. Returned code: %d\n", #call, ret);         \
-    exit(1);                                                                   \
-  }                                                                            \
-} while (0)
 
 uint64_t nowInNanosecs(){
   uint64_t nanoseconds;
@@ -56,8 +48,9 @@ bool isError(char *input)
 }
 
 
-char *utils_extract_wakumessage_from_signal(const nx_json *wakuMsgJson)
+char *utils_extract_wakumessage_from_signal(const nx_json *signal)
 {
+    const nx_json *wakuMsgJson = nx_json_get(nx_json_get(signal, "event"), "wakuMessage");
     const char *payload = nx_json_get(wakuMsgJson, "payload")->text_value;
     const char *contentTopic = nx_json_get(wakuMsgJson, "contentTopic")->text_value;
     int version = nx_json_get(wakuMsgJson, "version")->int_value;
@@ -69,5 +62,38 @@ char *utils_extract_wakumessage_from_signal(const nx_json *wakuMsgJson)
     return response;
 }
 
+long long utils_get_int(char *input)
+{
+    char *jsonStr = malloc(strlen(input) + 1);
+    strcpy(jsonStr, input);
+    const nx_json *json = nx_json_parse(jsonStr, 0);
+    long long result = -1;
+    if (json)
+    {
+        result = nx_json_get(json, "result")->int_value;
+    }
+    nx_json_free(json);
+    free(jsonStr);
+
+    return result;
+}
+
+char *utils_get_str(char *input)
+{
+    char *jsonStr = malloc(strlen(input) + 1);
+    strcpy(jsonStr, input);
+    const nx_json *json = nx_json_parse(jsonStr, 0);
+    char *result = "";
+    if (json)
+    {
+        const char *text_value = nx_json_get(json, "result")->text_value;
+        result = strdup(text_value);
+    }
+
+    nx_json_free(json);
+    free(jsonStr);
+
+    return result;
+}
 
 #endif /* MAIN_H */

--- a/library/c/README.md
+++ b/library/c/README.md
@@ -88,7 +88,7 @@ The criteria to create subscription to a filter full node in JSON Format:
 Fields:
 
 - `contentTopics`: Array of content topics.
-- `topic`: Optional pubsub topic when using contentTopics as per Autosharding. In case of named or static-sharding, pubSub topic is mandatory.
+- `topic`: pubsub topic.
 
 
 ### `LegacyFilterSubscription` type
@@ -766,6 +766,62 @@ A status code. Refer to the [`Status codes`](#status-codes) section for possible
 
 If the function is executed succesfully, `onOkCb` will receive the message ID.
 
+### `extern int waku_relay_publish_enc_asymmetric(char* messageJson, char* pubsubTopic, char* publicKey, char* optionalSigningKey, int timeoutMs, WakuCallBack onOkCb, WakuCallBack onErrCb)`
+
+Optionally sign,
+encrypt using asymmetric encryption
+and publish a message using Waku Relay.
+
+**Parameters**
+
+1. `char* messageJson`: JSON string containing the [Waku Message](https://rfc.vac.dev/spec/14/) as [`JsonMessage`](#jsonmessage-type).
+2. `char* pubsubTopic`: pubsub topic on which to publish the message.
+   If `NULL`, it uses the default pubsub topic.
+3. `char* publicKey`: hex encoded public key to be used for encryption.
+4. `char* optionalSigningKey`: hex encoded private key to be used to sign the message.
+5. `int timeoutMs`: Timeout value in milliseconds to execute the call.
+   If the function execution takes longer than this value,
+   the execution will be canceled and an error returned.
+   Use `0` for no timeout.
+6. `WakuCallBack onOkCb`: callback to be executed if the function is succesful
+7. `WakuCallBack onErrCb`: callback to be executed if the function fails
+
+Note: `messageJson.version` is overwritten to `1`.
+
+**Returns**
+
+A status code. Refer to the [`Status codes`](#status-codes) section for possible values.
+
+If the function is executed succesfully, `onOkCb` will receive the message ID.
+
+### `extern int waku_relay_publish_enc_symmetric(char* messageJson, char* pubsubTopic, char* symmetricKey, char* optionalSigningKey, int timeoutMs, WakuCallBack onOkCb, WakuCallBack onErrCb)`
+
+Optionally sign,
+encrypt using symmetric encryption
+and publish a message using Waku Relay.
+
+**Parameters**
+
+1. `char* messageJson`: JSON string containing the [Waku Message](https://rfc.vac.dev/spec/14/) as [`JsonMessage`](#jsonmessage-type).
+2. `char* pubsubTopic`: pubsub topic on which to publish the message.
+   If `NULL`, it uses the default pubsub topic.
+3. `char* symmetricKey`: hex encoded secret key to be used for encryption.
+4. `char* optionalSigningKey`: hex encoded private key to be used to sign the message.
+5. `int timeoutMs`: Timeout value in milliseconds to execute the call.
+   If the function execution takes longer than this value,
+   the execution will be canceled and an error returned.
+   Use `0` for no timeout.
+6. `WakuCallBack onOkCb`: callback to be executed if the function is succesful
+7. `WakuCallBack onErrCb`: callback to be executed if the function fails
+
+Note: `messageJson.version` is overwritten to `1`.
+
+**Returns**
+
+A status code. Refer to the [`Status codes`](#status-codes) section for possible values.
+
+If the function is executed succesfully, `onOkCb` will receive the message ID.
+
 ### `extern int waku_relay_enough_peers(char* pubsubTopic, WakuCallBack onOkCb, WakuCallBack onErrCb)`
 
 Determine if there are enough peers to publish a message on a given pubsub topic.
@@ -884,21 +940,15 @@ Creates a subscription to a filter full node matching a content filter..
 
 A status code. Refer to the [`Status codes`](#status-codes) section for possible values.
 
-If the function is executed succesfully, `onOkCb` will receive the following subscription details along with any partial errors.
+If the function is executed succesfully, `onOkCb` will receive the subscription details.
 
 For example:
 
 ```json
 {
-  "subscriptions" : [
-    {
-      "ID": "<subscriptionID>",
-      "peerID": "....",
-      "pubsubTopic": "...",
-      "contentTopics": [...]
-    }
-  ],
-  "error" : "subscriptions failed for contentTopics:<topicA>,.." // Empty if all subscriptions are succesful
+  "peerID": "....",
+  "pubsubTopic": "...",
+  "contentTopics": [...]
 }
 ```
 
@@ -1104,6 +1154,70 @@ A status code. Refer to the [`Status codes`](#status-codes) section for possible
 
 If the function is executed succesfully, `onOkCb` will receive the message ID.
 
+### `extern int waku_lightpush_publish_enc_asymmetric(char* messageJson, char* pubsubTopic, char* peerID, char* publicKey, char* optionalSigningKey, int timeoutMs, WakuCallBack onOkCb, WakuCallBack onErrCb)`
+
+Optionally sign,
+encrypt using asymmetric encryption
+and publish a message using Waku Lightpush.
+
+**Parameters**
+
+1. `char* messageJson`: JSON string containing the [Waku Message](https://rfc.vac.dev/spec/14/) as [`JsonMessage`](#jsonmessage-type).
+2. `char* pubsubTopic`: pubsub topic on which to publish the message.
+   If `NULL`, it uses the default pubsub topic.
+3. `char* peerID`: Peer ID supporting the lightpush protocol.
+   The peer must be already known.
+   It must have been added before with [`waku_add_peer`](#extern-char-waku_add_peerchar-address-char-protocolid)
+   or previously dialed with [`waku_connect_peer`](#extern-char-waku_connect_peerchar-address-int-timeoutms).
+4. `char* publicKey`: hex encoded public key to be used for encryption.
+5. `char* optionalSigningKey`: hex encoded private key to be used to sign the message.
+6. `int timeoutMs`: Timeout value in milliseconds to execute the call.
+   If the function execution takes longer than this value,
+   the execution will be canceled and an error returned.
+   Use `0` for no timeout.
+7. `WakuCallBack onOkCb`: callback to be executed if the function is succesful
+8. `WakuCallBack onErrCb`: callback to be executed if the function fails
+
+Note: `messageJson.version` is overwritten to `1`.
+
+**Returns**
+
+A status code. Refer to the [`Status codes`](#status-codes) section for possible values.
+
+If the function is executed succesfully, `onOkCb` will receive the message ID.
+
+### `extern int waku_lightpush_publish_enc_symmetric(char* messageJson, char* pubsubTopic, char* peerID, char* symmetricKey, char* optionalSigningKey, int timeoutMs, WakuCallBack onOkCb, WakuCallBack onErrCb)`
+
+Optionally sign,
+encrypt using symmetric encryption
+and publish a message using Waku Lightpush.
+
+**Parameters**
+
+1. `char* messageJson`: JSON string containing the [Waku Message](https://rfc.vac.dev/spec/14/) as [`JsonMessage`](#jsonmessage-type).
+2. `char* pubsubTopic`: pubsub topic on which to publish the message.
+   If `NULL`, it uses the default pubsub topic.
+3. `char* peerID`: Peer ID supporting the lightpush protocol.
+   The peer must be already known.
+   It must have been added before with [`waku_add_peer`](#extern-char-waku_add_peerchar-address-char-protocolid)
+   or previously dialed with [`waku_connect_peer`](#extern-char-waku_connect_peerchar-address-int-timeoutms).
+4. `char* symmetricKey`: hex encoded secret key to be used for encryption.
+5. `char* optionalSigningKey`: hex encoded private key to be used to sign the message.
+6. `int timeoutMs`: Timeout value in milliseconds to execute the call.
+   If the function execution takes longer than this value,
+   the execution will be canceled and an error returned.
+   Use `0` for no timeout.
+7. `WakuCallBack onOkCb`: callback to be executed if the function is succesful
+8. `WakuCallBack onErrCb`: callback to be executed if the function fails
+
+Note: `messageJson.version` is overwritten to `1`.
+
+**Returns**
+
+A status code. Refer to the [`Status codes`](#status-codes) section for possible values.
+
+If the function is executed succesfully, `onOkCb` will receive the message ID.
+
 ## Waku Store
 
 ### `extern int waku_store_query(char* queryJSON, char* peerID, int timeoutMs, WakuCallBack onOkCb, WakuCallBack onErrCb)`
@@ -1155,49 +1269,6 @@ must contain a cursor pointing to the Index from which a new page can be request
 A status code. Refer to the [`Status codes`](#status-codes) section for possible values.
 
 If the function is executed succesfully, `onOkCb` will receive a [`StoreResponse`](#storeresponse-type).
-
-## Encrypting messages
-
-### `extern int waku_encode_symmetric(char* messageJson, char* symmetricKey, char* optionalSigningKey, WakuCallBack onOkCb, WakuCallBack onErrCb)`
-
-Encrypt a message using symmetric encryption and optionally sign the message
-
-**Parameters**
-
-1. `char* messageJson`: JSON string containing the [Waku Message](https://rfc.vac.dev/spec/14/) as [`JsonMessage`](#jsonmessage-type).
-2. `char* symmetricKey`: hex encoded secret key to be used for encryption.
-3. `char* optionalSigningKey`: hex encoded private key to be used to sign the message.
-4. `WakuCallBack onOkCb`: callback to be executed if the function is succesful
-5. `WakuCallBack onErrCb`: callback to be executed if the function fails
-
-Note: `messageJson.version` is overwritten to `1`.
-
-**Returns**
-
-A status code. Refer to the [`Status codes`](#status-codes) section for possible values.
-
-If the function is executed succesfully, `onOkCb` will receive the encrypted waku message which can be broadcasted with relay or lightpush protocol publish functions
-
-### `extern int waku_encode_asymmetric(char* messageJson, char* publicKey, char* optionalSigningKey, WakuCallBack onOkCb, WakuCallBack onErrCb)`
-
-Encrypt a message using asymmetric encryption and optionally sign the message
-
-**Parameters**
-
-1. `char* messageJson`: JSON string containing the [Waku Message](https://rfc.vac.dev/spec/14/) as [`JsonMessage`](#jsonmessage-type).
-2. `char* publicKey`: hex encoded public key to be used for encryption.
-3. `char* optionalSigningKey`: hex encoded private key to be used to sign the message.
-4. `WakuCallBack onOkCb`: callback to be executed if the function is succesful
-5. `WakuCallBack onErrCb`: callback to be executed if the function fails
-
-Note: `messageJson.version` is overwritten to `1`.
-
-**Returns**
-
-A status code. Refer to the [`Status codes`](#status-codes) section for possible values.
-
-If the function is executed succesfully, `onOkCb` will receive the encrypted waku message which can be broadcasted with relay or lightpush protocol publish functions
-
 
 ## Decrypting messages
 

--- a/library/c/api_discovery.go
+++ b/library/c/api_discovery.go
@@ -1,8 +1,5 @@
 package main
 
-/*
-#include <cgo_utils.h>
-*/
 import "C"
 
 import "github.com/waku-org/go-waku/library"
@@ -17,17 +14,17 @@ import "github.com/waku-org/go-waku/library"
 // (in milliseconds) is reached, or an error will be returned
 //
 //export waku_dns_discovery
-func waku_dns_discovery(url *C.char, nameserver *C.char, ms C.int, onOkCb C.WakuCallBack, onErrCb C.WakuCallBack) C.int {
-	return singleFnExec(func() (string, error) {
+func waku_dns_discovery(url *C.char, nameserver *C.char, ms C.int) *C.char {
+	return singleFnExec(func() (any, error) {
 		return library.DNSDiscovery(C.GoString(url), C.GoString(nameserver), int(ms))
-	}, onOkCb, onErrCb)
+	})
 }
 
 // Update the bootnode list used for discovering new peers via DiscoveryV5
 // The bootnodes param should contain a JSON array containing the bootnode ENRs i.e. `["enr:...", "enr:..."]`
 //
 //export waku_discv5_update_bootnodes
-func waku_discv5_update_bootnodes(bootnodes *C.char, onErrCb C.WakuCallBack) C.int {
+func waku_discv5_update_bootnodes(bootnodes *C.char) *C.char {
 	err := library.SetBootnodes(C.GoString(bootnodes))
-	return execErrCB(onErrCb, err)
+	return execErrCB(err)
 }

--- a/library/c/api_encoding.go
+++ b/library/c/api_encoding.go
@@ -1,27 +1,24 @@
 package main
 
-/*
-#include <cgo_utils.h>
-*/
 import "C"
 import "github.com/waku-org/go-waku/library"
 
 // Decode a waku message using a 32 bytes symmetric key. The key must be a hex encoded string with "0x" prefix
 //
 //export waku_decode_symmetric
-func waku_decode_symmetric(messageJSON *C.char, symmetricKey *C.char, onOkCb C.WakuCallBack, onErrCb C.WakuCallBack) C.int {
-	return singleFnExec(func() (string, error) {
+func waku_decode_symmetric(messageJSON *C.char, symmetricKey *C.char) *C.char {
+	return singleFnExec(func() (any, error) {
 		return library.DecodeSymmetric(C.GoString(messageJSON), C.GoString(symmetricKey))
-	}, onOkCb, onErrCb)
+	})
 }
 
 // Decode a waku message using a secp256k1 private key. The key must be a hex encoded string with "0x" prefix
 //
 //export waku_decode_asymmetric
-func waku_decode_asymmetric(messageJSON *C.char, privateKey *C.char, onOkCb C.WakuCallBack, onErrCb C.WakuCallBack) C.int {
-	return singleFnExec(func() (string, error) {
+func waku_decode_asymmetric(messageJSON *C.char, privateKey *C.char) *C.char {
+	return singleFnExec(func() (any, error) {
 		return library.DecodeAsymmetric(C.GoString(messageJSON), C.GoString(privateKey))
-	}, onOkCb, onErrCb)
+	})
 }
 
 // Encrypt a message with a secp256k1 public key.
@@ -30,10 +27,10 @@ func waku_decode_asymmetric(messageJSON *C.char, privateKey *C.char, onOkCb C.Wa
 // The message version will be set to 1
 //
 //export waku_encode_asymmetric
-func waku_encode_asymmetric(messageJSON *C.char, publicKey *C.char, optionalSigningKey *C.char, onOkCb C.WakuCallBack, onErrCb C.WakuCallBack) C.int {
-	return singleFnExec(func() (string, error) {
+func waku_encode_asymmetric(messageJSON *C.char, publicKey *C.char, optionalSigningKey *C.char) *C.char {
+	return singleFnExec(func() (any, error) {
 		return library.EncodeAsymmetric(C.GoString(messageJSON), C.GoString(publicKey), C.GoString(optionalSigningKey))
-	}, onOkCb, onErrCb)
+	})
 }
 
 // Encrypt a message with a 32 bytes symmetric key
@@ -42,8 +39,8 @@ func waku_encode_asymmetric(messageJSON *C.char, publicKey *C.char, optionalSign
 // The message version will be set to 1
 //
 //export waku_encode_symmetric
-func waku_encode_symmetric(messageJSON *C.char, symmetricKey *C.char, optionalSigningKey *C.char, onOkCb C.WakuCallBack, onErrCb C.WakuCallBack) C.int {
-	return singleFnExec(func() (string, error) {
+func waku_encode_symmetric(messageJSON *C.char, symmetricKey *C.char, optionalSigningKey *C.char) *C.char {
+	return singleFnExec(func() (any, error) {
 		return library.EncodeSymmetric(C.GoString(messageJSON), C.GoString(symmetricKey), C.GoString(optionalSigningKey))
-	}, onOkCb, onErrCb)
+	})
 }

--- a/library/c/api_filter.go
+++ b/library/c/api_filter.go
@@ -1,8 +1,5 @@
 package main
 
-/*
-#include <cgo_utils.h>
-*/
 import "C"
 import "github.com/waku-org/go-waku/library"
 
@@ -20,10 +17,10 @@ import "github.com/waku-org/go-waku/library"
 // It returns a json object containing the details of the subscriptions along with any errors in case of partial failures
 //
 //export waku_filter_subscribe
-func waku_filter_subscribe(filterJSON *C.char, peerID *C.char, ms C.int, onOkCb C.WakuCallBack, onErrCb C.WakuCallBack) C.int {
-	return singleFnExec(func() (string, error) {
+func waku_filter_subscribe(filterJSON *C.char, peerID *C.char, ms C.int) *C.char {
+	return singleFnExec(func() (any, error) {
 		return library.FilterSubscribe(C.GoString(filterJSON), C.GoString(peerID), int(ms))
-	}, onOkCb, onErrCb)
+	})
 }
 
 // Used to know if a service node has an active subscription for this client
@@ -32,9 +29,9 @@ func waku_filter_subscribe(filterJSON *C.char, peerID *C.char, ms C.int, onOkCb 
 // (in milliseconds) is reached, or an error will be returned
 //
 //export waku_filter_ping
-func waku_filter_ping(peerID *C.char, ms C.int, onErrCb C.WakuCallBack) C.int {
+func waku_filter_ping(peerID *C.char, ms C.int) *C.char {
 	err := library.FilterPing(C.GoString(peerID), int(ms))
-	return execErrCB(onErrCb, err)
+	return execErrCB(err)
 }
 
 // Sends a requests to a service node to stop pushing messages matching this filter to this client.
@@ -51,9 +48,9 @@ func waku_filter_ping(peerID *C.char, ms C.int, onErrCb C.WakuCallBack) C.int {
 // (in milliseconds) is reached, or an error will be returned
 //
 //export waku_filter_unsubscribe
-func waku_filter_unsubscribe(filterJSON *C.char, peerID *C.char, ms C.int, onErrCb C.WakuCallBack) C.int {
+func waku_filter_unsubscribe(filterJSON *C.char, peerID *C.char, ms C.int) *C.char {
 	err := library.FilterUnsubscribe(C.GoString(filterJSON), C.GoString(peerID), int(ms))
-	return execErrCB(onErrCb, err)
+	return execErrCB(err)
 }
 
 // Sends a requests to a service node (or all service nodes) to stop pushing messages
@@ -63,8 +60,8 @@ func waku_filter_unsubscribe(filterJSON *C.char, peerID *C.char, ms C.int, onErr
 // (in milliseconds) is reached, or an error will be returned
 //
 //export waku_filter_unsubscribe_all
-func waku_filter_unsubscribe_all(peerID *C.char, ms C.int, onOkCb C.WakuCallBack, onErrCb C.WakuCallBack) C.int {
-	return singleFnExec(func() (string, error) {
+func waku_filter_unsubscribe_all(peerID *C.char, ms C.int) *C.char {
+	return singleFnExec(func() (any, error) {
 		return library.FilterUnsubscribeAll(C.GoString(peerID), int(ms))
-	}, onOkCb, onErrCb)
+	})
 }

--- a/library/c/api_legacy_filter.go
+++ b/library/c/api_legacy_filter.go
@@ -1,8 +1,5 @@
 package main
 
-/*
-#include <cgo_utils.h>
-*/
 import "C"
 import "github.com/waku-org/go-waku/library"
 
@@ -23,9 +20,9 @@ import "github.com/waku-org/go-waku/library"
 // (in milliseconds) is reached, or an error will be returned
 //
 //export waku_legacy_filter_subscribe
-func waku_legacy_filter_subscribe(filterJSON *C.char, peerID *C.char, ms C.int, onErrCb C.WakuCallBack) C.int {
+func waku_legacy_filter_subscribe(filterJSON *C.char, peerID *C.char, ms C.int) *C.char {
 	err := library.LegacyFilterSubscribe(C.GoString(filterJSON), C.GoString(peerID), int(ms))
-	return execErrCB(onErrCb, err)
+	return execErrCB(err)
 }
 
 // Removes subscriptions in a light node matching a content filter and, optionally, a pubSub topic.
@@ -44,7 +41,7 @@ func waku_legacy_filter_subscribe(filterJSON *C.char, peerID *C.char, ms C.int, 
 // (in milliseconds) is reached, or an error will be returned
 //
 //export waku_legacy_filter_unsubscribe
-func waku_legacy_filter_unsubscribe(filterJSON *C.char, ms C.int, onErrCb C.WakuCallBack) C.int {
+func waku_legacy_filter_unsubscribe(filterJSON *C.char, ms C.int) *C.char {
 	err := library.LegacyFilterUnsubscribe(C.GoString(filterJSON), int(ms))
-	return execErrCB(onErrCb, err)
+	return execErrCB(err)
 }

--- a/library/c/api_lightpush.go
+++ b/library/c/api_lightpush.go
@@ -1,8 +1,5 @@
 package main
 
-/*
-#include <cgo_utils.h>
-*/
 import "C"
 import "github.com/waku-org/go-waku/library"
 
@@ -12,8 +9,8 @@ import "github.com/waku-org/go-waku/library"
 // (in milliseconds) is reached, or an error will be returned
 //
 //export waku_lightpush_publish
-func waku_lightpush_publish(messageJSON *C.char, topic *C.char, peerID *C.char, ms C.int, onOkCb C.WakuCallBack, onErrCb C.WakuCallBack) C.int {
-	return singleFnExec(func() (string, error) {
+func waku_lightpush_publish(messageJSON *C.char, topic *C.char, peerID *C.char, ms C.int) *C.char {
+	return singleFnExec(func() (any, error) {
 		return library.LightpushPublish(C.GoString(messageJSON), C.GoString(topic), C.GoString(peerID), int(ms))
-	}, onOkCb, onErrCb)
+	})
 }

--- a/library/c/api_relay.go
+++ b/library/c/api_relay.go
@@ -1,8 +1,5 @@
 package main
 
-/*
-#include <cgo_utils.h>
-*/
 import "C"
 import "github.com/waku-org/go-waku/library"
 
@@ -10,14 +7,14 @@ import "github.com/waku-org/go-waku/library"
 // to verify the number of peers in the default pubsub topic
 //
 //export waku_relay_enough_peers
-func waku_relay_enough_peers(topic *C.char, onOkCb C.WakuCallBack, onErrCb C.WakuCallBack) C.int {
-	return singleFnExec(func() (string, error) {
+func waku_relay_enough_peers(topic *C.char) *C.char {
+	return singleFnExec(func() (any, error) {
 		result, err := library.RelayEnoughPeers(C.GoString(topic))
 		if result {
 			return "true", err
 		}
 		return "false", err
-	}, onOkCb, onErrCb)
+	})
 }
 
 // Publish a message using waku relay and returns the message ID. Use NULL for topic to use the default pubsub topic
@@ -25,10 +22,10 @@ func waku_relay_enough_peers(topic *C.char, onOkCb C.WakuCallBack, onErrCb C.Wak
 // (in milliseconds) is reached, or an error will be returned.
 //
 //export waku_relay_publish
-func waku_relay_publish(messageJSON *C.char, topic *C.char, ms C.int, onOkCb C.WakuCallBack, onErrCb C.WakuCallBack) C.int {
-	return singleFnExec(func() (string, error) {
+func waku_relay_publish(messageJSON *C.char, topic *C.char, ms C.int) *C.char {
+	return singleFnExec(func() (any, error) {
 		return library.RelayPublish(C.GoString(messageJSON), C.GoString(topic), int(ms))
-	}, onOkCb, onErrCb)
+	})
 }
 
 // Subscribe to a WakuRelay topic. Set the topic to NULL to subscribe
@@ -37,25 +34,25 @@ func waku_relay_publish(messageJSON *C.char, topic *C.char, ms C.int, onOkCb C.W
 // the message was received
 //
 //export waku_relay_subscribe
-func waku_relay_subscribe(topic *C.char, onErrCb C.WakuCallBack) C.int {
+func waku_relay_subscribe(topic *C.char) *C.char {
 	err := library.RelaySubscribe(C.GoString(topic))
-	return execErrCB(onErrCb, err)
+	return execErrCB(err)
 }
 
 // Returns a json response with the list of pubsub topics the node
 // is subscribed to in WakuRelay
 //
 //export waku_relay_topics
-func waku_relay_topics(onOkCb C.WakuCallBack, onErrCb C.WakuCallBack) C.int {
-	return singleFnExec(func() (string, error) {
+func waku_relay_topics() *C.char {
+	return singleFnExec(func() (any, error) {
 		return library.RelayTopics()
-	}, onOkCb, onErrCb)
+	})
 }
 
 // Closes the pubsub subscription to a pubsub topic
 //
 //export waku_relay_unsubscribe
-func waku_relay_unsubscribe(topic *C.char, onErrCb C.WakuCallBack) C.int {
+func waku_relay_unsubscribe(topic *C.char) *C.char {
 	err := library.RelayUnsubscribe(C.GoString(topic))
-	return execErrCB(onErrCb, err)
+	return execErrCB(err)
 }

--- a/library/c/api_store.go
+++ b/library/c/api_store.go
@@ -1,8 +1,5 @@
 package main
 
-/*
-#include <cgo_utils.h>
-*/
 import "C"
 import "github.com/waku-org/go-waku/library"
 
@@ -36,10 +33,10 @@ import "github.com/waku-org/go-waku/library"
 // (in milliseconds) is reached, or an error will be returned
 //
 //export waku_store_query
-func waku_store_query(queryJSON *C.char, peerID *C.char, ms C.int, onOkCb C.WakuCallBack, onErrCb C.WakuCallBack) C.int {
-	return singleFnExec(func() (string, error) {
+func waku_store_query(queryJSON *C.char, peerID *C.char, ms C.int) *C.char {
+	return singleFnExec(func() (any, error) {
 		return library.StoreQuery(C.GoString(queryJSON), C.GoString(peerID), int(ms))
-	}, onOkCb, onErrCb)
+	})
 }
 
 // Query historic messages stored in the localDB using waku store protocol.
@@ -70,8 +67,8 @@ func waku_store_query(queryJSON *C.char, peerID *C.char, ms C.int, onOkCb C.Waku
 // Requires the `store` option to be passed when setting up the initial configuration
 //
 //export waku_store_local_query
-func waku_store_local_query(queryJSON *C.char, onOkCb C.WakuCallBack, onErrCb C.WakuCallBack) C.int {
-	return singleFnExec(func() (string, error) {
+func waku_store_local_query(queryJSON *C.char) *C.char {
+	return singleFnExec(func() (any, error) {
 		return library.StoreLocalQuery(C.GoString(queryJSON))
-	}, onOkCb, onErrCb)
+	})
 }

--- a/library/c/cgo_utils.c
+++ b/library/c/cgo_utils.c
@@ -1,9 +1,0 @@
-#include <stdlib.h>
-#include <stddef.h>
-#include <cgo_utils.h>
-
-// This is a bridge function to execute C callbacks.
-// It's used internally in go-waku. Do not call directly
-void _waku_execCB(WakuCallBack op, char* a, size_t b) {
-    op(a, b);
-}

--- a/library/c/cgo_utils.h
+++ b/library/c/cgo_utils.h
@@ -1,6 +1,0 @@
-#include <stdlib.h>
-#include <stdint.h>
-
-typedef void (*WakuCallBack) (const char* msg, size_t len_0);
-
-typedef void (*BytesCallBack) (uint8_t* data, size_t len_0);

--- a/library/discovery.go
+++ b/library/discovery.go
@@ -17,7 +17,7 @@ type dnsDiscoveryItem struct {
 }
 
 // DNSDiscovery executes dns discovery on an url and returns a list of nodes
-func DNSDiscovery(url string, nameserver string, ms int) (string, error) {
+func DNSDiscovery(url string, nameserver string, ms int) ([]dnsDiscoveryItem, error) {
 	var ctx context.Context
 	var cancel context.CancelFunc
 
@@ -35,7 +35,7 @@ func DNSDiscovery(url string, nameserver string, ms int) (string, error) {
 
 	nodes, err := dnsdisc.RetrieveNodes(ctx, url, dnsDiscOpt...)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
 	var response []dnsDiscoveryItem
@@ -54,7 +54,7 @@ func DNSDiscovery(url string, nameserver string, ms int) (string, error) {
 		response = append(response, item)
 	}
 
-	return marshalJSON(response)
+	return response, nil
 }
 
 // StartDiscoveryV5 starts discv5 discovery

--- a/library/node.go
+++ b/library/node.go
@@ -377,5 +377,21 @@ func Peers() ([]*node.Peer, error) {
 		return nil, errWakuNodeNotReady
 	}
 
-	return wakuState.node.Peers()
+	peers, err := wakuState.node.Peers()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, p := range peers {
+		addrs := []multiaddr.Multiaddr{}
+		for i := range p.Addrs {
+			_, err := p.Addrs[i].ValueForProtocol(multiaddr.P_SNI)
+			if err != nil {
+				addrs = append(addrs, p.Addrs[i])
+			}
+		}
+		p.Addrs = addrs
+	}
+
+	return peers, nil
 }

--- a/library/node.go
+++ b/library/node.go
@@ -236,9 +236,9 @@ func PeerID() (string, error) {
 }
 
 // ListenAddresses returns the multiaddresses the wakunode is listening to
-func ListenAddresses() (string, error) {
+func ListenAddresses() ([]string, error) {
 	if wakuState.node == nil {
-		return "", errWakuNodeNotReady
+		return nil, errWakuNodeNotReady
 	}
 
 	var addresses []string
@@ -246,7 +246,7 @@ func ListenAddresses() (string, error) {
 		addresses = append(addresses, addr.String())
 	}
 
-	return marshalJSON(addresses)
+	return addresses, nil
 }
 
 // AddPeer adds a node multiaddress and protocol to the wakunode peerstore
@@ -265,7 +265,7 @@ func AddPeer(address string, protocolID string) (string, error) {
 		return "", err
 	}
 
-	return marshalJSON(peerID)
+	return peerID.Pretty(), nil
 }
 
 // Connect is used to connect to a peer at multiaddress. if ms > 0, cancel the function execution if it takes longer than N milliseconds
@@ -372,15 +372,10 @@ func toSubscriptionMessage(msg *protocol.Envelope) *subscriptionMsg {
 }
 
 // Peers retrieves the list of peers known by the waku node
-func Peers() (string, error) {
+func Peers() ([]*node.Peer, error) {
 	if wakuState.node == nil {
-		return "", errWakuNodeNotReady
+		return nil, errWakuNodeNotReady
 	}
 
-	peers, err := wakuState.node.Peers()
-	if err != nil {
-		return "", err
-	}
-
-	return marshalJSON(peers)
+	return wakuState.node.Peers()
 }

--- a/library/relay.go
+++ b/library/relay.go
@@ -95,12 +95,12 @@ func RelaySubscribe(topic string) error {
 }
 
 // RelayTopics returns a list of pubsub topics the node is subscribed to in WakuRelay
-func RelayTopics() (string, error) {
+func RelayTopics() ([]string, error) {
 	if wakuState.node == nil {
-		return "", errWakuNodeNotReady
+		return nil, errWakuNodeNotReady
 	}
 
-	return marshalJSON(wakuState.node.Relay().Topics())
+	return wakuState.node.Relay().Topics(), nil
 }
 
 // RelayUnsubscribe closes the pubsub subscription to a pubsub topic

--- a/waku/v2/peermanager/peer_manager.go
+++ b/waku/v2/peermanager/peer_manager.go
@@ -292,7 +292,6 @@ func (pm *PeerManager) AddDiscoveredPeer(p PeerData) {
 				logging.HostID("peer", p.AddrInfo.ID), zap.String("enr", p.ENR.String()))
 		}
 	}
-
 }
 
 // addPeer adds peer to only the peerStore.

--- a/waku/v2/protocol/rln/contracts/import.json
+++ b/waku/v2/protocol/rln/contracts/import.json
@@ -2,27 +2,27 @@
   "language": "Solidity",
   "sources": {
     "WakuRln.sol": {
-      "urls": ["./waku-rln-contract/contracts/WakuRln.sol"]
+      "urls": ["../../../../../libs/waku-rln-contract/contracts/WakuRln.sol"]
     },
     "WakuRlnRegistry.sol": {
-      "urls": ["./waku-rln-contract/contracts/WakuRlnRegistry.sol"]
+      "urls": ["../../../../../libs/waku-rln-contract/contracts/WakuRlnRegistry.sol"]
     },
     "rln-contract/PoseidonHasher.sol": {
       "urls": [
-        "./waku-rln-contract/lib/rln-contract/contracts/PoseidonHasher.sol"
+        "../../../../../libs/waku-rln-contract/lib/rln-contract/contracts/PoseidonHasher.sol"
       ]
     },
     "rln-contract/RlnBase.sol": {
-      "urls": ["./waku-rln-contract/lib/rln-contract/contracts/RlnBase.sol"]
+      "urls": ["../../../../../libs/waku-rln-contract/lib/rln-contract/contracts/RlnBase.sol"]
     },
     "rln-contract/IVerifier.sol": {
-        "urls": ["./waku-rln-contract/lib/rln-contract/contracts/IVerifier.sol"]
+        "urls": ["../../../../../libs/waku-rln-contract/lib/rln-contract/contracts/IVerifier.sol"]
       },
     "openzeppelin-contracts/contracts/access/Ownable.sol": {
-        "urls": ["./waku-rln-contract/lib/openzeppelin-contracts/contracts/access/Ownable.sol"]
+        "urls": ["../../../../../libs/waku-rln-contract/lib/openzeppelin-contracts/contracts/access/Ownable.sol"]
       },
       "openzeppelin-contracts/contracts/utils/Context.sol": {
-        "urls": ["./waku-rln-contract/lib/openzeppelin-contracts/contracts/utils/Context.sol"]
+        "urls": ["../../../../../libs/waku-rln-contract/lib/openzeppelin-contracts/contracts/utils/Context.sol"]
       }
   },
   "settings": {


### PR DESCRIPTION
This PR is created to temporarily revert the changes done in the bindings, due to an issue being identified that would force the usage of global variables. This is done because we have to update the rust bindings, and fixing the callbacks would take much more time than doing this revert