### PR TITLE
Update peer selection options for light protocols

### DIFF
--- a/waku/v2/peermanager/peer_manager.go
+++ b/waku/v2/peermanager/peer_manager.go
@@ -483,3 +483,17 @@ func (pm *PeerManager) selectServicePeer(proto protocol.ID, pubSubTopic string, 
 	}
 	return
 }
+
+func (pm *PeerManager) HandlePeerSelection(selectionType utils.PeerSelection, proto protocol.ID,
+	pubSubTopic string, specificPeers ...peer.ID) (peer.ID, error) {
+
+	switch selectionType {
+	case utils.Automatic:
+		return pm.SelectPeer(proto, pubSubTopic, specificPeers...)
+	case utils.LowestRTT:
+		//TODO: Move this to peer-manager
+		return utils.SelectPeerWithLowestRTT(context.Background(), pm.host, proto, specificPeers, pm.logger)
+	default:
+		return "", errors.New("unknown peer selection type specified")
+	}
+}


### PR DESCRIPTION
# Description
Update req/resp protocols to use new peerSelection logic based on pubSub/contentTopic as per #680 

@richard-ramos , it is becoming challenging to maintain both peerManager and option of using waku protocols without peer-manager (i.e using utils peer code). As you can see in this PR, there already is a lot of checks and duplicate code generated.

Now with peer-selection based on pubSubTopic, which cannot be done by default libp2p peerStore alone(since we store peer specific pubSub topics in wakuPeerStore), I am wondering if it is time to retire this option of peerutils without peerManager.
Maybe once we have WakuPeerStore implementation which is completely independent of libp2p peerStore as per #579  we can bring this option back. WDYT?

# Changes

<!-- List of detailed changes -->

- [x] Update peerSelection in lightpush to use peers filtered based on pubSubTopic.
- [ ] Update Filter to use peerSelection options based on pubSubTopic
- [ ] Update Store protocol to also use peerSelection based on pubSubTopic

# Tests

<!-- List down any tests that were executed specifically for this pull-request -->
