### PR TITLE
refactor: validate protobuffers for lightpush and relay

### DIFF
--- a/waku/v2/protocol/legacy_filter/filter_map.go
+++ b/waku/v2/protocol/legacy_filter/filter_map.go
@@ -104,10 +104,6 @@ func (fm *FilterMap) Notify(msg *pb.WakuMessage, requestID string) {
 	// Broadcasting message so it's stored
 	fm.broadcaster.Submit(envelope)
 
-	if msg.ContentTopic == "" {
-		filter.Chan <- envelope
-	}
-
 	// TODO: In case of no topics we should either trigger here for all messages,
 	// or we should not allow such filter to exist in the first place.
 	for _, contentTopic := range filter.ContentFilters {

--- a/waku/v2/protocol/lightpush/metrics.go
+++ b/waku/v2/protocol/lightpush/metrics.go
@@ -49,14 +49,14 @@ func (m *metricsImpl) RecordMessage() {
 type metricsErrCategory string
 
 var (
-	decodeRPCFailure         metricsErrCategory = "decode_rpc_failure"
-	writeRequestFailure      metricsErrCategory = "write_request_failure"
-	writeResponseFailure     metricsErrCategory = "write_response_failure"
-	dialFailure              metricsErrCategory = "dial_failure"
-	messagePushFailure       metricsErrCategory = "message_push_failure"
-	emptyRequestBodyFailure  metricsErrCategory = "empty_request_body_failure"
-	emptyResponseBodyFailure metricsErrCategory = "empty_response_body_failure"
-	peerNotFoundFailure      metricsErrCategory = "peer_not_found_failure"
+	decodeRPCFailure     metricsErrCategory = "decode_rpc_failure"
+	writeRequestFailure  metricsErrCategory = "write_request_failure"
+	writeResponseFailure metricsErrCategory = "write_response_failure"
+	dialFailure          metricsErrCategory = "dial_failure"
+	messagePushFailure   metricsErrCategory = "message_push_failure"
+	requestBodyFailure   metricsErrCategory = "request_failure"
+	responseBodyFailure  metricsErrCategory = "response_body_failure"
+	peerNotFoundFailure  metricsErrCategory = "peer_not_found_failure"
 )
 
 // RecordError increases the counter for different error types

--- a/waku/v2/protocol/lightpush/pb/validation.go
+++ b/waku/v2/protocol/lightpush/pb/validation.go
@@ -1,0 +1,48 @@
+package pb
+
+import "errors"
+
+var (
+	errMissingRequestID   = errors.New("missing RequestId field")
+	errMissingQuery       = errors.New("missing Query field")
+	errMissingMessage     = errors.New("missing Message field")
+	errMissingPubsubTopic = errors.New("missing PubsubTopic field")
+	errRequestIDMismatch  = errors.New("request_id in response does not match request")
+	errMissingResponse    = errors.New("missing response field")
+)
+
+func (x *PushRPC) ValidateRequest() error {
+	if x.RequestId == "" {
+		return errMissingRequestID
+	}
+
+	if x.Query == nil {
+		return errMissingQuery
+	}
+
+	if x.Query.PubsubTopic == "" {
+		return errMissingPubsubTopic
+	}
+
+	if x.Query.Message == nil {
+		return errMissingMessage
+	}
+
+	return x.Query.Message.Validate()
+}
+
+func (x *PushRPC) ValidateResponse(requestID string) error {
+	if x.RequestId == "" {
+		return errMissingRequestID
+	}
+
+	if x.RequestId != requestID {
+		return errRequestIDMismatch
+	}
+
+	if x.Response == nil {
+		return errMissingResponse
+	}
+
+	return nil
+}

--- a/waku/v2/protocol/lightpush/pb/validation.go
+++ b/waku/v2/protocol/lightpush/pb/validation.go
@@ -7,8 +7,8 @@ var (
 	errMissingQuery       = errors.New("missing Query field")
 	errMissingMessage     = errors.New("missing Message field")
 	errMissingPubsubTopic = errors.New("missing PubsubTopic field")
-	errRequestIDMismatch  = errors.New("request_id in response does not match request")
-	errMissingResponse    = errors.New("missing response field")
+	errRequestIDMismatch  = errors.New("RequestID in response does not match request")
+	errMissingResponse    = errors.New("missing Response field")
 )
 
 func (x *PushRPC) ValidateRequest() error {

--- a/waku/v2/protocol/lightpush/pb/validation_test.go
+++ b/waku/v2/protocol/lightpush/pb/validation_test.go
@@ -1,0 +1,35 @@
+package pb
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/waku-org/go-waku/waku/v2/protocol/pb"
+)
+
+func TestValidateRequest(t *testing.T) {
+	request := PushRPC{}
+	require.ErrorIs(t, request.ValidateRequest(), errMissingRequestID)
+	request.RequestId = "test"
+	require.ErrorIs(t, request.ValidateRequest(), errMissingQuery)
+	request.Query = &PushRequest{}
+	require.ErrorIs(t, request.ValidateRequest(), errMissingPubsubTopic)
+	request.Query.PubsubTopic = "test"
+	require.ErrorIs(t, request.ValidateRequest(), errMissingMessage)
+	request.Query.Message = &pb.WakuMessage{
+		Payload:      []byte{1, 2, 3},
+		ContentTopic: "test",
+	}
+	require.NoError(t, request.ValidateRequest())
+}
+
+func TestValidateResponse(t *testing.T) {
+	response := PushRPC{}
+	require.ErrorIs(t, response.ValidateResponse("test"), errMissingRequestID)
+	response.RequestId = "test1"
+	require.ErrorIs(t, response.ValidateResponse("test"), errRequestIDMismatch)
+	response.RequestId = "test"
+	require.ErrorIs(t, response.ValidateResponse("test"), errMissingResponse)
+	response.Response = &PushResponse{}
+	require.NoError(t, response.ValidateResponse("test"))
+}

--- a/waku/v2/protocol/pb/validation.go
+++ b/waku/v2/protocol/pb/validation.go
@@ -9,13 +9,18 @@ import (
 const MaxMetaAttrLength = 64
 
 var (
-	errMissingPayload    = errors.New("missing Payload field")
-	errInvalidMetaLength = errors.New("invalid length for Meta field")
+	errMissingPayload      = errors.New("missing Payload field")
+	errMissingContentTopic = errors.New("missing ContentTopic field")
+	errInvalidMetaLength   = errors.New("invalid length for Meta field")
 )
 
 func (msg *WakuMessage) Validate() error {
 	if len(msg.Payload) == 0 {
 		return errMissingPayload
+	}
+
+	if msg.ContentTopic == "" {
+		return errMissingContentTopic
 	}
 
 	if len(msg.Meta) > MaxMetaAttrLength {

--- a/waku/v2/protocol/pb/validation.go
+++ b/waku/v2/protocol/pb/validation.go
@@ -1,0 +1,42 @@
+package pb
+
+import (
+	"errors"
+
+	"google.golang.org/protobuf/proto"
+)
+
+const MaxMetaAttrLength = 64
+
+var (
+	errMissingPayload    = errors.New("missing Payload field")
+	errInvalidMetaLength = errors.New("invalid length for Meta field")
+)
+
+func (msg *WakuMessage) Validate() error {
+	if len(msg.Payload) == 0 {
+		return errMissingPayload
+	}
+
+	if len(msg.Meta) > MaxMetaAttrLength {
+		return errInvalidMetaLength
+	}
+
+	return nil
+}
+
+func Unmarshal(data []byte) (*WakuMessage, error) {
+	msg := &WakuMessage{}
+	err := proto.Unmarshal(data, msg)
+	if err != nil {
+		return nil, err
+	}
+
+	err = msg.Validate()
+	if err != nil {
+		return nil, err
+	}
+
+	return msg, nil
+
+}

--- a/waku/v2/protocol/relay/validators.go
+++ b/waku/v2/protocol/relay/validators.go
@@ -12,7 +12,6 @@ import (
 	"github.com/ethereum/go-ethereum/crypto/secp256k1"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	"github.com/libp2p/go-libp2p/core/peer"
-	proto "google.golang.org/protobuf/proto"
 
 	"github.com/waku-org/go-waku/waku/v2/hash"
 	"github.com/waku-org/go-waku/waku/v2/protocol/pb"
@@ -62,8 +61,7 @@ func (w *WakuRelay) RemoveTopicValidator(topic string) {
 
 func (w *WakuRelay) topicValidator(topic string) func(ctx context.Context, peerID peer.ID, message *pubsub.Message) bool {
 	return func(ctx context.Context, peerID peer.ID, message *pubsub.Message) bool {
-		msg := new(pb.WakuMessage)
-		err := proto.Unmarshal(message.Data, msg)
+		msg, err := pb.Unmarshal(message.Data)
 		if err != nil {
 			return false
 		}

--- a/waku/v2/protocol/relay/waku_relay.go
+++ b/waku/v2/protocol/relay/waku_relay.go
@@ -234,12 +234,15 @@ func (w *WakuRelay) PublishToTopic(ctx context.Context, message *pb.WakuMessage,
 		return nil, errors.New("message can't be null")
 	}
 
+	if err := message.Validate(); err != nil {
+		return nil, err
+	}
+
 	if !w.EnoughPeersToPublishToTopic(topic) {
 		return nil, errors.New("not enough peers to publish")
 	}
 
 	pubSubTopic, err := w.upsertTopic(topic)
-
 	if err != nil {
 		return nil, err
 	}
@@ -460,11 +463,13 @@ func (w *WakuRelay) pubsubTopicMsgHandler(pubsubTopic string, sub *pubsub.Subscr
 			sub.Cancel()
 			return
 		}
-		wakuMessage := &pb.WakuMessage{}
-		if err := proto.Unmarshal(msg.Data, wakuMessage); err != nil {
+
+		wakuMessage, err := pb.Unmarshal(msg.Data)
+		if err != nil {
 			w.log.Error("decoding message", zap.Error(err))
 			return
 		}
+
 		envelope := waku_proto.NewEnvelope(wakuMessage, w.timesource.Now().UnixNano(), pubsubTopic)
 		w.metrics.RecordMessage(envelope)
 


### PR DESCRIPTION
# Description
Validates the content of the protobuffers for both lightpush and relay. In the case of relay, if there's an error while validating the protobuffer, the error string will be returned as a response.

In next PRs I'll add similar validations to the other protocols, assuming this PR is approved!
