### PR TITLE
refactor: shard LRU for storing peers by shard 

### DIFF
--- a/waku/v2/protocol/peer_exchange/enr_cache.go
+++ b/waku/v2/protocol/peer_exchange/enr_cache.go
@@ -14,7 +14,7 @@ import (
 
 // simpleLRU internal uses container/list, which is ring buffer(double linked list)
 type enrCache struct {
-	// using lru, saves us from periodically cleaning the cache to mauint16ain a certain size
+	// using lru, saves us from periodically cleaning the cache to mauintain a certain size
 	data *shardLRU
 	rng  *rand.Rand
 	mu   sync.RWMutex
@@ -43,7 +43,7 @@ func (c *enrCache) updateCache(node *enode.Node) {
 }
 
 // get `numPeers` records of enr
-func (c *enrCache) getENRs(neededPeers int, clusterIndex *ClusterShard) ([]*pb.PeerInfo, error) {
+func (c *enrCache) getENRs(neededPeers int, clusterIndex *ShardInfo) ([]*pb.PeerInfo, error) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	//

--- a/waku/v2/protocol/peer_exchange/enr_cache.go
+++ b/waku/v2/protocol/peer_exchange/enr_cache.go
@@ -12,7 +12,7 @@ import (
 	"go.uber.org/zap"
 )
 
-// simpleLRU uint16ernal uses container/list, which is ring buffer(double linked list)
+// simpleLRU internal uses container/list, which is ring buffer(double linked list)
 type enrCache struct {
 	// using lru, saves us from periodically cleaning the cache to mauint16ain a certain size
 	data *shardLRU

--- a/waku/v2/protocol/peer_exchange/enr_cache.go
+++ b/waku/v2/protocol/peer_exchange/enr_cache.go
@@ -7,18 +7,16 @@ import (
 	"github.com/ethereum/go-ethereum/p2p/enode"
 
 	"github.com/waku-org/go-waku/waku/v2/protocol/peer_exchange/pb"
-	"go.uber.org/zap"
 )
 
 // simpleLRU internal uses container/list, which is ring buffer(double linked list)
 type enrCache struct {
 	// using lru, saves us from periodically cleaning the cache to mauintain a certain size
 	data *shardLRU
-	log  *zap.Logger
 }
 
 // err on negative size
-func newEnrCache(size int, log *zap.Logger) *enrCache {
+func newEnrCache(size int) *enrCache {
 	inner := newShardLRU(int(size))
 	return &enrCache{
 		data: inner,
@@ -26,12 +24,12 @@ func newEnrCache(size int, log *zap.Logger) *enrCache {
 }
 
 // updating cache
-func (c *enrCache) updateCache(node *enode.Node) {
+func (c *enrCache) updateCache(node *enode.Node) error {
 	currNode := c.data.Get(node.ID())
 	if currNode == nil || node.Seq() > currNode.Seq() {
-		c.data.Add(node)
-		c.log.Debug("discovered px peer via discv5", zap.Stringer("enr", node))
+		return c.data.Add(node)
 	}
+	return nil
 }
 
 // get `numPeers` records of enr

--- a/waku/v2/protocol/peer_exchange/protocol.go
+++ b/waku/v2/protocol/peer_exchange/protocol.go
@@ -57,7 +57,7 @@ func NewWakuPeerExchange(disc *discv5.DiscoveryV5, peerConnector PeerConnector, 
 	wakuPX.disc = disc
 	wakuPX.metrics = newMetrics(reg)
 	wakuPX.log = log.Named("wakupx")
-	wakuPX.enrCache = newEnrCache(MaxCacheSize, log)
+	wakuPX.enrCache = newEnrCache(MaxCacheSize)
 	wakuPX.peerConnector = peerConnector
 	wakuPX.pm = pm
 	wakuPX.CommonService = service.NewCommonService()
@@ -155,7 +155,11 @@ func (wakuPX *WakuPeerExchange) iterate(ctx context.Context) error {
 			continue
 		}
 
-		wakuPX.enrCache.updateCache(iterator.Node())
+		err = wakuPX.enrCache.updateCache(iterator.Node())
+		if err != nil {
+			wakuPX.log.Error("adding peer to cache", zap.Error(err))
+			continue
+		}
 
 		select {
 		case <-ctx.Done():

--- a/waku/v2/protocol/peer_exchange/protocol.go
+++ b/waku/v2/protocol/peer_exchange/protocol.go
@@ -57,16 +57,10 @@ func NewWakuPeerExchange(disc *discv5.DiscoveryV5, peerConnector PeerConnector, 
 	wakuPX.disc = disc
 	wakuPX.metrics = newMetrics(reg)
 	wakuPX.log = log.Named("wakupx")
+	wakuPX.enrCache = newEnrCache(MaxCacheSize, log)
 	wakuPX.peerConnector = peerConnector
 	wakuPX.pm = pm
 	wakuPX.CommonService = service.NewCommonService()
-
-	newEnrCache, err := newEnrCache(MaxCacheSize, wakuPX.log)
-	if err != nil {
-		return nil, err
-	}
-
-	wakuPX.enrCache = newEnrCache
 
 	return wakuPX, nil
 }
@@ -108,7 +102,7 @@ func (wakuPX *WakuPeerExchange) onRequest() func(network.Stream) {
 		if requestRPC.Query != nil {
 			logger.Info("request received")
 
-			records, err := wakuPX.enrCache.getENRs(int(requestRPC.Query.NumPeers))
+			records, err := wakuPX.enrCache.getENRs(int(requestRPC.Query.NumPeers), nil)
 			if err != nil {
 				logger.Error("obtaining enrs from cache", zap.Error(err))
 				wakuPX.metrics.RecordError(pxFailure)

--- a/waku/v2/protocol/peer_exchange/shard_lru.go
+++ b/waku/v2/protocol/peer_exchange/shard_lru.go
@@ -8,26 +8,26 @@ import (
 	wenr "github.com/waku-org/go-waku/waku/v2/protocol/enr"
 )
 
-type ClusterShard struct {
+type ShardInfo struct {
 	clusterID uint16
 	shard     uint16
 }
 type shardLRU struct {
 	size       int // number of nodes allowed per shard
 	idToNode   map[enode.ID][]*list.Element
-	shardNodes map[ClusterShard]*list.List
+	shardNodes map[ShardInfo]*list.List
 }
 
 func newShardLRU(size int) *shardLRU {
 	return &shardLRU{
 		idToNode:   map[enode.ID][]*list.Element{},
-		shardNodes: map[ClusterShard]*list.List{},
+		shardNodes: map[ShardInfo]*list.List{},
 		size:       size,
 	}
 }
 
 type nodeWithClusterIndex struct {
-	key  ClusterShard
+	key  ShardInfo
 	node *enode.Node
 }
 
@@ -66,7 +66,7 @@ func (l *shardLRU) add(node *enode.Node) {
 	}
 	elements := []*list.Element{}
 	for _, index := range shard.ShardIDs {
-		key := ClusterShard{
+		key := ShardInfo{
 			shard.ClusterID,
 			index,
 		}
@@ -96,7 +96,7 @@ func (l *shardLRU) Add(node *enode.Node) {
 }
 
 // clusterIndex is nil when peers for no specific shard are requested
-func (l shardLRU) getNodes(clusterIndex *ClusterShard) []*enode.Node {
+func (l shardLRU) getNodes(clusterIndex *ShardInfo) []*enode.Node {
 	// if clusterIndex is nil, then return all nodes
 	if clusterIndex == nil {
 		nodes := make([]*enode.Node, 0, len(l.idToNode))
@@ -118,7 +118,7 @@ func (l shardLRU) getNodes(clusterIndex *ClusterShard) []*enode.Node {
 
 // if clusterIndex is not nil, return len of nodes maintained for a given shard
 // if clusterIndex is nil, return count of all nodes maintained
-func (l shardLRU) len(clusterIndex *ClusterShard) int {
+func (l shardLRU) len(clusterIndex *ShardInfo) int {
 	if clusterIndex == nil {
 		return len(l.idToNode)
 	}

--- a/waku/v2/protocol/peer_exchange/shard_lru.go
+++ b/waku/v2/protocol/peer_exchange/shard_lru.go
@@ -1,0 +1,137 @@
+package peer_exchange
+
+import (
+	"container/list"
+
+	"github.com/ethereum/go-ethereum/p2p/enode"
+	"github.com/waku-org/go-waku/waku/v2/protocol"
+	wenr "github.com/waku-org/go-waku/waku/v2/protocol/enr"
+)
+
+type ClusterShard struct {
+	clusterID uint16
+	shard     uint16
+}
+type shardLRU struct {
+	size       int // number of nodes allowed per shard
+	idToNode   map[enode.ID][]*list.Element
+	shardNodes map[ClusterShard]*list.List
+}
+
+func newShardLRU(size int) *shardLRU {
+	return &shardLRU{
+		idToNode:   map[enode.ID][]*list.Element{},
+		shardNodes: map[ClusterShard]*list.List{},
+		size:       size,
+	}
+}
+
+type nodeWithClusterIndex struct {
+	key  ClusterShard
+	node *enode.Node
+}
+
+// time complexity: O(number of previous indexes present for node.ID)
+func (l *shardLRU) remove(node *enode.Node) {
+	elements := l.idToNode[node.ID()]
+	for _, element := range elements {
+		key := element.Value.(nodeWithClusterIndex).key
+		l.shardNodes[key].Remove(element)
+	}
+	delete(l.idToNode, node.ID())
+}
+
+// if a node is removed for a list, remove it from idToNode too
+func (l *shardLRU) removeFromIdToNode(ele *list.Element) {
+	nodeID := ele.Value.(nodeWithClusterIndex).node.ID()
+	for ind, entries := range l.idToNode[nodeID] {
+		if entries == ele {
+			l.idToNode[nodeID] = append(l.idToNode[nodeID][:ind], l.idToNode[nodeID][ind+1:]...)
+			break
+		}
+	}
+	if len(l.idToNode[nodeID]) == 0 {
+		delete(l.idToNode, nodeID)
+	}
+}
+
+// time complexity: O(new number of indexes in node's shard)
+func (l *shardLRU) add(node *enode.Node) {
+	shard, err := wenr.RelaySharding(node.Record())
+	if shard == nil || err != nil { // if no shard info, then add to node to Cluster 0, Index 0
+		shard = &protocol.RelayShards{
+			ClusterID: 0,
+			ShardIDs:  []uint16{0},
+		}
+	}
+	elements := []*list.Element{}
+	for _, index := range shard.ShardIDs {
+		key := ClusterShard{
+			shard.ClusterID,
+			index,
+		}
+		if l.shardNodes[key] == nil {
+			l.shardNodes[key] = list.New()
+		}
+		if l.shardNodes[key].Len() >= l.size {
+			oldest := l.shardNodes[key].Back()
+			l.removeFromIdToNode(oldest)
+			l.shardNodes[key].Remove(oldest)
+		}
+		entry := l.shardNodes[key].PushFront(nodeWithClusterIndex{
+			key:  key,
+			node: node,
+		})
+		elements = append(elements, entry)
+
+	}
+	l.idToNode[node.ID()] = elements
+}
+
+// this will be called when the seq number of node is more than the one in cache
+func (l *shardLRU) Add(node *enode.Node) {
+	// removing bcz previous node might be subscribed to different shards, we need to remove node from those shards
+	l.remove(node)
+	l.add(node)
+}
+
+// clusterIndex is nil when peers for no specific shard are requested
+func (l shardLRU) getNodes(clusterIndex *ClusterShard) []*enode.Node {
+	// if clusterIndex is nil, then return all nodes
+	if clusterIndex == nil {
+		nodes := make([]*enode.Node, 0, len(l.idToNode))
+		for _, entries := range l.idToNode {
+			nodes = append(nodes, entries[0].Value.(nodeWithClusterIndex).node)
+		}
+		return nodes
+	}
+	//
+	if entries := l.shardNodes[*clusterIndex]; entries != nil && entries.Len() != 0 {
+		nodes := make([]*enode.Node, 0, entries.Len())
+		for ent := entries.Back(); ent != nil; ent = ent.Prev() {
+			nodes = append(nodes, ent.Value.(nodeWithClusterIndex).node)
+		}
+		return nodes
+	}
+	return nil
+}
+
+// if clusterIndex is not nil, return len of nodes maintained for a given shard
+// if clusterIndex is nil, return count of all nodes maintained
+func (l shardLRU) len(clusterIndex *ClusterShard) int {
+	if clusterIndex == nil {
+		return len(l.idToNode)
+	}
+	if entries := l.shardNodes[*clusterIndex]; entries != nil {
+		return entries.Len()
+	}
+	return 0
+}
+
+// get the node with the given id, if it is present in cache
+func (l shardLRU) Get(id enode.ID) *enode.Node {
+	if elements, ok := l.idToNode[id]; ok && len(elements) > 0 {
+		return elements[0].Value.(nodeWithClusterIndex).node
+	}
+	return nil
+}

--- a/waku/v2/protocol/peer_exchange/shard_lru_test.go
+++ b/waku/v2/protocol/peer_exchange/shard_lru_test.go
@@ -39,7 +39,7 @@ func TestLruMoreThanSize(t *testing.T) {
 	lru.Add(node2)
 	lru.Add(node3)
 
-	nodes := lru.getNodes(&ClusterIndex{1, 1})
+	nodes := lru.getNodes(&ShardInfo{1, 1})
 
 	require.Equal(t, 2, len(nodes))
 	require.Equal(t, node2.ID(), nodes[0].ID())
@@ -75,13 +75,13 @@ func TestLruNodeWithNewSeq(t *testing.T) {
 	lru.Add(node1)
 
 	//
-	nodes := lru.getNodes(&ClusterIndex{1, 1})
+	nodes := lru.getNodes(&ShardInfo{1, 1})
 	require.Equal(t, 0, len(nodes))
 	//
-	nodes = lru.getNodes(&ClusterIndex{1, 2})
+	nodes = lru.getNodes(&ShardInfo{1, 2})
 	require.Equal(t, 1, len(nodes))
 	//
-	nodes = lru.getNodes(&ClusterIndex{1, 3})
+	nodes = lru.getNodes(&ShardInfo{1, 3})
 	require.Equal(t, 1, len(nodes))
 }
 
@@ -119,12 +119,12 @@ func TestLruMixedNodes(t *testing.T) {
 	require.Equal(t, 3, lru.len(nil))
 
 	//
-	nodes := lru.getNodes(&ClusterIndex{1, 1})
+	nodes := lru.getNodes(&ShardInfo{1, 1})
 	require.Equal(t, 1, len(nodes))
 	require.Equal(t, node2.ID(), nodes[0].ID())
 
 	//
-	nodes = lru.getNodes(&ClusterIndex{1, 2})
+	nodes = lru.getNodes(&ShardInfo{1, 2})
 	require.Equal(t, 1, len(nodes))
 	require.Equal(t, node3.ID(), nodes[0].ID())
 }

--- a/waku/v2/protocol/peer_exchange/shard_lru_test.go
+++ b/waku/v2/protocol/peer_exchange/shard_lru_test.go
@@ -35,9 +35,14 @@ func TestLruMoreThanSize(t *testing.T) {
 
 	lru := newShardLRU(2)
 
-	lru.Add(node1)
-	lru.Add(node2)
-	lru.Add(node3)
+	err := lru.Add(node1)
+	require.NoError(t, err)
+
+	err = lru.Add(node2)
+	require.NoError(t, err)
+
+	err = lru.Add(node3)
+	require.NoError(t, err)
 
 	nodes := lru.GetRandomNodes(&ShardInfo{1, 1}, 1)
 
@@ -50,8 +55,12 @@ func TestLruMoreThanSize(t *testing.T) {
 
 	// node 2 is removed from lru for cluster 1/shard 1 but it is still being maintained for cluster1,index2
 	{
-		lru.Add(getEnode(t, nil, 1, 1)) // add two more nodes to 1/1 cluster shard
-		lru.Add(getEnode(t, nil, 1, 1))
+		err = lru.Add(getEnode(t, nil, 1, 1)) // add two more nodes to 1/1 cluster shard
+		require.NoError(t, err)
+
+		err = lru.Add(getEnode(t, nil, 1, 1))
+		require.NoError(t, err)
+
 	}
 
 	// node2 still present in lru
@@ -59,8 +68,11 @@ func TestLruMoreThanSize(t *testing.T) {
 
 	// now node2 is removed from all shards' cache
 	{
-		lru.Add(getEnode(t, nil, 1, 2)) // add two more nodes to 1/2 cluster shard
-		lru.Add(getEnode(t, nil, 1, 2))
+		err = lru.Add(getEnode(t, nil, 1, 2)) // add two more nodes to 1/2 cluster shard
+		require.NoError(t, err)
+
+		err = lru.Add(getEnode(t, nil, 1, 2))
+		require.NoError(t, err)
 	}
 
 	// node2 still present in lru
@@ -74,10 +86,12 @@ func TestLruNodeWithNewSeq(t *testing.T) {
 	require.NoError(t, err)
 
 	node1 := getEnode(t, key, 1, 1)
-	lru.Add(node1)
+	err = lru.Add(node1)
+	require.NoError(t, err)
 
 	node1 = getEnode(t, key, 1, 2, 3)
-	lru.Add(node1)
+	err = lru.Add(node1)
+	require.NoError(t, err)
 
 	//
 	nodes := lru.GetRandomNodes(&ShardInfo{1, 1}, 2)
@@ -96,8 +110,11 @@ func TestLruNoShard(t *testing.T) {
 	node1 := getEnode(t, nil, 0)
 	node2 := getEnode(t, nil, 0)
 
-	lru.Add(node1)
-	lru.Add(node2)
+	err := lru.Add(node1)
+	require.NoError(t, err)
+
+	err = lru.Add(node2)
+	require.NoError(t, err)
 
 	// check returned nodes
 	require.Equal(t, 2, lru.len(nil))
@@ -113,12 +130,16 @@ func TestLruMixedNodes(t *testing.T) {
 	lru := newShardLRU(2)
 
 	node1 := getEnode(t, nil, 0)
-	lru.Add(node1)
+	err := lru.Add(node1)
+	require.NoError(t, err)
 
 	node2 := getEnode(t, nil, 1, 1)
-	lru.Add(node2)
+	err = lru.Add(node2)
+	require.NoError(t, err)
+
 	node3 := getEnode(t, nil, 1, 2)
-	lru.Add(node3)
+	err = lru.Add(node3)
+	require.NoError(t, err)
 
 	// check that default
 	require.Equal(t, 3, lru.len(nil))

--- a/waku/v2/protocol/peer_exchange/shard_lru_test.go
+++ b/waku/v2/protocol/peer_exchange/shard_lru_test.go
@@ -39,7 +39,7 @@ func TestLruMoreThanSize(t *testing.T) {
 	lru.Add(node2)
 	lru.Add(node3)
 
-	nodes := lru.getRandomNodes(&ShardInfo{1, 1}, 1)
+	nodes := lru.GetRandomNodes(&ShardInfo{1, 1}, 1)
 
 	require.Equal(t, 1, len(nodes))
 	if nodes[0].ID() != node2.ID() && nodes[0].ID() != node3.ID() {
@@ -80,13 +80,13 @@ func TestLruNodeWithNewSeq(t *testing.T) {
 	lru.Add(node1)
 
 	//
-	nodes := lru.getRandomNodes(&ShardInfo{1, 1}, 2)
+	nodes := lru.GetRandomNodes(&ShardInfo{1, 1}, 2)
 	require.Equal(t, 0, len(nodes))
 	//
-	nodes = lru.getRandomNodes(&ShardInfo{1, 2}, 2)
+	nodes = lru.GetRandomNodes(&ShardInfo{1, 2}, 2)
 	require.Equal(t, 1, len(nodes))
 	//
-	nodes = lru.getRandomNodes(&ShardInfo{1, 3}, 2)
+	nodes = lru.GetRandomNodes(&ShardInfo{1, 3}, 2)
 	require.Equal(t, 1, len(nodes))
 }
 
@@ -101,7 +101,7 @@ func TestLruNoShard(t *testing.T) {
 
 	// check returned nodes
 	require.Equal(t, 2, lru.len(nil))
-	for _, node := range lru.getRandomNodes(nil, 2) {
+	for _, node := range lru.GetRandomNodes(nil, 2) {
 		if node.ID() != node1.ID() && node.ID() != node2.ID() {
 			t.Fatalf("different node found %v", node)
 		}
@@ -124,12 +124,12 @@ func TestLruMixedNodes(t *testing.T) {
 	require.Equal(t, 3, lru.len(nil))
 
 	//
-	nodes := lru.getRandomNodes(&ShardInfo{1, 1}, 2)
+	nodes := lru.GetRandomNodes(&ShardInfo{1, 1}, 2)
 	require.Equal(t, 1, len(nodes))
 	require.Equal(t, node2.ID(), nodes[0].ID())
 
 	//
-	nodes = lru.getRandomNodes(&ShardInfo{1, 2}, 2)
+	nodes = lru.GetRandomNodes(&ShardInfo{1, 2}, 2)
 	require.Equal(t, 1, len(nodes))
 	require.Equal(t, node3.ID(), nodes[0].ID())
 }

--- a/waku/v2/protocol/peer_exchange/shard_lru_test.go
+++ b/waku/v2/protocol/peer_exchange/shard_lru_test.go
@@ -1,0 +1,130 @@
+package peer_exchange
+
+import (
+	"crypto/ecdsa"
+	"testing"
+
+	gcrypto "github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/p2p/enode"
+	"github.com/ethereum/go-ethereum/p2p/enr"
+	"github.com/stretchr/testify/require"
+	"github.com/waku-org/go-waku/waku/v2/protocol"
+	wenr "github.com/waku-org/go-waku/waku/v2/protocol/enr"
+)
+
+func getEnode(t *testing.T, key *ecdsa.PrivateKey, cluster uint16, indexes ...uint16) *enode.Node {
+	if key == nil {
+		var err error
+		key, err = gcrypto.GenerateKey()
+		require.NoError(t, err)
+	}
+	myNode, err := wenr.NewLocalnode(key)
+	require.NoError(t, err)
+	if cluster != 0 {
+		shard, err := protocol.NewRelayShards(cluster, indexes...)
+		require.NoError(t, err)
+		myNode.Set(enr.WithEntry(wenr.ShardingBitVectorEnrField, shard.BitVector()))
+	}
+	return myNode.Node()
+}
+
+func TestLruMoreThanSize(t *testing.T) {
+	node1 := getEnode(t, nil, 1, 1)
+	node2 := getEnode(t, nil, 1, 1, 2)
+	node3 := getEnode(t, nil, 1, 1)
+
+	lru := newShardLRU(2)
+
+	lru.Add(node1)
+	lru.Add(node2)
+	lru.Add(node3)
+
+	nodes := lru.getNodes(&ClusterIndex{1, 1})
+
+	require.Equal(t, 2, len(nodes))
+	require.Equal(t, node2.ID(), nodes[0].ID())
+	require.Equal(t, node3.ID(), nodes[1].ID())
+	// checks if removed node is deleted from lru or not
+	require.Nil(t, lru.Get(node1.ID()))
+
+	// node 2 is removed from lru for cluster 1/index 1 but it is still being maintained for cluster1,index2
+	node4 := getEnode(t, nil, 1, 1, 2)
+	lru.Add(node4)
+
+	// node2 still present in lru
+	require.Equal(t, node2, lru.Get(node2.ID()))
+
+	// now node2 is removed from all shards' cache
+	node5 := getEnode(t, nil, 1, 2)
+	lru.Add(node5)
+
+	// node2 still present in lru
+	require.Nil(t, lru.Get(node2.ID()))
+}
+
+func TestLruNodeWithNewSeq(t *testing.T) {
+	lru := newShardLRU(2)
+	//
+	key, err := gcrypto.GenerateKey()
+	require.NoError(t, err)
+
+	node1 := getEnode(t, key, 1, 1)
+	lru.Add(node1)
+
+	node1 = getEnode(t, key, 1, 2, 3)
+	lru.Add(node1)
+
+	//
+	nodes := lru.getNodes(&ClusterIndex{1, 1})
+	require.Equal(t, 0, len(nodes))
+	//
+	nodes = lru.getNodes(&ClusterIndex{1, 2})
+	require.Equal(t, 1, len(nodes))
+	//
+	nodes = lru.getNodes(&ClusterIndex{1, 3})
+	require.Equal(t, 1, len(nodes))
+}
+
+func TestLruNoShard(t *testing.T) {
+	lru := newShardLRU(2)
+
+	node1 := getEnode(t, nil, 0)
+	node2 := getEnode(t, nil, 0)
+
+	lru.Add(node1)
+	lru.Add(node2)
+
+	// check returned nodes
+	require.Equal(t, 2, lru.len(nil))
+	for _, node := range lru.getNodes(nil) {
+		if node.ID() != node1.ID() && node.ID() != node2.ID() {
+			t.Fatalf("different node found %v", node)
+		}
+	}
+}
+
+// checks if lru is able to handle nodes with/without shards together
+func TestLruMixedNodes(t *testing.T) {
+	lru := newShardLRU(2)
+
+	node1 := getEnode(t, nil, 0)
+	lru.Add(node1)
+
+	node2 := getEnode(t, nil, 1, 1)
+	lru.Add(node2)
+	node3 := getEnode(t, nil, 1, 2)
+	lru.Add(node3)
+
+	// check that default
+	require.Equal(t, 3, lru.len(nil))
+
+	//
+	nodes := lru.getNodes(&ClusterIndex{1, 1})
+	require.Equal(t, 1, len(nodes))
+	require.Equal(t, node2.ID(), nodes[0].ID())
+
+	//
+	nodes = lru.getNodes(&ClusterIndex{1, 2})
+	require.Equal(t, 1, len(nodes))
+	require.Equal(t, node3.ID(), nodes[0].ID())
+}


### PR DESCRIPTION
# Description
Add data structure for storing peers by cluster/index in peerExchange.  Related to https://github.com/waku-org/go-waku/issues/839
- Addition of node takes time complexity  of O(count of prev index+ new indexes).



# Tests


- [x] add  test for functionality of the sharded cache



## How to test

- [x] make sure all the tests are passing




