### PR TITLE
feat: force reachability

### DIFF
--- a/cmd/waku/flags.go
+++ b/cmd/waku/flags.go
@@ -172,7 +172,7 @@ var (
 		EnvVars:     []string{"WAKUNODE2_CIRCUIT_RELAY"},
 	})
 	ForceReachability = altsrc.NewStringFlag(&cli.StringFlag{
-		Name:        "reachability",
+		Name:        "force-reachability",
 		Usage:       "Force the node reachability. WARNING: This flag is created for testing circuit relay and is not meant to be used in production. Use 'public' or 'private'",
 		Value:       "",
 		Hidden:      true,

--- a/cmd/waku/flags.go
+++ b/cmd/waku/flags.go
@@ -171,13 +171,13 @@ var (
 		Destination: &options.CircuitRelay,
 		EnvVars:     []string{"WAKUNODE2_CIRCUIT_RELAY"},
 	})
-	ForceUnreachable = altsrc.NewBoolFlag(&cli.BoolFlag{
-		Name:        "unreachable",
-		Usage:       "Force the node to be unreachable. WARNING: This flag is created for testing circuit relay and is not meant to be used in production",
-		Value:       false,
+	ForceReachability = altsrc.NewStringFlag(&cli.StringFlag{
+		Name:        "reachability",
+		Usage:       "Force the node reachability. WARNING: This flag is created for testing circuit relay and is not meant to be used in production. Use 'public' or 'private'",
+		Value:       "",
 		Hidden:      true,
-		Destination: &options.ForceUnreachable,
-		EnvVars:     []string{"WAKUNODE2_UNREACHABLE"},
+		Destination: &options.ForceReachability,
+		EnvVars:     []string{"WAKUNODE2_REACHABILITY"},
 	})
 	ResourceScalingMemoryPercent = altsrc.NewFloat64Flag(&cli.Float64Flag{
 		Name:        "resource-scaling-memory-percentage",

--- a/cmd/waku/main.go
+++ b/cmd/waku/main.go
@@ -41,7 +41,7 @@ func main() {
 		ExtMultiaddresses,
 		ShowAddresses,
 		CircuitRelay,
-		ForceUnreachable,
+		ForceReachability,
 		ResourceScalingMemoryPercent,
 		ResourceScalingFDPercent,
 		LogLevel,

--- a/cmd/waku/node.go
+++ b/cmd/waku/node.go
@@ -169,10 +169,18 @@ func Execute(options NodeOptions) {
 		libp2pOpts = append(libp2pOpts, libp2p.EnableRelayService())
 	}
 
-	if options.ForceUnreachable {
-		logger.Warn("node forced to be unreachable!")
-		libp2pOpts = append(libp2pOpts, libp2p.EnableRelay(), libp2p.ForceReachabilityPrivate())
+	if options.ForceReachability != "" {
+		libp2pOpts = append(libp2pOpts, libp2p.EnableRelay())
 		nodeOpts = append(nodeOpts, node.WithCircuitRelayParams(2*time.Second, 2*time.Second))
+		if options.ForceReachability == "private" {
+			logger.Warn("node forced to be unreachable!")
+			libp2pOpts = append(libp2pOpts, libp2p.ForceReachabilityPrivate())
+		} else if options.ForceReachability == "public" {
+			logger.Warn("node forced to be publicly reachable!")
+			libp2pOpts = append(libp2pOpts, libp2p.ForceReachabilityPublic())
+		} else {
+			failOnErr(errors.New("invalid reachability value"), "Reachability")
+		}
 	}
 
 	if options.UserAgent != "" {

--- a/cmd/waku/options.go
+++ b/cmd/waku/options.go
@@ -157,7 +157,7 @@ type NodeOptions struct {
 	AdvertiseAddresses           []multiaddr.Multiaddr
 	ShowAddresses                bool
 	CircuitRelay                 bool
-	ForceUnreachable             bool
+	ForceReachability            string
 	ResourceScalingMemoryPercent float64
 	ResourceScalingFDPercent     float64
 	LogLevel                     string


### PR DESCRIPTION
# Description
Replaces the `--unreachable` flag by `--reachability` which accepts the values `public` or `private` to force circuit relay to work locally.

i.e.:

node1 (circuit relay server)
```
./build/waku --reachability=public --circuit-relay --p=55344 --nodekey=1122334455667788990011223344556677889900112233445566778899001122
```

node2 (unreachable node)
```
./build/waku --reachability=private --staticnode=/ip4/192.168.0.1/tcp/55344/p2p/16Uiu2HAmMGhfSTUzKbsjMWxc6T1X4wiTWSF1bEWSLjAukCm7KiHV -p=0
```

After a while, node2 should receive a circuit relay addr from node1