### PR TITLE
fix: modify store test to not depend on order of msgs

### DIFF
--- a/waku/v2/protocol/store/waku_store_query_test.go
+++ b/waku/v2/protocol/store/waku_store_query_test.go
@@ -145,22 +145,9 @@ func TestStoreQueryPubsubTopicAllMessages(t *testing.T) {
 	})
 
 	require.Len(t, response.Messages, 3)
-	var msgRcvd [3]bool
-	for i := 0; i < 3; i++ {
-		if proto.Equal(response.Messages[i], msg1) {
-			msgRcvd[0] = true
-		} else if proto.Equal(response.Messages[i], msg2) {
-			msgRcvd[1] = true
-		} else if proto.Equal(response.Messages[i], msg3) {
-			msgRcvd[2] = true
-		} else {
-			t.FailNow()
-		}
-	}
-	for i := 0; i < 3; i++ {
-		require.True(t, true, msgRcvd[i])
-
-	}
+	require.Contains(t, response.Messages, msg1)
+	require.Contains(t, response.Messages, msg2)
+	require.Contains(t, response.Messages, msg3)
 }
 
 func TestStoreQueryForwardPagination(t *testing.T) {

--- a/waku/v2/protocol/store/waku_store_query_test.go
+++ b/waku/v2/protocol/store/waku_store_query_test.go
@@ -145,9 +145,22 @@ func TestStoreQueryPubsubTopicAllMessages(t *testing.T) {
 	})
 
 	require.Len(t, response.Messages, 3)
-	require.True(t, proto.Equal(response.Messages[0], msg1))
-	require.True(t, proto.Equal(response.Messages[1], msg2))
-	require.True(t, proto.Equal(response.Messages[2], msg3))
+	var msgRcvd [3]bool
+	for i := 0; i < 3; i++ {
+		if proto.Equal(response.Messages[i], msg1) {
+			msgRcvd[0] = true
+		} else if proto.Equal(response.Messages[i], msg2) {
+			msgRcvd[1] = true
+		} else if proto.Equal(response.Messages[i], msg3) {
+			msgRcvd[2] = true
+		} else {
+			t.FailNow()
+		}
+	}
+	for i := 0; i < 3; i++ {
+		require.True(t, true, msgRcvd[i])
+
+	}
 }
 
 func TestStoreQueryForwardPagination(t *testing.T) {


### PR DESCRIPTION
# Description

Issue due to macOS/darwin time precision. 
macOS/darwin time is maintained/returned only at microsecond granularity and not at nanosecond granularity. This was the reason for failure of the test. As the test is not meant to depend on timestamps, it has been modified to address the issue.
https://groups.google.com/g/golang-dev/c/DboHw1eCiSc?pli=1 


# Changes

- [x] Rather than depending on order of messages in validating the test, test now validates whether all 3 messages are retrieved
