### PR TITLE
fix(store): query time comparison and max rows per page

### DIFF
--- a/waku/persistence/db_key.go
+++ b/waku/persistence/db_key.go
@@ -35,7 +35,10 @@ func (k *DBKey) Bytes() []byte {
 
 // NewDBKey creates a new DBKey with the given values.
 func NewDBKey(senderTimestamp uint64, receiverTimestamp uint64, pubsubTopic string, digest []byte) *DBKey {
-	pubSubHash := hash.SHA256([]byte(pubsubTopic))
+	pubSubHash := make([]byte, PubsubTopicLength)
+	if pubsubTopic != "" {
+		pubSubHash = hash.SHA256([]byte(pubsubTopic))
+	}
 
 	var k DBKey
 	k.raw = make([]byte, DBKeyLength)

--- a/waku/persistence/store.go
+++ b/waku/persistence/store.go
@@ -346,7 +346,7 @@ func (d *DBStore) handleQueryCursor(query *pb.HistoryQuery, paramCnt *int, condi
 	handleTimeParam := func(time int64, op string) {
 		*paramCnt++
 		conditions = append(conditions, fmt.Sprintf("id %s $%d", op, *paramCnt))
-		timeDBKey := NewDBKey(uint64(time), uint64(time), "", []byte{})
+		timeDBKey := NewDBKey(uint64(time), 0, "", []byte{})
 		parameters = append(parameters, timeDBKey.Bytes())
 	}
 
@@ -358,7 +358,7 @@ func (d *DBStore) handleQueryCursor(query *pb.HistoryQuery, paramCnt *int, condi
 
 	if query.EndTime != 0 {
 		if !usesCursor || query.PagingInfo.Direction == pb.PagingInfo_FORWARD {
-			handleTimeParam(query.EndTime, "<=")
+			handleTimeParam(query.EndTime+1, "<")
 		}
 	}
 	return conditions, parameters, nil

--- a/waku/persistence/store_test.go
+++ b/waku/persistence/store_test.go
@@ -127,11 +127,11 @@ func TestQuery(t *testing.T) {
 			{ContentTopic: "test3"},
 		},
 		PagingInfo: &pb.PagingInfo{PageSize: 10},
-		StartTime:  insertTime.Add(-41 * time.Second).UnixNano(),
-		EndTime:    insertTime.Add(-21 * time.Second).UnixNano(),
+		StartTime:  insertTime.Add(-40 * time.Second).UnixNano(),
+		EndTime:    insertTime.Add(-20 * time.Second).UnixNano(),
 	})
 	require.NoError(t, err)
-	require.Len(t, msgs, 2)
+	require.Len(t, msgs, 3)
 
 	_ = store.Put(protocol.NewEnvelope(tests.CreateWakuMessage("test5", insertTime.UnixNano()), insertTime.Add(-10*time.Second).UnixNano(), "test"))
 

--- a/waku/v2/protocol/store/waku_store_common.go
+++ b/waku/v2/protocol/store/waku_store_common.go
@@ -18,7 +18,7 @@ import (
 const StoreID_v20beta4 = libp2pProtocol.ID("/vac/waku/store/2.0.0-beta4")
 
 // MaxPageSize is the maximum number of waku messages to return per page
-const MaxPageSize = 100
+const MaxPageSize = 20
 
 // MaxContentFilters is the maximum number of allowed content filters in a query
 const MaxContentFilters = 10


### PR DESCRIPTION
# Description
Fixes an issue reported by @fbarbu15 where a store was not including a message whose timestamp matched the starttime of the query, and also sets the max page size to 20 to match nwaku
