### PR TITLE
Chore: test cov improvement

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ test-with-race:
 	${GOBIN} test -race -timeout 300s ./waku/... 
 
 test:
-	${GOBIN} test -timeout 300s ./waku/... -coverprofile=${GO_TEST_OUTFILE}.tmp
+	${GOBIN} test -timeout 300s ./waku/... -coverprofile=${GO_TEST_OUTFILE}.tmp -coverpkg ./...
 	cat ${GO_TEST_OUTFILE}.tmp | grep -v ".pb.go" > ${GO_TEST_OUTFILE}
 	${GOBIN} tool cover -html=${GO_TEST_OUTFILE} -o ${GO_HTML_COV}
 

--- a/waku/v2/node/wakunode2_test.go
+++ b/waku/v2/node/wakunode2_test.go
@@ -53,6 +53,13 @@ func TestWakuNode2(t *testing.T) {
 	err = wakuNode.Start(ctx)
 	require.NoError(t, err)
 
+	_, err = wakuNode.Relay().SubscribeToTopic(ctx, "waku/rs/1/1")
+	require.NoError(t, err)
+	time.Sleep(time.Second * 1)
+
+	err = wakuNode.Relay().Unsubscribe(ctx, "waku/rs/1/1")
+	require.NoError(t, err)
+
 	defer wakuNode.Stop()
 }
 


### PR DESCRIPTION
# Description
By using -coverpkg flag, coverage is reported from tests that are run outside a package.
In most cases since tests run on waku/v2/node cover many areas under protocol etc, coverage percentage is not updated.
Similarly if tests are in a separate folder, then coverage is not updated for tests run.

Also added few additional tests to improve coverage in recently added code.