### PR TITLE
refactor(c-bindings): userdata

### DIFF
--- a/examples/c-bindings/main.c
+++ b/examples/c-bindings/main.c
@@ -1,41 +1,52 @@
-#include <stdbool.h>
-#include <stdio.h>
-#include <string.h>
-#include <unistd.h>
-#include <time.h>
-#include <stdint.h>
-#include <inttypes.h>
 
+#include "main.h"
+#include "base64.h"
 #include "libgowaku.h"
 #include "nxjson.c"
-#include "base64.h"
-#include "main.h"
+#include <inttypes.h>
+#include <unistd.h>
 
-char *alicePrivKey = "0x4f012057e1a1458ce34189cb27daedbbe434f3df0825c1949475dec786e2c64e";
-char *alicePubKey = "0x0440f05847c4c7166f57ae8ecaaf72d31bddcbca345e26713ca9e26c93fb8362ddcd5ae7f4533ee956428ad08a89cd18b234c2911a3b1c7fbd1c0047610d987302";
+char *alicePrivKey =
+    "0x4f012057e1a1458ce34189cb27daedbbe434f3df0825c1949475dec786e2c64e";
+char *alicePubKey =
+    "0x0440f05847c4c7166f57ae8ecaaf72d31bddcbca345e26713ca9e26c93fb8362ddcd5ae7"
+    "f4533ee956428ad08a89cd18b234c2911a3b1c7fbd1c0047610d987302";
 
-char *bobPrivKey = "0xb91d6b2df8fb6ef8b53b51b2b30a408c49d5e2b530502d58ac8f94e5c5de1453";
-char *bobPubKey = "0x045eef61a98ba1cf44a2736fac91183ea2bd86e67de20fe4bff467a71249a8a0c05f795dd7f28ced7c15eaa69c89d4212cc4f526ca5e9a62e88008f506d850cccd";
+char *bobPrivKey =
+    "0xb91d6b2df8fb6ef8b53b51b2b30a408c49d5e2b530502d58ac8f94e5c5de1453";
+char *bobPubKey =
+    "0x045eef61a98ba1cf44a2736fac91183ea2bd86e67de20fe4bff467a71249a8a0c05f795d"
+    "d7f28ced7c15eaa69c89d4212cc4f526ca5e9a62e88008f506d850cccd";
 
