### PR TITLE
fix: do not disconnect peers in `TestWakuMetadataRequest`

### DIFF
--- a/waku/v2/protocol/metadata/waku_metadata_test.go
+++ b/waku/v2/protocol/metadata/waku_metadata_test.go
@@ -54,6 +54,11 @@ func TestWakuMetadataRequest(t *testing.T) {
 	m16_2 := createWakuMetadata(t, &rs16_2)
 	m_noRS := createWakuMetadata(t, nil)
 
+	// Removing notifee to test metadata protocol functionality without having the peers being disconnected by the notify process
+	m16_1.h.Network().StopNotify(m16_1)
+	m16_2.h.Network().StopNotify(m16_2)
+	m_noRS.h.Network().StopNotify(m_noRS)
+
 	m16_1.h.Peerstore().AddAddrs(m16_2.h.ID(), m16_2.h.Network().ListenAddresses(), peerstore.PermanentAddrTTL)
 	m16_1.h.Peerstore().AddAddrs(m_noRS.h.ID(), m_noRS.h.Network().ListenAddresses(), peerstore.PermanentAddrTTL)
 


### PR DESCRIPTION
# Description
`TestWakuMetadataRequest` is a test intended to check the request/responses for metadata protocol are correct. As such, since we're interested in having deterministic responses, and not disconnect the peers automatically, in this PR I remove the notification process specifically for this test. Other metadata tests are not affected and will still use the notifier mechanism to disconnect peers
