### PR TITLE
Feat: filter select peer for sharding

### DIFF
--- a/waku/v2/node/wakunode2.go
+++ b/waku/v2/node/wakunode2.go
@@ -847,9 +847,19 @@ func (w *WakuNode) Peers() ([]*Peer, error) {
 	return peers, nil
 }
 
-func (w *WakuNode) PeersByShard(cluster uint16, shard uint16) peer.IDSlice {
+// PeersByShard filters peers based on shard information following static sharding
+func (w *WakuNode) PeersByStaticShard(cluster uint16, shard uint16) peer.IDSlice {
 	pTopic := wakuprotocol.NewStaticShardingPubsubTopic(cluster, shard).String()
-	return w.peerstore.(wps.WakuPeerstore).PeersByPubSubTopic(pTopic)
+	return w.peerstore.(wps.WakuPeerstore).PeersByPubSubTopic(pTopic, nil)
+}
+
+// PeersByContentTopics filters peers based on contentTopic
+func (w *WakuNode) PeersByContentTopic(contentTopic string) peer.IDSlice {
+	pTopic, err := wakuprotocol.GetPubSubTopicFromContentTopic(contentTopic)
+	if err != nil {
+		return nil
+	}
+	return w.peerstore.(wps.WakuPeerstore).PeersByPubSubTopic(pTopic, nil)
 }
 
 func (w *WakuNode) findRelayNodes(ctx context.Context) {

--- a/waku/v2/node/wakunode2.go
+++ b/waku/v2/node/wakunode2.go
@@ -850,7 +850,7 @@ func (w *WakuNode) Peers() ([]*Peer, error) {
 // PeersByShard filters peers based on shard information following static sharding
 func (w *WakuNode) PeersByStaticShard(cluster uint16, shard uint16) peer.IDSlice {
 	pTopic := wakuprotocol.NewStaticShardingPubsubTopic(cluster, shard).String()
-	return w.peerstore.(wps.WakuPeerstore).PeersByPubSubTopic(pTopic, nil)
+	return w.peerstore.(wps.WakuPeerstore).PeersByPubSubTopic(pTopic)
 }
 
 // PeersByContentTopics filters peers based on contentTopic
@@ -859,7 +859,7 @@ func (w *WakuNode) PeersByContentTopic(contentTopic string) peer.IDSlice {
 	if err != nil {
 		return nil
 	}
-	return w.peerstore.(wps.WakuPeerstore).PeersByPubSubTopic(pTopic, nil)
+	return w.peerstore.(wps.WakuPeerstore).PeersByPubSubTopic(pTopic)
 }
 
 func (w *WakuNode) findRelayNodes(ctx context.Context) {

--- a/waku/v2/peermanager/peer_manager.go
+++ b/waku/v2/peermanager/peer_manager.go
@@ -456,14 +456,15 @@ func (pm *PeerManager) SelectPeer(proto protocol.ID, pubSubTopic string, specifi
 	return utils.SelectRandomPeer(filteredPeers, pm.logger)
 }
 
-func (pm *PeerManager) selectServicePeer(proto protocol.ID, pubSubTopic string, specificPeers []peer.ID) *peer.ID {
+func (pm *PeerManager) selectServicePeer(proto protocol.ID, pubSubTopic string, specificPeers []peer.ID) (peerIDPtr *peer.ID) {
+	peerIDPtr = nil
+
 	//Try to fetch from serviceSlot
 	if slot := pm.serviceSlots.getPeers(proto); slot != nil {
 		if pubSubTopic == "" {
 			if peerID, err := slot.getRandom(); err == nil {
-				return &peerID
+				peerIDPtr = &peerID
 			}
-			return nil
 		} else { //PubsubTopic based selection
 			var keys peer.IDSlice
 			keys = make([]peer.ID, 0, len(slot.m))
@@ -472,11 +473,10 @@ func (pm *PeerManager) selectServicePeer(proto protocol.ID, pubSubTopic string, 
 			}
 			selectedPeers := pm.host.Peerstore().(wps.WakuPeerstore).PeersByPubSubTopic(pubSubTopic, keys)
 			peerID, err := utils.SelectRandomPeer(selectedPeers, pm.logger)
-			if err != nil {
-				return nil
+			if err == nil {
+				peerIDPtr = &peerID
 			}
-			return &peerID
 		}
 	}
-	return nil
+	return
 }

--- a/waku/v2/peermanager/peer_manager_test.go
+++ b/waku/v2/peermanager/peer_manager_test.go
@@ -66,7 +66,7 @@ func TestServiceSlots(t *testing.T) {
 	///////////////
 
 	// select peer from pm, currently only h2 is set in pm
-	peerID, err := pm.SelectPeer(protocol, "", nil)
+	peerID, err := pm.SelectPeer(protocol, "")
 	require.NoError(t, err)
 	require.Equal(t, peerID, h2.ID())
 
@@ -75,7 +75,7 @@ func TestServiceSlots(t *testing.T) {
 	require.NoError(t, err)
 
 	// check that returned peer is h2 or h3 peer
-	peerID, err = pm.SelectPeer(protocol, "", nil)
+	peerID, err = pm.SelectPeer(protocol, "")
 	require.NoError(t, err)
 	if peerID == h2.ID() || peerID == h3.ID() {
 		//Test success
@@ -91,7 +91,7 @@ func TestServiceSlots(t *testing.T) {
 	require.NoError(t, err)
 	defer h4.Close()
 
-	_, err = pm.SelectPeer(protocol1, "", nil)
+	_, err = pm.SelectPeer(protocol1, "")
 	require.Error(t, err, utils.ErrNoPeersAvailable)
 
 	// add h4 peer for protocol1
@@ -99,11 +99,11 @@ func TestServiceSlots(t *testing.T) {
 	require.NoError(t, err)
 
 	//Test peer selection for protocol1
-	peerID, err = pm.SelectPeer(protocol1, "", nil)
+	peerID, err = pm.SelectPeer(protocol1, "")
 	require.NoError(t, err)
 	require.Equal(t, peerID, h4.ID())
 
-	_, err = pm.SelectPeerByContentTopic(protocol1, "", nil)
+	_, err = pm.SelectPeerByContentTopic(protocol1, "")
 	require.Error(t, wakuproto.ErrInvalidFormat, err)
 
 }
@@ -127,17 +127,17 @@ func TestPeerSelection(t *testing.T) {
 	_, err = pm.AddPeer(getAddr(h3), wps.Static, []string{"/waku/rs/2/1"}, libp2pProtocol.ID(protocol))
 	require.NoError(t, err)
 
-	_, err = pm.SelectPeer(protocol, "", nil)
+	_, err = pm.SelectPeer(protocol, "")
 	require.NoError(t, err)
 
-	peerID, err := pm.SelectPeer(protocol, "/waku/rs/2/2", nil)
+	peerID, err := pm.SelectPeer(protocol, "/waku/rs/2/2")
 	require.NoError(t, err)
 	require.Equal(t, h2.ID(), peerID)
 
-	_, err = pm.SelectPeer(protocol, "/waku/rs/2/3", nil)
+	_, err = pm.SelectPeer(protocol, "/waku/rs/2/3")
 	require.Error(t, utils.ErrNoPeersAvailable, err)
 
-	_, err = pm.SelectPeer(protocol, "/waku/rs/2/1", nil)
+	_, err = pm.SelectPeer(protocol, "/waku/rs/2/1")
 	require.NoError(t, err)
 
 }
@@ -149,7 +149,7 @@ func TestDefaultProtocol(t *testing.T) {
 	// check peer for default protocol
 	///////////////
 	//Test empty peer selection for relay protocol
-	_, err := pm.SelectPeer(relay.WakuRelayID_v200, "", nil)
+	_, err := pm.SelectPeer(relay.WakuRelayID_v200, "")
 	require.Error(t, err, utils.ErrNoPeersAvailable)
 
 	///////////////
@@ -164,7 +164,7 @@ func TestDefaultProtocol(t *testing.T) {
 	require.NoError(t, err)
 
 	// since we are not passing peerList, selectPeer fn using filterByProto checks in PeerStore for peers with same protocol.
-	peerID, err := pm.SelectPeer(relay.WakuRelayID_v200, "", nil)
+	peerID, err := pm.SelectPeer(relay.WakuRelayID_v200, "")
 	require.NoError(t, err)
 	require.Equal(t, peerID, h5.ID())
 }
@@ -184,12 +184,12 @@ func TestAdditionAndRemovalOfPeer(t *testing.T) {
 	_, err = pm.AddPeer(getAddr(h6), wps.Static, []string{""}, protocol2)
 	require.NoError(t, err)
 
-	peerID, err := pm.SelectPeer(protocol2, "", nil)
+	peerID, err := pm.SelectPeer(protocol2, "")
 	require.NoError(t, err)
 	require.Equal(t, peerID, h6.ID())
 
 	pm.RemovePeer(peerID)
-	_, err = pm.SelectPeer(protocol2, "", nil)
+	_, err = pm.SelectPeer(protocol2, "")
 	require.Error(t, err, utils.ErrNoPeersAvailable)
 }
 

--- a/waku/v2/peermanager/peer_manager_test.go
+++ b/waku/v2/peermanager/peer_manager_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/waku-org/go-waku/tests"
 	wps "github.com/waku-org/go-waku/waku/v2/peerstore"
+	wakuproto "github.com/waku-org/go-waku/waku/v2/protocol"
 	"github.com/waku-org/go-waku/waku/v2/protocol/relay"
 	"github.com/waku-org/go-waku/waku/v2/utils"
 )
@@ -65,7 +66,7 @@ func TestServiceSlots(t *testing.T) {
 	///////////////
 
 	// select peer from pm, currently only h2 is set in pm
-	peerID, err := pm.SelectPeer(protocol, nil)
+	peerID, err := pm.SelectPeer(protocol, "", nil)
 	require.NoError(t, err)
 	require.Equal(t, peerID, h2.ID())
 
@@ -74,7 +75,7 @@ func TestServiceSlots(t *testing.T) {
 	require.NoError(t, err)
 
 	// check that returned peer is h2 or h3 peer
-	peerID, err = pm.SelectPeer(protocol, nil)
+	peerID, err = pm.SelectPeer(protocol, "", nil)
 	require.NoError(t, err)
 	if peerID == h2.ID() || peerID == h3.ID() {
 		//Test success
@@ -90,7 +91,7 @@ func TestServiceSlots(t *testing.T) {
 	require.NoError(t, err)
 	defer h4.Close()
 
-	_, err = pm.SelectPeer(protocol1, nil)
+	_, err = pm.SelectPeer(protocol1, "", nil)
 	require.Error(t, err, utils.ErrNoPeersAvailable)
 
 	// add h4 peer for protocol1
@@ -98,9 +99,46 @@ func TestServiceSlots(t *testing.T) {
 	require.NoError(t, err)
 
 	//Test peer selection for protocol1
-	peerID, err = pm.SelectPeer(protocol1, nil)
+	peerID, err = pm.SelectPeer(protocol1, "", nil)
 	require.NoError(t, err)
 	require.Equal(t, peerID, h4.ID())
+
+	_, err = pm.SelectPeerByContentTopic(protocol1, "", nil)
+	require.Error(t, wakuproto.ErrInvalidFormat, err)
+
+}
+
+func TestPeerSelection(t *testing.T) {
+	ctx, pm, deferFn := initTest(t)
+	defer deferFn()
+
+	h2, err := tests.MakeHost(ctx, 0, rand.Reader)
+	require.NoError(t, err)
+	defer h2.Close()
+
+	h3, err := tests.MakeHost(ctx, 0, rand.Reader)
+	require.NoError(t, err)
+	defer h3.Close()
+
+	protocol := libp2pProtocol.ID("test/protocol")
+	_, err = pm.AddPeer(getAddr(h2), wps.Static, []string{"/waku/rs/2/1", "/waku/rs/2/2"}, libp2pProtocol.ID(protocol))
+	require.NoError(t, err)
+
+	_, err = pm.AddPeer(getAddr(h3), wps.Static, []string{"/waku/rs/2/1"}, libp2pProtocol.ID(protocol))
+	require.NoError(t, err)
+
+	_, err = pm.SelectPeer(protocol, "", nil)
+	require.NoError(t, err)
+
+	peerID, err := pm.SelectPeer(protocol, "/waku/rs/2/2", nil)
+	require.NoError(t, err)
+	require.Equal(t, h2.ID(), peerID)
+
+	_, err = pm.SelectPeer(protocol, "/waku/rs/2/3", nil)
+	require.Error(t, utils.ErrNoPeersAvailable, err)
+
+	_, err = pm.SelectPeer(protocol, "/waku/rs/2/1", nil)
+	require.NoError(t, err)
 
 }
 
@@ -111,7 +149,7 @@ func TestDefaultProtocol(t *testing.T) {
 	// check peer for default protocol
 	///////////////
 	//Test empty peer selection for relay protocol
-	_, err := pm.SelectPeer(relay.WakuRelayID_v200, nil)
+	_, err := pm.SelectPeer(relay.WakuRelayID_v200, "", nil)
 	require.Error(t, err, utils.ErrNoPeersAvailable)
 
 	///////////////
@@ -126,7 +164,7 @@ func TestDefaultProtocol(t *testing.T) {
 	require.NoError(t, err)
 
 	// since we are not passing peerList, selectPeer fn using filterByProto checks in PeerStore for peers with same protocol.
-	peerID, err := pm.SelectPeer(relay.WakuRelayID_v200, nil)
+	peerID, err := pm.SelectPeer(relay.WakuRelayID_v200, "", nil)
 	require.NoError(t, err)
 	require.Equal(t, peerID, h5.ID())
 }
@@ -146,12 +184,12 @@ func TestAdditionAndRemovalOfPeer(t *testing.T) {
 	_, err = pm.AddPeer(getAddr(h6), wps.Static, []string{""}, protocol2)
 	require.NoError(t, err)
 
-	peerID, err := pm.SelectPeer(protocol2, nil)
+	peerID, err := pm.SelectPeer(protocol2, "", nil)
 	require.NoError(t, err)
 	require.Equal(t, peerID, h6.ID())
 
 	pm.RemovePeer(peerID)
-	_, err = pm.SelectPeer(protocol2, nil)
+	_, err = pm.SelectPeer(protocol2, "", nil)
 	require.Error(t, err, utils.ErrNoPeersAvailable)
 }
 

--- a/waku/v2/peermanager/topic_event_handler.go
+++ b/waku/v2/peermanager/topic_event_handler.go
@@ -33,7 +33,7 @@ func (pm *PeerManager) handleNewRelayTopicSubscription(pubsubTopic string, topic
 	pm.subRelayTopics[pubsubTopic] = &NodeTopicDetails{topicInst}
 	//Check how many relay peers we are connected to that subscribe to this topic, if less than D find peers in peerstore and connect.
 	//If no peers in peerStore, trigger discovery for this topic?
-	relevantPeersForPubSubTopic := pm.host.Peerstore().(*wps.WakuPeerstoreImpl).PeersByPubSubTopic(pubsubTopic, nil)
+	relevantPeersForPubSubTopic := pm.host.Peerstore().(*wps.WakuPeerstoreImpl).PeersByPubSubTopic(pubsubTopic)
 	var notConnectedPeers peer.IDSlice
 	connectedPeers := 0
 	for _, peer := range relevantPeersForPubSubTopic {
@@ -91,7 +91,7 @@ func (pm *PeerManager) handleNewRelayTopicUnSubscription(pubsubTopic string) {
 	delete(pm.subRelayTopics, pubsubTopic)
 
 	//If there are peers only subscribed to this topic, disconnect them.
-	relevantPeersForPubSubTopic := pm.host.Peerstore().(*wps.WakuPeerstoreImpl).PeersByPubSubTopic(pubsubTopic, nil)
+	relevantPeersForPubSubTopic := pm.host.Peerstore().(*wps.WakuPeerstoreImpl).PeersByPubSubTopic(pubsubTopic)
 	for _, peer := range relevantPeersForPubSubTopic {
 		if pm.host.Network().Connectedness(peer) == network.Connected {
 			peerTopics, err := pm.host.Peerstore().(*wps.WakuPeerstoreImpl).PubSubTopics(peer)

--- a/waku/v2/peermanager/topic_event_handler.go
+++ b/waku/v2/peermanager/topic_event_handler.go
@@ -33,7 +33,7 @@ func (pm *PeerManager) handleNewRelayTopicSubscription(pubsubTopic string, topic
 	pm.subRelayTopics[pubsubTopic] = &NodeTopicDetails{topicInst}
 	//Check how many relay peers we are connected to that subscribe to this topic, if less than D find peers in peerstore and connect.
 	//If no peers in peerStore, trigger discovery for this topic?
-	relevantPeersForPubSubTopic := pm.host.Peerstore().(*wps.WakuPeerstoreImpl).PeersByPubSubTopic(pubsubTopic)
+	relevantPeersForPubSubTopic := pm.host.Peerstore().(*wps.WakuPeerstoreImpl).PeersByPubSubTopic(pubsubTopic, nil)
 	var notConnectedPeers peer.IDSlice
 	connectedPeers := 0
 	for _, peer := range relevantPeersForPubSubTopic {
@@ -91,7 +91,7 @@ func (pm *PeerManager) handleNewRelayTopicUnSubscription(pubsubTopic string) {
 	delete(pm.subRelayTopics, pubsubTopic)
 
 	//If there are peers only subscribed to this topic, disconnect them.
-	relevantPeersForPubSubTopic := pm.host.Peerstore().(*wps.WakuPeerstoreImpl).PeersByPubSubTopic(pubsubTopic)
+	relevantPeersForPubSubTopic := pm.host.Peerstore().(*wps.WakuPeerstoreImpl).PeersByPubSubTopic(pubsubTopic, nil)
 	for _, peer := range relevantPeersForPubSubTopic {
 		if pm.host.Network().Connectedness(peer) == network.Connected {
 			peerTopics, err := pm.host.Peerstore().(*wps.WakuPeerstoreImpl).PubSubTopics(peer)

--- a/waku/v2/peerstore/waku_peer_store.go
+++ b/waku/v2/peerstore/waku_peer_store.go
@@ -59,7 +59,7 @@ type WakuPeerstore interface {
 	RemovePubSubTopic(p peer.ID, topic string) error
 	PubSubTopics(p peer.ID) ([]string, error)
 	SetPubSubTopics(p peer.ID, topics []string) error
-	PeersByPubSubTopic(pubSubTopic string, specificPeers peer.IDSlice) peer.IDSlice
+	PeersByPubSubTopic(pubSubTopic string, specificPeers ...peer.ID) peer.IDSlice
 }
 
 // NewWakuPeerstore creates a new WakuPeerStore object
@@ -209,7 +209,7 @@ func (ps *WakuPeerstoreImpl) PubSubTopics(p peer.ID) ([]string, error) {
 
 // PeersByPubSubTopic Returns list of peers by pubSubTopic
 // If specifiPeers are listed, filtering is done from them otherwise from all peers in peerstore
-func (ps *WakuPeerstoreImpl) PeersByPubSubTopic(pubSubTopic string, specificPeers peer.IDSlice) peer.IDSlice {
+func (ps *WakuPeerstoreImpl) PeersByPubSubTopic(pubSubTopic string, specificPeers ...peer.ID) peer.IDSlice {
 	if specificPeers == nil {
 		specificPeers = ps.Peers()
 	}

--- a/waku/v2/peerstore/waku_peer_store.go
+++ b/waku/v2/peerstore/waku_peer_store.go
@@ -59,7 +59,7 @@ type WakuPeerstore interface {
 	RemovePubSubTopic(p peer.ID, topic string) error
 	PubSubTopics(p peer.ID) ([]string, error)
 	SetPubSubTopics(p peer.ID, topics []string) error
-	PeersByPubSubTopic(pubSubTopic string) peer.IDSlice
+	PeersByPubSubTopic(pubSubTopic string, specificPeers peer.IDSlice) peer.IDSlice
 }
 
 // NewWakuPeerstore creates a new WakuPeerStore object
@@ -208,9 +208,13 @@ func (ps *WakuPeerstoreImpl) PubSubTopics(p peer.ID) ([]string, error) {
 }
 
 // PeersByPubSubTopic Returns list of peers by pubSubTopic
-func (ps *WakuPeerstoreImpl) PeersByPubSubTopic(pubSubTopic string) peer.IDSlice {
+// If specifiPeers are listed, filtering is done from them otherwise from all peers in peerstore
+func (ps *WakuPeerstoreImpl) PeersByPubSubTopic(pubSubTopic string, specificPeers peer.IDSlice) peer.IDSlice {
+	if specificPeers == nil {
+		specificPeers = ps.Peers()
+	}
 	var result peer.IDSlice
-	for _, p := range ps.Peers() {
+	for _, p := range specificPeers {
 		topics, err := ps.PubSubTopics(p)
 		if err == nil {
 			for _, topic := range topics {

--- a/waku/v2/protocol/filter/options.go
+++ b/waku/v2/protocol/filter/options.go
@@ -60,7 +60,7 @@ func WithAutomaticPeerSelection(fromThesePeers ...peer.ID) FilterSubscribeOption
 		if params.pm == nil {
 			p, err = utils.SelectPeer(params.host, FilterSubscribeID_v20beta1, fromThesePeers, params.log)
 		} else {
-			p, err = params.pm.SelectPeer(FilterSubscribeID_v20beta1, fromThesePeers)
+			p, err = params.pm.SelectPeer(FilterSubscribeID_v20beta1, "", fromThesePeers)
 		}
 		if err == nil {
 			params.selectedPeer = p

--- a/waku/v2/protocol/filter/options.go
+++ b/waku/v2/protocol/filter/options.go
@@ -60,7 +60,7 @@ func WithAutomaticPeerSelection(fromThesePeers ...peer.ID) FilterSubscribeOption
 		if params.pm == nil {
 			p, err = utils.SelectPeer(params.host, FilterSubscribeID_v20beta1, fromThesePeers, params.log)
 		} else {
-			p, err = params.pm.SelectPeer(FilterSubscribeID_v20beta1, "", fromThesePeers)
+			p, err = params.pm.SelectPeer(FilterSubscribeID_v20beta1, "", fromThesePeers...)
 		}
 		if err == nil {
 			params.selectedPeer = p

--- a/waku/v2/protocol/lightpush/waku_lightpush_option.go
+++ b/waku/v2/protocol/lightpush/waku_lightpush_option.go
@@ -40,7 +40,7 @@ func WithAutomaticPeerSelection(fromThesePeers ...peer.ID) Option {
 		if params.pm == nil {
 			p, err = utils.SelectPeer(params.host, LightPushID_v20beta1, fromThesePeers, params.log)
 		} else {
-			p, err = params.pm.SelectPeer(LightPushID_v20beta1, "", fromThesePeers)
+			p, err = params.pm.SelectPeer(LightPushID_v20beta1, "", fromThesePeers...)
 		}
 		if err == nil {
 			params.selectedPeer = p

--- a/waku/v2/protocol/lightpush/waku_lightpush_option.go
+++ b/waku/v2/protocol/lightpush/waku_lightpush_option.go
@@ -40,7 +40,7 @@ func WithAutomaticPeerSelection(fromThesePeers ...peer.ID) Option {
 		if params.pm == nil {
 			p, err = utils.SelectPeer(params.host, LightPushID_v20beta1, fromThesePeers, params.log)
 		} else {
-			p, err = params.pm.SelectPeer(LightPushID_v20beta1, fromThesePeers)
+			p, err = params.pm.SelectPeer(LightPushID_v20beta1, "", fromThesePeers)
 		}
 		if err == nil {
 			params.selectedPeer = p

--- a/waku/v2/protocol/peer_exchange/waku_peer_exchange_option.go
+++ b/waku/v2/protocol/peer_exchange/waku_peer_exchange_option.go
@@ -37,7 +37,7 @@ func WithAutomaticPeerSelection(fromThesePeers ...peer.ID) PeerExchangeOption {
 		if params.pm == nil {
 			p, err = utils.SelectPeer(params.host, PeerExchangeID_v20alpha1, fromThesePeers, params.log)
 		} else {
-			p, err = params.pm.SelectPeer(PeerExchangeID_v20alpha1, fromThesePeers)
+			p, err = params.pm.SelectPeer(PeerExchangeID_v20alpha1, "", fromThesePeers)
 		}
 		if err == nil {
 			params.selectedPeer = p

--- a/waku/v2/protocol/peer_exchange/waku_peer_exchange_option.go
+++ b/waku/v2/protocol/peer_exchange/waku_peer_exchange_option.go
@@ -37,7 +37,7 @@ func WithAutomaticPeerSelection(fromThesePeers ...peer.ID) PeerExchangeOption {
 		if params.pm == nil {
 			p, err = utils.SelectPeer(params.host, PeerExchangeID_v20alpha1, fromThesePeers, params.log)
 		} else {
-			p, err = params.pm.SelectPeer(PeerExchangeID_v20alpha1, "", fromThesePeers)
+			p, err = params.pm.SelectPeer(PeerExchangeID_v20alpha1, "", fromThesePeers...)
 		}
 		if err == nil {
 			params.selectedPeer = p

--- a/waku/v2/protocol/store/waku_store_client.go
+++ b/waku/v2/protocol/store/waku_store_client.go
@@ -111,7 +111,7 @@ func WithAutomaticPeerSelection(fromThesePeers ...peer.ID) HistoryRequestOption 
 		if params.s.pm == nil {
 			p, err = utils.SelectPeer(params.s.h, StoreID_v20beta4, fromThesePeers, params.s.log)
 		} else {
-			p, err = params.s.pm.SelectPeer(StoreID_v20beta4, fromThesePeers)
+			p, err = params.s.pm.SelectPeer(StoreID_v20beta4, "", fromThesePeers)
 		}
 		if err == nil {
 			params.selectedPeer = p

--- a/waku/v2/protocol/store/waku_store_client.go
+++ b/waku/v2/protocol/store/waku_store_client.go
@@ -111,7 +111,7 @@ func WithAutomaticPeerSelection(fromThesePeers ...peer.ID) HistoryRequestOption 
 		if params.s.pm == nil {
 			p, err = utils.SelectPeer(params.s.h, StoreID_v20beta4, fromThesePeers, params.s.log)
 		} else {
-			p, err = params.s.pm.SelectPeer(StoreID_v20beta4, "", fromThesePeers)
+			p, err = params.s.pm.SelectPeer(StoreID_v20beta4, "", fromThesePeers...)
 		}
 		if err == nil {
 			params.selectedPeer = p


### PR DESCRIPTION
# Description
Current selectPeer functionality works without taking sharding into consideration. #680  
This enhances to take pubSubTopic or contentTopic into consideration during peer selection.

# Changes

- [x] Updated selectPeer function to take pubSub topic as argument
- [x] Added a new function to selectPeer based on contentTopic

# Tests

Ran all existing unit tests.
Added few new ones to validate functionality.