+void on_error(int ret, const char *result, void *user_data) {
+  if (ret == 0) {
+    return;
+  }
 
-char* result = NULL;
-char* contentTopic;
-
-void handle_ok(const char* msg, size_t len) {
-    if (result != NULL) {
-        free(result);
-    }
-    result = malloc(len * sizeof(char) + 1);
-    strcpy(result, msg);
+  printf("function execution failed. Returned code: %d\n", ret);
+  exit(1);
 }
 
-void handle_error(const char* msg, size_t len) {
-    printf("Error: %s\n", msg);
+void on_response(int ret, const char *result, void *user_data) {
+  if (ret != 0) {
+    printf("function execution failed. Returned code: %d\n", ret);
     exit(1);
+  }
+
+  if (user_data == NULL)
+    return;
+
+  char **data_ref = (char **)user_data;
+  size_t len = strlen(result);
+
+  if (*data_ref != NULL)
+    free(*data_ref);
+
+  *data_ref = malloc(len * sizeof(char) + 1);
+  strcpy(*data_ref, result);
 }
 
-void callBack(const char* signal, size_t len_0)
-{
+void callBack(int ret, const char *signal, void *user_data) {
   // This callback will be executed each time a new message is received
 
   // Example signal:
@@ -54,32 +65,43 @@ void callBack(const char* signal, size_t len_0)
       }
     }*/
 
-  const nx_json *json = nx_json_parse((char*) signal, 0);
+  if (ret != 0) {
+    printf("function execution failed. Returned code: %d\n", ret);
+    exit(1);
+  }
+
+  const nx_json *json = nx_json_parse((char *)signal, 0);
   const char *type = nx_json_get(json, "type")->text_value;
 
-  if (strcmp(type, "message") == 0)
-  {
-    const nx_json *wakuMsgJson = nx_json_get(nx_json_get(json, "event"), "wakuMessage");
-    const char *contentTopic = nx_json_get(wakuMsgJson, "contentTopic")->text_value;
+  if (strcmp(type, "message") == 0) {
+    const nx_json *wakuMsgJson =
+        nx_json_get(nx_json_get(json, "event"), "wakuMessage");
+    const char *contentTopic =
+        nx_json_get(wakuMsgJson, "contentTopic")->text_value;
 
-    if (strcmp(contentTopic, contentTopic) == 0)
-    {
-      char* msg = utils_extract_wakumessage_from_signal(wakuMsgJson);
-      WAKU_CALL(waku_decode_asymmetric(msg, bobPrivKey, handle_ok, handle_error));
+    if (strcmp(contentTopic, "/example/1/default/rfc26") == 0) {
+      char *msg = utils_extract_wakumessage_from_signal(wakuMsgJson);
 
-      char *decodedMsg = strdup(result);
+      // Decode a message using asymmetric encryption
+      char *decodedMsg = NULL;
+      waku_decode_asymmetric(msg, bobPrivKey, on_response, (void *)&decodedMsg);
 
       const nx_json *dataJson = nx_json_parse(decodedMsg, 0);
 
       const char *pubkey = nx_json_get(dataJson, "pubkey")->text_value;
       const char *base64data = nx_json_get(dataJson, "data")->text_value;
-          
+
       size_t data_len = b64_decoded_size(base64data);
-      char *data = malloc(data_len);
-    
-      b64_decode(base64data,  (unsigned char *)data, data_len) ;
+      unsigned char *data = malloc(data_len);
+
+      b64_decode(base64data, data, data_len);
 
       printf(">>> Received \"%s\" from %s\n", data, pubkey);
+
+      free(msg);
+      free(decodedMsg);
+      free(data);
+
       fflush(stdout);
     }
   }
@@ -87,79 +109,113 @@ void callBack(const char* signal, size_t len_0)
   nx_json_free(json);
 }
 
-int main(int argc, char *argv[])
-{
+int main(int argc, char *argv[]) {
+  // Set callback to be executed each time a message is received
   waku_set_event_callback(callBack);
 
-  char *configJSON = "{\"host\": \"0.0.0.0\", \"port\": 60000, \"logLevel\":\"error\", \"store\":true}";
-  WAKU_CALL( waku_new(configJSON, handle_error) );  // configJSON can be NULL too to use defaults
+  // configJSON can be NULL too to use defaults. Any value not defined will have
+  // a default set
+  char *configJSON = "{\"host\": \"0.0.0.0\", \"port\": 60000, "
+                     "\"logLevel\":\"error\", \"store\":true}";
+  waku_new(configJSON, on_error, NULL);
 
-  WAKU_CALL(waku_start(handle_error) ); // Start the node, enabling the waku protocols
+  // Start the node, enabling the waku protocols
+  waku_start(on_error, NULL);
 
-  WAKU_CALL(waku_peerid(handle_ok, handle_error)); // Obtain the node peerID
-  char *peerID = strdup(result);
-  printf("PeerID: %s\n", result);
+  // Obtain the node's peerID
+  char *peerID = NULL;
+  waku_peerid(on_response, (void *)&peerID);
+  printf("PeerID: %s\n", peerID);
 
-  WAKU_CALL(waku_content_topic("example", 1, "default", "rfc26", handle_ok));
-  contentTopic = strdup(result);
-  
-  WAKU_CALL(waku_connect("/dns4/node-01.gc-us-central1-a.wakuv2.test.statusim.net/tcp/30303/p2p/16Uiu2HAmJb2e28qLXxT5kZxVUUoJt72EMzNGXB47Rxx5hw3q4YjS", 0, handle_error)); // Connect to a node
+  // Obtain the node's multiaddresses
+  char *addresses = NULL;
+  waku_listen_addresses(on_response, (void *)&addresses);
+  printf("Addresses: %s\n", addresses);
+
+  // Build a content topic
+  char *contentTopic = NULL;
+  waku_content_topic("example", 1, "default", "rfc26", on_response,
+                     (void *)&contentTopic);
+  printf("Content Topic: %s\n", contentTopic);
+
+  // Obtain the default pubsub topic
+  char *defaultPubsubTopic = NULL;
+  waku_default_pubsub_topic(on_response, (void *)&defaultPubsubTopic);
+  printf("Default pubsub topic: %s\n", defaultPubsubTopic);
 
   // To use dns discovery, and retrieve nodes from a enrtree url
- WAKU_CALL( waku_dns_discovery("enrtree://AO47IDOLBKH72HIZZOXQP6NMRESAN7CHYWIBNXDXWRJRZWLODKII6@test.wakuv2.nodes.status.im", "", 0, handle_ok, handle_error)); // Discover Nodes
-  printf("Discovered nodes: %s\n", result);
-  
-  WAKU_CALL(waku_default_pubsub_topic(handle_ok));
-  char *pubsubTopic = strdup(result);
-  printf("Default pubsub topic: %s\n", pubsubTopic);
+  char *discoveredNodes = NULL;
+  waku_dns_discovery("enrtree://"
+                     "AOGECG2SPND25EEFMAJ5WF3KSGJNSGV356DSTL2YVLLZWIV"
+                     "6SAYBM@test.waku.nodes.status.im",
+                     "", 0, on_response, (void *)&discoveredNodes);
+  printf("Discovered nodes: %s\n", discoveredNodes);
+
+  // Connect to a node
+  waku_connect("/dns4/node-01.do-ams3.wakuv2.test.statusim.net/tcp/30303/"
+               "p2p/16Uiu2HAmPLe7Mzm8TsYUubgCAW1aJoeFScxrLj8ppHFivPo97bUZ",
+               0, on_response, NULL);
 
   // To see a store query in action:
-  /*
-  char query[1000];
-  sprintf(query, "{\"pubsubTopic\":\"%s\", \"pagingOptions\":{\"pageSize\": 40, \"forward\":false}}", pubsubTopic);
-  WAKU_CALL(waku_store_query(query, NULL, 0, handle_ok, handle_error));
-  printf("%s\n",result);
-  */
-
-  WAKU_CALL( waku_relay_subscribe(NULL, handle_error));
+  // char query[1000];
+  // sprintf(query,
+  //        "{\"pubsubTopic\":\"%s\", \"pagingOptions\":{\"pageSize\": 40,  "
+  //        "\"forward\":false}}",
+  //        pubsubTopic);
+  // char *query_result = NULL;
+  // waku_store_query(query, NULL, 0, on_response, (void*)&query_result);
+  // printf("%s\n", query_result);
+  char contentFilter[1000];
+    sprintf(contentFilter,
+            "{\"pubsubTopic\":\"%s\",\"contentTopics\":[\"%s\"]}",
+            defaultPubsubTopic, contentTopic);
+  waku_relay_subscribe(contentFilter, on_error, NULL);
 
   int i = 0;
   int version = 1;
-  while (i < 5)
-  {
+  while (i < 5) {
     i++;
 
     char wakuMsg[1000];
-    char *msgPayload = b64_encode("Hello World!", 12);
+    unsigned char plain_text[] = "Hello World!";
+    char *msgPayload = b64_encode(&plain_text[0], 12);
 
-    sprintf(wakuMsg, "{\"payload\":\"%s\",\"contentTopic\":\"%s\",\"timestamp\":%"PRIu64"}", msgPayload, contentTopic, nowInNanosecs());
+    // Build the waku message
+    sprintf(wakuMsg,
+            "{\"payload\":\"%s\",\"contentTopic\":\"%s\",\"timestamp\":%" PRIu64
+            "}",
+            msgPayload, contentTopic, nowInNanosecs());
     free(msgPayload);
 
+    // Use asymmetric encryption to encrypt the waku message
+    char *encodedMessage = NULL;
+    waku_encode_asymmetric(wakuMsg, bobPubKey, alicePrivKey, on_response,
+                           (void *)&encodedMessage);
 
-    WAKU_CALL(waku_encode_asymmetric(wakuMsg, bobPubKey, alicePrivKey, handle_ok, handle_error));
-    char *encodedMessage = strdup(result);
-
-    WAKU_CALL(waku_relay_publish(encodedMessage, NULL, 0, handle_ok, handle_error)); // Broadcast via waku relay
-    printf("C\n");
-
-    char *messageID = strdup(result);
-    printf("MessageID: %s\n",messageID);
-
-    free(messageID);
+    // Broadcast via waku relay
+    char *messageID = NULL;
+    waku_relay_publish(encodedMessage, defaultPubsubTopic, 0, on_response,
+                       (void *)&messageID);
+    printf("MessageID: %s\n", messageID);
 
     sleep(1);
   }
 
-    
-  // To retrieve messages from local store, set store:true in the node config, and use waku_store_local_query
-  /*
-  char query[1000];
-  sprintf(query, "{\"pubsubTopic\":\"%s\", \"pagingOptions\":{\"pageSize\": 40, \"forward\":false}}", pubsubTopic);
-  WAKU_CALL(waku_store_local_query(query, handle_ok, handle_error));
-  printf("%s\n",result);
-  */
+  // To retrieve messages from local store, set store:true in the node
+  // config, and use waku_store_local_query
+  // char query2[1000];
+  // sprintf(query2,
+  //        "{\"pubsubTopic\":\"%s\", \"pagingOptions\":{\"pageSize\":  40, "
+  //        "\"forward\":false}}",
+  //        pubsubTopic);
+  // char *local_result = NULL;
+  // waku_store_local_query(query2, on_response, (void*)&local_result);
+  // printf("%s\n", local_result);
 
-  WAKU_CALL(waku_stop(handle_error));
-  
+  // Stop the node's execution
+  waku_stop(on_response, NULL);
+
+  // TODO: free all char*
+
   return 0;
 }

--- a/examples/c-bindings/main.h
+++ b/examples/c-bindings/main.h
@@ -2,6 +2,8 @@
 #define MAIN_H
 
 #include <stdbool.h>
+#include <time.h>
+#include <stdint.h>
 #include "nxjson.c"
 
 /// Convert seconds to nanoseconds

--- a/library/c/api.go
+++ b/library/c/api.go
@@ -6,11 +6,11 @@ package main
 #include <stddef.h>
 
 // The possible returned values for the functions that return int
-#define RET_OK                0
-#define RET_ERR               1
-#define RET_MISSING_CALLBACK  2
+static const int RET_OK = 0;
+static const int RET_ERR = 1;
+static const int RET_MISSING_CALLBACK = 2;
 
-typedef void (*WakuCallBack) (const char* msg, size_t len_0);
+typedef void (*WakuCallBack) (int ret_code, const char* msg, void * user_data);
 */
 import "C"
 import (
@@ -20,10 +20,6 @@ import (
 	"github.com/waku-org/go-waku/library"
 	"github.com/waku-org/go-waku/waku/v2/protocol"
 )
-
-const retOk = C.RET_OK
-const retErr = C.RET_ERR
-const retMissingCallback = C.RET_MISSING_CALLBACK
 
 func main() {}
 
@@ -92,25 +88,25 @@ func main() {}
 // - dns4DomainName: the domain name resolving to the node's public IPv4 address.
 //
 //export waku_new
-func waku_new(configJSON *C.char, onErrCb C.WakuCallBack) C.int {
+func waku_new(configJSON *C.char, cb C.WakuCallBack, userData unsafe.Pointer) C.int {
 	err := library.NewNode(C.GoString(configJSON))
-	return execErrCB(onErrCb, err)
+	return onError(err, cb, userData)
 }
 
 // Starts the waku node
 //
 //export waku_start
-func waku_start(onErrCb C.WakuCallBack) C.int {
+func waku_start(onErr C.WakuCallBack, userData unsafe.Pointer) C.int {
 	err := library.Start()
-	return execErrCB(onErrCb, err)
+	return onError(err, onErr, userData)
 }
 
 // Stops a waku node
 //
 //export waku_stop
-func waku_stop(onErrCb C.WakuCallBack) C.int {
+func waku_stop(onErr C.WakuCallBack, userData unsafe.Pointer) C.int {
 	err := library.Stop()
-	return execErrCB(onErrCb, err)
+	return onError(err, onErr, userData)
 }
 
 // Determine is a node is started or not
@@ -126,96 +122,96 @@ func waku_is_started() C.int {
 
 type fn func() (string, error)
 
-func singleFnExec(f fn, onOkCb C.WakuCallBack, onErrCb C.WakuCallBack) C.int {
+func singleFnExec(f fn, cb C.WakuCallBack, userData unsafe.Pointer) C.int {
 	result, err := f()
 	if err != nil {
-		return execErrCB(onErrCb, err)
+		return onError(err, cb, userData)
 	}
-	return execOkCB(onOkCb, result)
+	return onSuccesfulResponse(result, cb, userData)
 }
 
 // Obtain the peer ID of the waku node
 //
 //export waku_peerid
-func waku_peerid(onOkCb C.WakuCallBack, onErrCb C.WakuCallBack) C.int {
+func waku_peerid(cb C.WakuCallBack, userData unsafe.Pointer) C.int {
 	return singleFnExec(func() (string, error) {
 		return library.PeerID()
-	}, onOkCb, onErrCb)
+	}, cb, userData)
 }
 
 // Obtain the multiaddresses the wakunode is listening to
 //
 //export waku_listen_addresses
-func waku_listen_addresses(onOkCb C.WakuCallBack, onErrCb C.WakuCallBack) C.int {
+func waku_listen_addresses(cb C.WakuCallBack, userData unsafe.Pointer) C.int {
 	return singleFnExec(func() (string, error) {
 		return library.ListenAddresses()
-	}, onOkCb, onErrCb)
+	}, cb, userData)
 }
 
 // Add node multiaddress and protocol to the wakunode peerstore
 //
 //export waku_add_peer
-func waku_add_peer(address *C.char, protocolID *C.char, onOkCb C.WakuCallBack, onErrCb C.WakuCallBack) C.int {
+func waku_add_peer(address *C.char, protocolID *C.char, cb C.WakuCallBack, userData unsafe.Pointer) C.int {
 	return singleFnExec(func() (string, error) {
 		return library.AddPeer(C.GoString(address), C.GoString(protocolID))
-	}, onOkCb, onErrCb)
+	}, cb, userData)
 }
 
 // Connect to peer at multiaddress. if ms > 0, cancel the function execution if it takes longer than N milliseconds
 //
 //export waku_connect
-func waku_connect(address *C.char, ms C.int, onErrCb C.WakuCallBack) C.int {
+func waku_connect(address *C.char, ms C.int, cb C.WakuCallBack, userData unsafe.Pointer) C.int {
 	err := library.Connect(C.GoString(address), int(ms))
-	return execErrCB(onErrCb, err)
+	return onError(err, cb, userData)
 }
 
 // Connect to known peer by peerID. if ms > 0, cancel the function execution if it takes longer than N milliseconds
 //
 //export waku_connect_peerid
-func waku_connect_peerid(peerID *C.char, ms C.int, onErrCb C.WakuCallBack) C.int {
+func waku_connect_peerid(peerID *C.char, ms C.int, cb C.WakuCallBack, userData unsafe.Pointer) C.int {
 	err := library.ConnectPeerID(C.GoString(peerID), int(ms))
-	return execErrCB(onErrCb, err)
+	return onError(err, cb, userData)
 }
 
 // Close connection to a known peer by peerID
 //
 //export waku_disconnect
-func waku_disconnect(peerID *C.char, onErrCb C.WakuCallBack) C.int {
+func waku_disconnect(peerID *C.char, cb C.WakuCallBack, userData unsafe.Pointer) C.int {
 	err := library.Disconnect(C.GoString(peerID))
-	return execErrCB(onErrCb, err)
+	return onError(err, cb, userData)
 }
 
 // Get number of connected peers
 //
 //export waku_peer_cnt
-func waku_peer_cnt(onOkCb C.WakuCallBack, onErrCb C.WakuCallBack) C.int {
+func waku_peer_cnt(cb C.WakuCallBack, userData unsafe.Pointer) C.int {
 	return singleFnExec(func() (string, error) {
 		peerCnt, err := library.PeerCnt()
 		return fmt.Sprintf("%d", peerCnt), err
-	}, onOkCb, onErrCb)
+	}, cb, userData)
 }
 
 // Create a content topic string according to RFC 23
 //
 //export waku_content_topic
-func waku_content_topic(applicationName *C.char, applicationVersion C.uint, contentTopicName *C.char, encoding *C.char, onOkCb C.WakuCallBack) C.int {
+func waku_content_topic(applicationName *C.char, applicationVersion C.uint, contentTopicName *C.char, encoding *C.char, cb C.WakuCallBack, userData unsafe.Pointer) C.int {
 	contentTopic, _ := protocol.NewContentTopic(C.GoString(applicationName), uint32(applicationVersion), C.GoString(contentTopicName), C.GoString(encoding))
-	return execOkCB(onOkCb, contentTopic.String())
+	return onSuccesfulResponse(contentTopic.String(), cb, userData)
 }
 
 // Create a pubsub topic string according to RFC 23
 //
 //export waku_pubsub_topic
-func waku_pubsub_topic(name *C.char, encoding *C.char, onOkCb C.WakuCallBack) C.int {
+func waku_pubsub_topic(name *C.char, encoding *C.char, cb C.WakuCallBack, userData unsafe.Pointer) C.int {
 	topic := library.PubsubTopic(C.GoString(name), C.GoString(encoding))
-	return execOkCB(onOkCb, topic)
+	return onSuccesfulResponse(topic, cb, userData)
 }
 
 // Get the default pubsub topic used in waku2: /waku/2/default-waku/proto
 //
 //export waku_default_pubsub_topic
-func waku_default_pubsub_topic(onOkCb C.WakuCallBack) C.int {
-	return execOkCB(onOkCb, library.DefaultPubsubTopic())
+func waku_default_pubsub_topic(cb C.WakuCallBack, userData unsafe.Pointer) C.int {
+	return onSuccesfulResponse(library.DefaultPubsubTopic(), cb, userData)
 }
 
 // Register callback to act as signal handler and receive application signals
@@ -230,8 +226,8 @@ func waku_set_event_callback(cb C.WakuCallBack) {
 // Retrieve the list of peers known by the waku node
 //
 //export waku_peers
-func waku_peers(onOkCb C.WakuCallBack, onErrCb C.WakuCallBack) C.int {
+func waku_peers(cb C.WakuCallBack, userData unsafe.Pointer) C.int {
 	return singleFnExec(func() (string, error) {
 		return library.Peers()
-	}, onOkCb, onErrCb)
+	}, cb, userData)
 }

--- a/library/c/api_discovery.go
+++ b/library/c/api_discovery.go
@@ -5,7 +5,11 @@ package main
 */
 import "C"
 
-import "github.com/waku-org/go-waku/library"
+import (
+	"unsafe"
+
+	"github.com/waku-org/go-waku/library"
+)
 
 // Returns a list of objects containing the peerID, enr and multiaddresses for each node found
 //
@@ -17,17 +21,17 @@ import "github.com/waku-org/go-waku/library"
 // (in milliseconds) is reached, or an error will be returned
 //
 //export waku_dns_discovery
-func waku_dns_discovery(url *C.char, nameserver *C.char, ms C.int, onOkCb C.WakuCallBack, onErrCb C.WakuCallBack) C.int {
+func waku_dns_discovery(url *C.char, nameserver *C.char, ms C.int, cb C.WakuCallBack, userData unsafe.Pointer) C.int {
 	return singleFnExec(func() (string, error) {
 		return library.DNSDiscovery(C.GoString(url), C.GoString(nameserver), int(ms))
-	}, onOkCb, onErrCb)
+	}, cb, userData)
 }
 
 // Update the bootnode list used for discovering new peers via DiscoveryV5
 // The bootnodes param should contain a JSON array containing the bootnode ENRs i.e. `["enr:...", "enr:..."]`
 //
 //export waku_discv5_update_bootnodes
-func waku_discv5_update_bootnodes(bootnodes *C.char, onErrCb C.WakuCallBack) C.int {
+func waku_discv5_update_bootnodes(bootnodes *C.char, cb C.WakuCallBack, userData unsafe.Pointer) C.int {
 	err := library.SetBootnodes(C.GoString(bootnodes))
-	return execErrCB(onErrCb, err)
+	return onError(err, cb, userData)
 }

--- a/library/c/api_encoding.go
+++ b/library/c/api_encoding.go
@@ -4,24 +4,28 @@ package main
 #include <cgo_utils.h>
 */
 import "C"
-import "github.com/waku-org/go-waku/library"
+import (
+	"unsafe"
+
+	"github.com/waku-org/go-waku/library"
+)
 
 // Decode a waku message using a 32 bytes symmetric key. The key must be a hex encoded string with "0x" prefix
 //
 //export waku_decode_symmetric
-func waku_decode_symmetric(messageJSON *C.char, symmetricKey *C.char, onOkCb C.WakuCallBack, onErrCb C.WakuCallBack) C.int {
+func waku_decode_symmetric(messageJSON *C.char, symmetricKey *C.char, cb C.WakuCallBack, userData unsafe.Pointer) C.int {
 	return singleFnExec(func() (string, error) {
 		return library.DecodeSymmetric(C.GoString(messageJSON), C.GoString(symmetricKey))
-	}, onOkCb, onErrCb)
+	}, cb, userData)
 }
 
 // Decode a waku message using a secp256k1 private key. The key must be a hex encoded string with "0x" prefix
 //
 //export waku_decode_asymmetric
-func waku_decode_asymmetric(messageJSON *C.char, privateKey *C.char, onOkCb C.WakuCallBack, onErrCb C.WakuCallBack) C.int {
+func waku_decode_asymmetric(messageJSON *C.char, privateKey *C.char, cb C.WakuCallBack, userData unsafe.Pointer) C.int {
 	return singleFnExec(func() (string, error) {
 		return library.DecodeAsymmetric(C.GoString(messageJSON), C.GoString(privateKey))
-	}, onOkCb, onErrCb)
+	}, cb, userData)
 }
 
 // Encrypt a message with a secp256k1 public key.
@@ -30,10 +34,10 @@ func waku_decode_asymmetric(messageJSON *C.char, privateKey *C.char, onOkCb C.Wa
 // The message version will be set to 1
 //
 //export waku_encode_asymmetric
-func waku_encode_asymmetric(messageJSON *C.char, publicKey *C.char, optionalSigningKey *C.char, onOkCb C.WakuCallBack, onErrCb C.WakuCallBack) C.int {
+func waku_encode_asymmetric(messageJSON *C.char, publicKey *C.char, optionalSigningKey *C.char, cb C.WakuCallBack, userData unsafe.Pointer) C.int {
 	return singleFnExec(func() (string, error) {
 		return library.EncodeAsymmetric(C.GoString(messageJSON), C.GoString(publicKey), C.GoString(optionalSigningKey))
-	}, onOkCb, onErrCb)
+	}, cb, userData)
 }
 
 // Encrypt a message with a 32 bytes symmetric key
@@ -42,8 +46,8 @@ func waku_encode_asymmetric(messageJSON *C.char, publicKey *C.char, optionalSign
 // The message version will be set to 1
 //
 //export waku_encode_symmetric
-func waku_encode_symmetric(messageJSON *C.char, symmetricKey *C.char, optionalSigningKey *C.char, onOkCb C.WakuCallBack, onErrCb C.WakuCallBack) C.int {
+func waku_encode_symmetric(messageJSON *C.char, symmetricKey *C.char, optionalSigningKey *C.char, cb C.WakuCallBack, userData unsafe.Pointer) C.int {
 	return singleFnExec(func() (string, error) {
 		return library.EncodeSymmetric(C.GoString(messageJSON), C.GoString(symmetricKey), C.GoString(optionalSigningKey))
-	}, onOkCb, onErrCb)
+	}, cb, userData)
 }

--- a/library/c/api_filter.go
+++ b/library/c/api_filter.go
@@ -4,7 +4,11 @@ package main
 #include <cgo_utils.h>
 */
 import "C"
-import "github.com/waku-org/go-waku/library"
+import (
+	"unsafe"
+
+	"github.com/waku-org/go-waku/library"
+)
 
 // Creates a subscription to a filter full node matching a content filter.
 // filterJSON must contain a JSON with this format:
@@ -20,10 +24,10 @@ import "github.com/waku-org/go-waku/library"
 // It returns a json object containing the details of the subscriptions along with any errors in case of partial failures
 //
 //export waku_filter_subscribe
-func waku_filter_subscribe(filterJSON *C.char, peerID *C.char, ms C.int, onOkCb C.WakuCallBack, onErrCb C.WakuCallBack) C.int {
+func waku_filter_subscribe(filterJSON *C.char, peerID *C.char, ms C.int, cb C.WakuCallBack, userData unsafe.Pointer) C.int {
 	return singleFnExec(func() (string, error) {
 		return library.FilterSubscribe(C.GoString(filterJSON), C.GoString(peerID), int(ms))
-	}, onOkCb, onErrCb)
+	}, cb, userData)
 }
 
 // Used to know if a service node has an active subscription for this client
@@ -32,9 +36,9 @@ func waku_filter_subscribe(filterJSON *C.char, peerID *C.char, ms C.int, onOkCb 
 // (in milliseconds) is reached, or an error will be returned
 //
 //export waku_filter_ping
-func waku_filter_ping(peerID *C.char, ms C.int, onErrCb C.WakuCallBack) C.int {
+func waku_filter_ping(peerID *C.char, ms C.int, cb C.WakuCallBack, userData unsafe.Pointer) C.int {
 	err := library.FilterPing(C.GoString(peerID), int(ms))
-	return execErrCB(onErrCb, err)
+	return onError(err, cb, userData)
 }
 
 // Sends a requests to a service node to stop pushing messages matching this filter to this client.
@@ -51,9 +55,9 @@ func waku_filter_ping(peerID *C.char, ms C.int, onErrCb C.WakuCallBack) C.int {
 // (in milliseconds) is reached, or an error will be returned
 //
 //export waku_filter_unsubscribe
-func waku_filter_unsubscribe(filterJSON *C.char, peerID *C.char, ms C.int, onErrCb C.WakuCallBack) C.int {
+func waku_filter_unsubscribe(filterJSON *C.char, peerID *C.char, ms C.int, cb C.WakuCallBack, userData unsafe.Pointer) C.int {
 	err := library.FilterUnsubscribe(C.GoString(filterJSON), C.GoString(peerID), int(ms))
-	return execErrCB(onErrCb, err)
+	return onError(err, cb, userData)
 }
 
 // Sends a requests to a service node (or all service nodes) to stop pushing messages
@@ -63,8 +67,8 @@ func waku_filter_unsubscribe(filterJSON *C.char, peerID *C.char, ms C.int, onErr
 // (in milliseconds) is reached, or an error will be returned
 //
 //export waku_filter_unsubscribe_all
-func waku_filter_unsubscribe_all(peerID *C.char, ms C.int, onOkCb C.WakuCallBack, onErrCb C.WakuCallBack) C.int {
+func waku_filter_unsubscribe_all(peerID *C.char, ms C.int, cb C.WakuCallBack, userData unsafe.Pointer) C.int {
 	return singleFnExec(func() (string, error) {
 		return library.FilterUnsubscribeAll(C.GoString(peerID), int(ms))
-	}, onOkCb, onErrCb)
+	}, cb, userData)
 }

--- a/library/c/api_legacy_filter.go
+++ b/library/c/api_legacy_filter.go
@@ -4,7 +4,11 @@ package main
 #include <cgo_utils.h>
 */
 import "C"
-import "github.com/waku-org/go-waku/library"
+import (
+	"unsafe"
+
+	"github.com/waku-org/go-waku/library"
+)
 
 // Creates a subscription to a light node matching a content filter and, optionally, a pubSub topic.
 // filterJSON must contain a JSON with this format:
@@ -23,9 +27,9 @@ import "github.com/waku-org/go-waku/library"
 // (in milliseconds) is reached, or an error will be returned
 //
 //export waku_legacy_filter_subscribe
-func waku_legacy_filter_subscribe(filterJSON *C.char, peerID *C.char, ms C.int, onErrCb C.WakuCallBack) C.int {
+func waku_legacy_filter_subscribe(filterJSON *C.char, peerID *C.char, ms C.int, cb C.WakuCallBack, userData unsafe.Pointer) C.int {
 	err := library.LegacyFilterSubscribe(C.GoString(filterJSON), C.GoString(peerID), int(ms))
-	return execErrCB(onErrCb, err)
+	return onError(err, cb, userData)
 }
 
 // Removes subscriptions in a light node matching a content filter and, optionally, a pubSub topic.
@@ -44,7 +48,7 @@ func waku_legacy_filter_subscribe(filterJSON *C.char, peerID *C.char, ms C.int, 
 // (in milliseconds) is reached, or an error will be returned
 //
 //export waku_legacy_filter_unsubscribe
-func waku_legacy_filter_unsubscribe(filterJSON *C.char, ms C.int, onErrCb C.WakuCallBack) C.int {
+func waku_legacy_filter_unsubscribe(filterJSON *C.char, ms C.int, cb C.WakuCallBack, userData unsafe.Pointer) C.int {
 	err := library.LegacyFilterUnsubscribe(C.GoString(filterJSON), int(ms))
-	return execErrCB(onErrCb, err)
+	return onError(err, cb, userData)
 }

--- a/library/c/api_lightpush.go
+++ b/library/c/api_lightpush.go
@@ -4,7 +4,11 @@ package main
 #include <cgo_utils.h>
 */
 import "C"
-import "github.com/waku-org/go-waku/library"
+import (
+	"unsafe"
+
+	"github.com/waku-org/go-waku/library"
+)
 
 // Publish a message using waku lightpush. Use NULL for topic to derive the pubsub topic from the contentTopic.
 // peerID should contain the ID of a peer supporting the lightpush protocol. Use NULL to automatically select a node
@@ -12,8 +16,8 @@ import "github.com/waku-org/go-waku/library"
 // (in milliseconds) is reached, or an error will be returned
 //
 //export waku_lightpush_publish
-func waku_lightpush_publish(messageJSON *C.char, topic *C.char, peerID *C.char, ms C.int, onOkCb C.WakuCallBack, onErrCb C.WakuCallBack) C.int {
+func waku_lightpush_publish(messageJSON *C.char, topic *C.char, peerID *C.char, ms C.int, cb C.WakuCallBack, userData unsafe.Pointer) C.int {
 	return singleFnExec(func() (string, error) {
 		return library.LightpushPublish(C.GoString(messageJSON), C.GoString(topic), C.GoString(peerID), int(ms))
-	}, onOkCb, onErrCb)
+	}, cb, userData)
 }

--- a/library/c/api_relay.go
+++ b/library/c/api_relay.go
@@ -4,58 +4,74 @@ package main
 #include <cgo_utils.h>
 */
 import "C"
-import "github.com/waku-org/go-waku/library"
+import (
+	"unsafe"
+
+	"github.com/waku-org/go-waku/library"
+)
 
 // Determine if there are enough peers to publish a message on a topic. Use NULL
 // to verify the number of peers in the default pubsub topic
 //
 //export waku_relay_enough_peers
-func waku_relay_enough_peers(topic *C.char, onOkCb C.WakuCallBack, onErrCb C.WakuCallBack) C.int {
+func waku_relay_enough_peers(topic *C.char, cb C.WakuCallBack, userData unsafe.Pointer) C.int {
 	return singleFnExec(func() (string, error) {
 		result, err := library.RelayEnoughPeers(C.GoString(topic))
 		if result {
 			return "true", err
 		}
 		return "false", err
-	}, onOkCb, onErrCb)
+	}, cb, userData)
 }
 
-// Publish a message using waku relay and returns the message ID. Use NULL for topic to use the default pubsub topic
+// Publish a message using waku relay and returns the message ID. Use NULL for topic to derive the pubsub topic from the contentTopic.
 // If ms is greater than 0, the broadcast of the message must happen before the timeout
 // (in milliseconds) is reached, or an error will be returned.
 //
 //export waku_relay_publish
-func waku_relay_publish(messageJSON *C.char, topic *C.char, ms C.int, onOkCb C.WakuCallBack, onErrCb C.WakuCallBack) C.int {
+func waku_relay_publish(messageJSON *C.char, topic *C.char, ms C.int, cb C.WakuCallBack, userData unsafe.Pointer) C.int {
 	return singleFnExec(func() (string, error) {
 		return library.RelayPublish(C.GoString(messageJSON), C.GoString(topic), int(ms))
-	}, onOkCb, onErrCb)
+	}, cb, userData)
 }
 
-// Subscribe to a WakuRelay topic. Set the topic to NULL to subscribe
-// to the default topic. Returns a json response. When a message is received,
-// a "message" event is emitted containing the message and pubsub topic in which
+// Subscribe to WakuRelay to receive messages matching a content filter.
+// filterJSON must contain a JSON with this format:
+//
+//		{
+//		  "pubsubTopic": "the pubsub topic" // optional if using autosharding, mandatory if using static or named sharding.
+//	      "contentTopics": ["the content topic"] // optional
+//		}
+//
+// When a message is received, a "message" event is emitted containing the message and pubsub topic in which
 // the message was received
 //
 //export waku_relay_subscribe
-func waku_relay_subscribe(topic *C.char, onErrCb C.WakuCallBack) C.int {
-	err := library.RelaySubscribe(C.GoString(topic))
-	return execErrCB(onErrCb, err)
+func waku_relay_subscribe(filterJSON *C.char, cb C.WakuCallBack, userData unsafe.Pointer) C.int {
+	err := library.RelaySubscribe(C.GoString(filterJSON))
+	return onError(err, cb, userData)
 }
 
 // Returns a json response with the list of pubsub topics the node
 // is subscribed to in WakuRelay
 //
 //export waku_relay_topics
-func waku_relay_topics(onOkCb C.WakuCallBack, onErrCb C.WakuCallBack) C.int {
+func waku_relay_topics(cb C.WakuCallBack, userData unsafe.Pointer) C.int {
 	return singleFnExec(func() (string, error) {
 		return library.RelayTopics()
-	}, onOkCb, onErrCb)
+	}, cb, userData)
 }
 
-// Closes the pubsub subscription to a pubsub topic
+// Closes the pubsub subscription to stop receiving messages matching a content filter
+// filterJSON must contain a JSON with this format:
+//
+//		{
+//		  "pubsubTopic": "the pubsub topic" // optional if using autosharding, mandatory if using static or named sharding.
+//	      "contentTopics": ["the content topic"] // optional
+//		}
 //
 //export waku_relay_unsubscribe
-func waku_relay_unsubscribe(topic *C.char, onErrCb C.WakuCallBack) C.int {
-	err := library.RelayUnsubscribe(C.GoString(topic))
-	return execErrCB(onErrCb, err)
+func waku_relay_unsubscribe(filterJSON *C.char, cb C.WakuCallBack, userData unsafe.Pointer) C.int {
+	err := library.RelayUnsubscribe(C.GoString(filterJSON))
+	return onError(err, cb, userData)
 }

--- a/library/c/api_store.go
+++ b/library/c/api_store.go
@@ -4,30 +4,33 @@ package main
 #include <cgo_utils.h>
 */
 import "C"
-import "github.com/waku-org/go-waku/library"
+import (
+	"unsafe"
+
+	"github.com/waku-org/go-waku/library"
+)
 
 // Query historic messages using waku store protocol.
 // queryJSON must contain a valid json string with the following format:
 //
 //	{
 //		"pubsubTopic": "...", // optional string
-//	 "startTime": 1234, // optional, unix epoch time in nanoseconds
-//	 "endTime": 1234, // optional, unix epoch time in nanoseconds
-//	 "contentFilters": [ // optional
-//			{
-//		      contentTopic: "contentTopic1"
-//			}, ...
-//	 ],
-//	 "pagingOptions": {// optional pagination information
-//	     "pageSize": 40, // number
+//		"startTime": 1234, // optional, unix epoch time in nanoseconds
+//		"endTime": 1234, // optional, unix epoch time in nanoseconds
+//		"contentTopics": [ // optional
+//			"contentTopic1",
+//			...
+//		],
+//		"pagingOptions": {// optional pagination information
+//			"pageSize": 40, // number
 //			"cursor": { // optional
 //				"digest": ...,
 //				"receiverTime": ...,
 //				"senderTime": ...,
-//				"pubsubTopic" ...,
-//	     }
+//				"pubsubTopic": ...,
+//			},
 //			"forward": true, // sort order
-//	 }
+//		}
 //	}
 //
 // If a non empty cursor is returned, this function should be executed again, setting  the `cursor` attribute with the cursor returned in the response
@@ -36,10 +39,10 @@ import "github.com/waku-org/go-waku/library"
 // (in milliseconds) is reached, or an error will be returned
 //
 //export waku_store_query
-func waku_store_query(queryJSON *C.char, peerID *C.char, ms C.int, onOkCb C.WakuCallBack, onErrCb C.WakuCallBack) C.int {
+func waku_store_query(queryJSON *C.char, peerID *C.char, ms C.int, cb C.WakuCallBack, userData unsafe.Pointer) C.int {
 	return singleFnExec(func() (string, error) {
 		return library.StoreQuery(C.GoString(queryJSON), C.GoString(peerID), int(ms))
-	}, onOkCb, onErrCb)
+	}, cb, userData)
 }
 
 // Query historic messages stored in the localDB using waku store protocol.
@@ -47,31 +50,30 @@ func waku_store_query(queryJSON *C.char, peerID *C.char, ms C.int, onOkCb C.Waku
 //
 //	{
 //		"pubsubTopic": "...", // optional string
-//	 "startTime": 1234, // optional, unix epoch time in nanoseconds
-//	 "endTime": 1234, // optional, unix epoch time in nanoseconds
-//	 "contentFilters": [ // optional
-//			{
-//		      contentTopic: "contentTopic1"
-//			}, ...
-//	 ],
-//	 "pagingOptions": {// optional pagination information
-//	     "pageSize": 40, // number
+//		"startTime": 1234, // optional, unix epoch time in nanoseconds
+//		"endTime": 1234, // optional, unix epoch time in nanoseconds
+//		"contentTopics": [ // optional
+//			"contentTopic1"
+//			...
+//		],
+//		"pagingOptions": {// optional pagination information
+//			"pageSize": 40, // number
 //			"cursor": { // optional
 //				"digest": ...,
 //				"receiverTime": ...,
 //				"senderTime": ...,
-//				"pubsubTopic" ...,
-//	     }
+//				"pubsubTopic": ...,
+//			},
 //			"forward": true, // sort order
-//	 }
+//		}
 //	}
 //
 // If a non empty cursor is returned, this function should be executed again, setting  the `cursor` attribute with the cursor returned in the response
 // Requires the `store` option to be passed when setting up the initial configuration
 //
 //export waku_store_local_query
-func waku_store_local_query(queryJSON *C.char, onOkCb C.WakuCallBack, onErrCb C.WakuCallBack) C.int {
+func waku_store_local_query(queryJSON *C.char, cb C.WakuCallBack, userData unsafe.Pointer) C.int {
 	return singleFnExec(func() (string, error) {
 		return library.StoreLocalQuery(C.GoString(queryJSON))
-	}, onOkCb, onErrCb)
+	}, cb, userData)
 }

--- a/library/c/cgo_utils.c
+++ b/library/c/cgo_utils.c
@@ -4,6 +4,6 @@
 
 // This is a bridge function to execute C callbacks.
 // It's used internally in go-waku. Do not call directly
-void _waku_execCB(WakuCallBack op, char* a, size_t b) {
-    op(a, b);
+void _waku_execCB(WakuCallBack op, int retCode, char* msg, void * user_data) {
+    op(retCode, msg, user_data);
 }

--- a/library/c/cgo_utils.h
+++ b/library/c/cgo_utils.h
@@ -1,6 +1,4 @@
 #include <stdlib.h>
 #include <stdint.h>
 
-typedef void (*WakuCallBack) (const char* msg, size_t len_0);
-
-typedef void (*BytesCallBack) (uint8_t* data, size_t len_0);
+typedef void (*WakuCallBack) (int ret_code, const char* msg, void * user_data);

--- a/library/encoding.go
+++ b/library/encoding.go
@@ -128,6 +128,18 @@ func extractPubKeyAndSignature(payload *payload.DecodedPayload) (pubkey string, 
 	return
 }
 
+type v0Response struct {
+	Data    []byte `json:"data"`
+	Padding []byte `json:"padding"`
+}
+
+type v1Response struct {
+	PubKey    string `json:"pubkey,omitempty"`
+	Signature string `json:"signature,omitempty"`
+	Data      []byte `json:"data"`
+	Padding   []byte `json:"padding"`
+}
+
 // DecodeSymmetric decodes a waku message using a 32 bytes symmetric key. The key must be a hex encoded string with "0x" prefix
 func DecodeSymmetric(messageJSON string, symmetricKey string) (string, error) {
 	var msg pb.WakuMessage
@@ -137,7 +149,9 @@ func DecodeSymmetric(messageJSON string, symmetricKey string) (string, error) {
 	}
 
 	if msg.Version == 0 {
-		return marshalJSON(msg.Payload)
+		return marshalJSON(v0Response{
+			Data: msg.Payload,
+		})
 	} else if msg.Version > 1 {
 		return "", errors.New("unsupported wakumessage version")
 	}
@@ -158,12 +172,7 @@ func DecodeSymmetric(messageJSON string, symmetricKey string) (string, error) {
 
 	pubkey, signature := extractPubKeyAndSignature(payload)
 
-	response := struct {
-		PubKey    string `json:"pubkey,omitempty"`
-		Signature string `json:"signature,omitempty"`
-		Data      []byte `json:"data"`
-		Padding   []byte `json:"padding"`
-	}{
+	response := v1Response{
 		PubKey:    pubkey,
 		Signature: signature,
 		Data:      payload.Data,
@@ -182,7 +191,9 @@ func DecodeAsymmetric(messageJSON string, privateKey string) (string, error) {
 	}
 
 	if msg.Version == 0 {
-		return marshalJSON(msg.Payload)
+		return marshalJSON(v0Response{
+			Data: msg.Payload,
+		})
 	} else if msg.Version > 1 {
 		return "", errors.New("unsupported wakumessage version")
 	}
@@ -208,12 +219,7 @@ func DecodeAsymmetric(messageJSON string, privateKey string) (string, error) {
 
 	pubkey, signature := extractPubKeyAndSignature(payload)
 
-	response := struct {
-		PubKey    string `json:"pubkey,omitempty"`
-		Signature string `json:"signature,omitempty"`
-		Data      []byte `json:"data"`
-		Padding   []byte `json:"padding"`
-	}{
+	response := v1Response{
 		PubKey:    pubkey,
 		Signature: signature,
 		Data:      payload.Data,

--- a/library/filter.go
+++ b/library/filter.go
@@ -81,7 +81,10 @@ func FilterSubscribe(filterJSON string, peerID string, ms int) (string, error) {
 	}
 	var subResult subscribeResult
 	subResult.Subscriptions = subscriptions
-	subResult.Error = err.Error()
+	if err != nil {
+		subResult.Error = err.Error()
+	}
+
 	return marshalJSON(subResult)
 }
 

--- a/library/lightpush.go
+++ b/library/lightpush.go
@@ -52,5 +52,5 @@ func LightpushPublish(messageJSON string, pubsubTopic string, peerID string, ms 
 		return "", err
 	}
 
-	return lightpushPublish(msg, getTopic(pubsubTopic), peerID, ms)
+	return lightpushPublish(msg, pubsubTopic, peerID, ms)
 }

--- a/library/signals.c
+++ b/library/signals.c
@@ -7,12 +7,12 @@
 #include <stdbool.h>
 #include "_cgo_export.h"
 
-typedef void (*callback)(const char *jsonEvent, size_t len_0);
+typedef void (*callback)(int retCode, const char *jsonEvent, void* userData);
 callback gCallback = 0;
 
-bool ServiceSignalEvent(const char *jsonEvent, size_t len_0) {
+bool ServiceSignalEvent(const char *jsonEvent) {
 	if (gCallback) {
-		gCallback(jsonEvent, len_0);
+		gCallback(0, jsonEvent, NULL);
 	}
 
 	return true;

--- a/library/signals.go
+++ b/library/signals.go
@@ -4,7 +4,7 @@ package library
 #include <stddef.h>
 #include <stdbool.h>
 #include <stdlib.h>
-extern bool ServiceSignalEvent(const char *jsonEvent, size_t len);
+extern bool ServiceSignalEvent(const char *jsonEvent);
 extern void SetEventCallback(void *cb);
 */
 import "C"
@@ -51,7 +51,7 @@ func send(signalType string, event interface{}) {
 		// ...and fallback to C implementation otherwise.
 		dataStr := string(data)
 		str := C.CString(dataStr)
-		C.ServiceSignalEvent(str, C.size_t(len(data)))
+		C.ServiceSignalEvent(str)
 		C.free(unsafe.Pointer(str))
 	}
 }

--- a/library/store.go
+++ b/library/store.go
@@ -22,11 +22,11 @@ type storePagingOptions struct {
 }
 
 type storeMessagesArgs struct {
-	Topic          string              `json:"pubsubTopic,omitempty"`
-	ContentFilters []*pb.ContentFilter `json:"contentFilters,omitempty"`
-	StartTime      int64               `json:"startTime,omitempty"`
-	EndTime        int64               `json:"endTime,omitempty"`
-	PagingOptions  storePagingOptions  `json:"pagingOptions,omitempty"`
+	Topic         string             `json:"pubsubTopic,omitempty"`
+	ContentTopics []string           `json:"contentTopics,omitempty"`
+	StartTime     int64              `json:"startTime,omitempty"`
+	EndTime       int64              `json:"endTime,omitempty"`
+	PagingOptions storePagingOptions `json:"pagingOptions,omitempty"`
 }
 
 type storeMessagesReply struct {
@@ -36,16 +36,11 @@ type storeMessagesReply struct {
 }
 
 func queryResponse(ctx context.Context, args storeMessagesArgs, options []store.HistoryRequestOption) (string, error) {
-	var contentTopics []string
-	for _, ct := range args.ContentFilters {
-		contentTopics = append(contentTopics, ct.ContentTopic)
-	}
-
 	res, err := wakuState.node.Store().Query(
 		ctx,
 		store.Query{
 			Topic:         args.Topic,
-			ContentTopics: contentTopics,
+			ContentTopics: args.ContentTopics,
 			StartTime:     args.StartTime,
 			EndTime:       args.EndTime,
 		},

--- a/waku/v2/protocol/content_filter.go
+++ b/waku/v2/protocol/content_filter.go
@@ -20,8 +20,8 @@ func NewContentTopicSet(contentTopics ...string) ContentTopicSet {
 // ContentTopics - Specify list of content topics to be filtered under a pubSubTopic (for named and static sharding), or a list of contentTopics (in case ofAuto sharding)
 // If pubSub topic is not specified, then content-topics are used to derive the shard and corresponding pubSubTopic using autosharding algorithm
 type ContentFilter struct {
-	PubsubTopic   string
-	ContentTopics ContentTopicSet
+	PubsubTopic   string          `json:"pubsubTopic"`
+	ContentTopics ContentTopicSet `json:"contentTopics"`
 }
 
 func (cf ContentFilter) ContentTopicsList() []string {

--- a/waku/v2/protocol/subscription/subscriptions_map.go
+++ b/waku/v2/protocol/subscription/subscriptions_map.go
@@ -15,14 +15,14 @@ import (
 type SubscriptionDetails struct {
 	sync.RWMutex
 
-	ID     string
+	ID     string `json:"subscriptionID"`
 	mapRef *SubscriptionsMap
-	Closed bool
+	Closed bool `json:"-"`
 	once   sync.Once
 
-	PeerID        peer.ID
-	ContentFilter protocol.ContentFilter
-	C             chan *protocol.Envelope
+	PeerID        peer.ID                 `json:"peerID"`
+	ContentFilter protocol.ContentFilter  `json:"contentFilters"`
+	C             chan *protocol.Envelope `json:"-"`
 }
 
 // Map of SubscriptionDetails.ID to subscriptions


### PR DESCRIPTION
# Description
Adds an `void* user_data` parameter to all c-bindings API functions so it's possible to use them without having to use global variables

# New API:
```c
// Initialize a waku node. Receives a JSON string containing the configuration
// for the node. It can be NULL. Example configuration:
// ```
// {"host": "0.0.0.0", "port": 60000, "advertiseAddr": "1.2.3.4", "nodeKey": "0x123...567", "keepAliveInterval": 20, "relay": true}
// ```
// All keys are optional. If not specified a default value will be set:
// - host: IP address. Default 0.0.0.0
// - port: TCP port to listen. Default 60000. Use 0 for random
// - advertiseAddr: External IP
// - nodeKey: secp256k1 private key. Default random
// - keepAliveInterval: interval in seconds to ping all peers
// - relay: Enable WakuRelay. Default `true`
// - relayTopics: Array of pubsub topics that WakuRelay will automatically subscribe to when the node starts
// - gossipsubParams: an object containing custom gossipsub parameters. All attributes are optional, and if not specified, it will use default values.
//   - d: optimal degree for a GossipSub topic mesh. Default `6`
//   - dLow: lower bound on the number of peers we keep in a GossipSub topic mesh. Default `5`
//   - dHigh: upper bound on the number of peers we keep in a GossipSub topic mesh. Default `12`
//   - dScore: affects how peers are selected when pruning a mesh due to over subscription. Default `4`
//   - dOut: sets the quota for the number of outbound connections to maintain in a topic mesh. Default `2`
//   - historyLength: controls the size of the message cache used for gossip. Default `5`
//   - historyGossip: controls how many cached message ids we will advertise in IHAVE gossip messages. Default `3`
//   - dLazy: affects how many peers we will emit gossip to at each heartbeat. Default `6`
//   - gossipFactor: affects how many peers we will emit gossip to at each heartbeat. Default `0.25`
//   - gossipRetransmission: controls how many times we will allow a peer to request the same message id through IWANT gossip before we start ignoring them. Default `3`
//   - heartbeatInitialDelayMs: short delay in milliseconds before the heartbeat timer begins after the router is initialized. Default `100` milliseconds
//   - heartbeatIntervalSeconds: controls the time between heartbeats. Default `1` second
//   - slowHeartbeatWarning: duration threshold for heartbeat processing before emitting a warning. Default `0.1`
//   - fanoutTTLSeconds: controls how long we keep track of the fanout state. Default `60` seconds
//   - prunePeers: controls the number of peers to include in prune Peer eXchange. Default `16`
//   - pruneBackoffSeconds: controls the backoff time for pruned peers. Default `60` seconds
//   - unsubscribeBackoffSeconds: controls the backoff time to use when unsuscribing from a topic. Default `10` seconds
//   - connectors: number of active connection attempts for peers obtained through PX. Default `8`
//   - maxPendingConnections: maximum number of pending connections for peers attempted through px. Default `128`
//   - connectionTimeoutSeconds: timeout in seconds for connection attempts. Default `30` seconds
//   - directConnectTicks: the number of heartbeat ticks for attempting to reconnect direct peers that are not currently connected. Default `300`
//   - directConnectInitialDelaySeconds: initial delay before opening connections to direct peers. Default `1` second
//   - opportunisticGraftTicks: number of heartbeat ticks for attempting to improve the mesh with opportunistic grafting. Default `60`
//   - opportunisticGraftPeers: the number of peers to opportunistically graft. Default `2`
//   - graftFloodThresholdSeconds: If a GRAFT comes before GraftFloodThresholdSeconds has elapsed since the last PRUNE, then there is an extra score penalty applied to the peer through P7. Default `10` seconds
//   - maxIHaveLength: max number of messages to include in an IHAVE message, also controls the max number of IHAVE ids we will accept and request with IWANT from a peer within a heartbeat. Default `5000`
//   - maxIHaveMessages: max number of IHAVE messages to accept from a peer within a heartbeat. Default `10`
//   - iWantFollowupTimeSeconds: Time to wait for a message requested through IWANT following an IHAVE advertisement. Default `3` seconds
//   - seenMessagesTTLSeconds:  configures when a previously seen message ID can be forgotten about. Default `120` seconds
//
// - minPeersToPublish: The minimum number of peers required on a topic to allow broadcasting a message. Default `0`
// - legacyFilter: Enable LegacyFilter. Default `false`
// - discV5: Enable DiscoveryV5. Default `false`
// - discV5BootstrapNodes: Array of bootstrap nodes ENR
// - discV5UDPPort: UDP port for DiscoveryV5
// - logLevel: Set the log level. Default `INFO`. Allowed values "DEBUG", "INFO", "WARN", "ERROR", "DPANIC", "PANIC", "FATAL"
// - store: Enable Store. Default `false`
// - databaseURL: url connection string. Default: "sqlite3://store.db". Also accepts PostgreSQL connection strings
// - storeRetentionMaxMessages: max number of messages to store in the database. Default 10000
// - storeRetentionTimeSeconds: max number of seconds that a message will be persisted in the database. Default 2592000 (30d)
// - websockets: an optional object containing settings to setup the websocket configuration
//   - enabled: indicates if websockets support will be enabled. Default `false`
//   - host: listening address for websocket connections. Default `0.0.0.0`
//   - port: TCP listening port for websocket connection (0 for random, binding to 443 requires root access). Default: `60001“, if secure websockets support is enabled, the default is `6443“
//   - secure: enable secure websockets support. Default `false`
//   - certPath: secure websocket certificate path
//   - keyPath: secure websocket key path
//
// - dns4DomainName: the domain name resolving to the node's public IPv4 address.
//
extern int waku_new(char* configJSON, WakuCallBack cb, void* userData);

// Starts the waku node
//
extern int waku_start(WakuCallBack onErr, void* userData);

// Stops a waku node
//
extern int waku_stop(WakuCallBack onErr, void* userData);

// Determine is a node is started or not
//
extern int waku_is_started();

// Obtain the peer ID of the waku node
//
extern int waku_peerid(WakuCallBack cb, void* userData);

// Obtain the multiaddresses the wakunode is listening to
//
extern int waku_listen_addresses(WakuCallBack cb, void* userData);

// Add node multiaddress and protocol to the wakunode peerstore
//
extern int waku_add_peer(char* address, char* protocolID, WakuCallBack cb, void* userData);

// Connect to peer at multiaddress. if ms > 0, cancel the function execution if it takes longer than N milliseconds
//
extern int waku_connect(char* address, int ms, WakuCallBack cb, void* userData);

// Connect to known peer by peerID. if ms > 0, cancel the function execution if it takes longer than N milliseconds
//
extern int waku_connect_peerid(char* peerID, int ms, WakuCallBack cb, void* userData);

// Close connection to a known peer by peerID
//
extern int waku_disconnect(char* peerID, WakuCallBack cb, void* userData);

// Get number of connected peers
//
extern int waku_peer_cnt(WakuCallBack cb, void* userData);

// Create a content topic string according to RFC 23
//
extern int waku_content_topic(char* applicationName, unsigned int applicationVersion, char* contentTopicName, char* encoding, WakuCallBack cb, void* userData);

// Create a pubsub topic string according to RFC 23
//
extern int waku_pubsub_topic(char* name, char* encoding, WakuCallBack cb, void* userData);

// Get the default pubsub topic used in waku2: /waku/2/default-waku/proto
//
extern int waku_default_pubsub_topic(WakuCallBack cb, void* userData);

// Register callback to act as signal handler and receive application signals
// (in JSON) which are used to react to asynchronous events in waku. The function
// signature for the callback should be `void myCallback(char* signalJSON)`
//
extern void waku_set_event_callback(WakuCallBack cb);

// Retrieve the list of peers known by the waku node
//
extern int waku_peers(WakuCallBack cb, void* userData);

// Returns a list of objects containing the peerID, enr and multiaddresses for each node found
//
//	given a url to a DNS discoverable ENR tree
//
// The nameserver can optionally be specified to resolve the enrtree url. Otherwise NULL or
// empty to automatically use the default system dns.
// If ms is greater than 0, the subscription must happen before the timeout
// (in milliseconds) is reached, or an error will be returned
//
extern int waku_dns_discovery(char* url, char* nameserver, int ms, WakuCallBack cb, void* userData);

// Update the bootnode list used for discovering new peers via DiscoveryV5
// The bootnodes param should contain a JSON array containing the bootnode ENRs i.e. `["enr:...", "enr:..."]`
//
extern int waku_discv5_update_bootnodes(char* bootnodes, WakuCallBack cb, void* userData);

// Decode a waku message using a 32 bytes symmetric key. The key must be a hex encoded string with "0x" prefix
//
extern int waku_decode_symmetric(char* messageJSON, char* symmetricKey, WakuCallBack cb, void* userData);

// Decode a waku message using a secp256k1 private key. The key must be a hex encoded string with "0x" prefix
//
extern int waku_decode_asymmetric(char* messageJSON, char* privateKey, WakuCallBack cb, void* userData);

// Encrypt a message with a secp256k1 public key.
// publicKey must be a hex string prefixed with "0x" containing a valid secp256k1 public key.
// optionalSigningKey is an optional hex string prefixed with "0x" containing a valid secp256k1 private key for signing the message. Use NULL otherwise
// The message version will be set to 1
//
extern int waku_encode_asymmetric(char* messageJSON, char* publicKey, char* optionalSigningKey, WakuCallBack cb, void* userData);

// Encrypt a message with a 32 bytes symmetric key
// symmetricKey must be a hex string prefixed with "0x" containing a 32 bytes symmetric key
// optionalSigningKey is an optional hex string prefixed with "0x" containing a valid secp256k1 private key for signing the message. Use NULL otherwise
// The message version will be set to 1
//
extern int waku_encode_symmetric(char* messageJSON, char* symmetricKey, char* optionalSigningKey, WakuCallBack cb, void* userData);

// Creates a subscription to a filter full node matching a content filter.
// filterJSON must contain a JSON with this format:
//
//		{
//		  "pubsubTopic": "the pubsub topic" // optional if using autosharding, mandatory if using static or named sharding.
//	      "contentTopics": ["the content topic"] // mandatory, at least one required, with a max of 10
//		}
//
// peerID should contain the ID of a peer supporting the filter protocol. Use NULL to automatically select a node
// If ms is greater than 0, the subscription must happen before the timeout
// (in milliseconds) is reached, or an error will be returned
// It returns a json object containing the details of the subscriptions along with any errors in case of partial failures
//
extern int waku_filter_subscribe(char* filterJSON, char* peerID, int ms, WakuCallBack cb, void* userData);

// Used to know if a service node has an active subscription for this client
// peerID should contain the ID of a peer we are subscribed to, supporting the filter protocol
// If ms is greater than 0, the subscription must happen before the timeout
// (in milliseconds) is reached, or an error will be returned
//
extern int waku_filter_ping(char* peerID, int ms, WakuCallBack cb, void* userData);

// Sends a requests to a service node to stop pushing messages matching this filter to this client.
// It might be used to modify an existing subscription by providing a subset of the original filter
// criteria
//
//		{
//		  "pubsubTopic": "the pubsub topic" //  optional if using autosharding, mandatory if using static or named sharding.
//	      "contentTopics": ["the content topic"] // mandatory, at least one required, with a max of 10
//		}
//
// peerID should contain the ID of a peer this client is subscribed to.
// If ms is greater than 0, the subscription must happen before the timeout
// (in milliseconds) is reached, or an error will be returned
//
extern int waku_filter_unsubscribe(char* filterJSON, char* peerID, int ms, WakuCallBack cb, void* userData);

// Sends a requests to a service node (or all service nodes) to stop pushing messages
// peerID should contain the ID of a peer this client is subscribed to, or can be NULL to
// stop all active subscriptions
// If ms is greater than 0, the subscription must happen before the timeout
// (in milliseconds) is reached, or an error will be returned
//
extern int waku_filter_unsubscribe_all(char* peerID, int ms, WakuCallBack cb, void* userData);

// Creates a subscription to a light node matching a content filter and, optionally, a pubSub topic.
// filterJSON must contain a JSON with this format:
//
//	{
//		 "contentFilters": [ // mandatory
//	    {
//	      "contentTopic": "the content topic"
//	    }, ...
//	  ],
//	  "pubsubTopic": "the pubsub topic" // optional
//	}
//
// peerID should contain the ID of a peer supporting the filter protocol. Use NULL to automatically select a node
// If ms is greater than 0, the subscription must happen before the timeout
// (in milliseconds) is reached, or an error will be returned
//
extern int waku_legacy_filter_subscribe(char* filterJSON, char* peerID, int ms, WakuCallBack cb, void* userData);

// Removes subscriptions in a light node matching a content filter and, optionally, a pubSub topic.
// filterJSON must contain a JSON with this format:
//
//	{
//		 "contentFilters": [ // mandatory
//	    {
//	      "contentTopic": "the content topic"
//	    }, ...
//	  ],
//	  "pubsubTopic": "the pubsub topic" // optional
//	}
//
// If ms is greater than 0, the subscription must happen before the timeout
// (in milliseconds) is reached, or an error will be returned
//
extern int waku_legacy_filter_unsubscribe(char* filterJSON, int ms, WakuCallBack cb, void* userData);

// Publish a message using waku lightpush. Use NULL for topic to derive the pubsub topic from the contentTopic.
// peerID should contain the ID of a peer supporting the lightpush protocol. Use NULL to automatically select a node
// If ms is greater than 0, the broadcast of the message must happen before the timeout
// (in milliseconds) is reached, or an error will be returned
//
extern int waku_lightpush_publish(char* messageJSON, char* topic, char* peerID, int ms, WakuCallBack cb, void* userData);

// Determine if there are enough peers to publish a message on a topic. Use NULL
// to verify the number of peers in the default pubsub topic
//
extern int waku_relay_enough_peers(char* topic, WakuCallBack cb, void* userData);

// Publish a message using waku relay and returns the message ID. Use NULL for topic to use the default pubsub topic
// If ms is greater than 0, the broadcast of the message must happen before the timeout
// (in milliseconds) is reached, or an error will be returned.
//
extern int waku_relay_publish(char* messageJSON, char* topic, int ms, WakuCallBack cb, void* userData);

// Subscribe to WakuRelay to receive messages matching a content filter.
// filterJSON must contain a JSON with this format:
//
//		{
//		  "pubsubTopic": "the pubsub topic" // optional if using autosharding, mandatory if using static or named sharding.
//	      "contentTopics": ["the content topic"] // mandatory, at least one required, with a max of 10
//		}
//
// When a message is received, a "message" event is emitted containing the message and pubsub topic in which
// the message was received
//
extern int waku_relay_subscribe(char* contentfilterJSON, WakuCallBack cb, void* userData);

// Returns a json response with the list of pubsub topics the node
// is subscribed to in WakuRelay
//
extern int waku_relay_topics(WakuCallBack cb, void* userData);

// Closes the pubsub subscription to stop receiving messages matching a content filter
// filterJSON must contain a JSON with this format:
//
//		{
//		  "pubsubTopic": "the pubsub topic" // optional if using autosharding, mandatory if using static or named sharding.
//	      "contentTopics": ["the content topic"] // mandatory, at least one required, with a max of 10
//		}
//
extern int waku_relay_unsubscribe(char* filterJSON, WakuCallBack cb, void* userData);

// Query historic messages using waku store protocol.
// queryJSON must contain a valid json string with the following format:
//
//	{
//		"pubsubTopic": "...", // optional string
//	 "startTime": 1234, // optional, unix epoch time in nanoseconds
//	 "endTime": 1234, // optional, unix epoch time in nanoseconds
//	 "contentFilters": [ // optional
//			{
//		      contentTopic: "contentTopic1"
//			}, ...
//	 ],
//	 "pagingOptions": {// optional pagination information
//	     "pageSize": 40, // number
//			"cursor": { // optional
//				"digest": ...,
//				"receiverTime": ...,
//				"senderTime": ...,
//				"pubsubTopic" ...,
//	     }
//			"forward": true, // sort order
//	 }
//	}
//
// If a non empty cursor is returned, this function should be executed again, setting  the `cursor` attribute with the cursor returned in the response
// peerID should contain the ID of a peer supporting the store protocol. Use NULL to automatically select a node
// If ms is greater than 0, the broadcast of the message must happen before the timeout
// (in milliseconds) is reached, or an error will be returned
//
extern int waku_store_query(char* queryJSON, char* peerID, int ms, WakuCallBack cb, void* userData);

// Query historic messages stored in the localDB using waku store protocol.
// queryJSON must contain a valid json string with the following format:
//
//	{
//		"pubsubTopic": "...", // optional string
//	 "startTime": 1234, // optional, unix epoch time in nanoseconds
//	 "endTime": 1234, // optional, unix epoch time in nanoseconds
//	 "contentFilters": [ // optional
//			{
//		      contentTopic: "contentTopic1"
//			}, ...
//	 ],
//	 "pagingOptions": {// optional pagination information
//	     "pageSize": 40, // number
//			"cursor": { // optional
//				"digest": ...,
//				"receiverTime": ...,
//				"senderTime": ...,
//				"pubsubTopic" ...,
//	     }
//			"forward": true, // sort order
//	 }
//	}
//
// If a non empty cursor is returned, this function should be executed again, setting  the `cursor` attribute with the cursor returned in the response
// Requires the `store` option to be passed when setting up the initial configuration
//
extern int waku_store_local_query(char* queryJSON, WakuCallBack cb, void* userData);


```



# Tests

<!-- List down any tests that were executed specifically for this pull-request -->



<!--
## How to test

1.
1.
1.

-->


<!--
## Issue

closes #
-->
