### PR TITLE
fix: setFallbackIP with reported libp2p addr

### DIFF
--- a/waku/v2/node/localnode.go
+++ b/waku/v2/node/localnode.go
@@ -43,11 +43,13 @@ func (w *WakuNode) updateLocalNode(localnode *enode.LocalNode, multiaddrs []ma.M
 		ip4 := ipAddr.IP.To4()
 		ip6 := ipAddr.IP.To16()
 		if ip4 != nil && !ip4.IsUnspecified() {
+			localnode.SetFallbackIP(ip4)
 			localnode.Set(enr.IPv4(ip4))
 			localnode.Set(enr.TCP(uint16(ipAddr.Port)))
 		} else {
 			localnode.Delete(enr.IPv4{})
 			localnode.Delete(enr.TCP(0))
+			localnode.SetFallbackIP(net.IP{127, 0, 0, 1})
 		}
 
 		if ip4 == nil && ip6 != nil && !ip6.IsUnspecified() {
@@ -58,8 +60,6 @@ func (w *WakuNode) updateLocalNode(localnode *enode.LocalNode, multiaddrs []ma.M
 			localnode.Delete(enr.TCP6(0))
 		}
 	}
-
-	localnode.SetFallbackIP(net.IP{127, 0, 0, 1})
 
 	return wenr.Update(localnode, options...)
 }


### PR DESCRIPTION
# Description
While testing `shards.test` fleet, i noticed that when discv5 endpoint predictor fails, the node's IP address reported in the ENR was 127.0.0.1 regardless of the value being set. With this change, the reported libp2p address will be set as fallback address to be used in case endpoint predictor fails to obtain the IP address
