### PR TITLE
fix: propagate relay subscribe opt properly

### DIFF
--- a/waku/v2/protocol/relay/broadcast.go
+++ b/waku/v2/protocol/relay/broadcast.go
@@ -24,6 +24,12 @@ func DontConsume() BroadcasterOption {
 	}
 }
 
+func WithConsumerOption(dontConsume bool) BroadcasterOption {
+	return func(params *BroadcasterParameters) {
+		params.dontConsume = dontConsume
+	}
+}
+
 // WithBufferSize option let's a user set channel buffer to be set.
 func WithBufferSize(size int) BroadcasterOption {
 	return func(params *BroadcasterParameters) {

--- a/waku/v2/protocol/relay/waku_relay.go
+++ b/waku/v2/protocol/relay/waku_relay.go
@@ -339,7 +339,8 @@ func (w *WakuRelay) subscribe(ctx context.Context, contentFilter waku_proto.Cont
 			}
 		}
 
-		subscription := w.bcaster.Register(cFilter, WithBufferSize(DefaultRelaySubscriptionBufferSize))
+		subscription := w.bcaster.Register(cFilter, WithBufferSize(DefaultRelaySubscriptionBufferSize),
+			WithConsumerOption(params.dontConsume))
 
 		// Create Content subscription
 		w.topicsMutex.RLock()


### PR DESCRIPTION
# Description
Relay subscription option was not propagated to broadcaster causing subscriber too slow issue when running service node.

