### PR TITLE
fix: decode url param in relay rest API

### DIFF
--- a/cmd/waku/server/rest/filter_cache.go
+++ b/cmd/waku/server/rest/filter_cache.go
@@ -68,7 +68,7 @@ func (c *filterCache) getMessages(pubsubTopic string, contentTopic string) ([]*p
 	defer c.mu.RUnlock()
 
 	if c.data[pubsubTopic] == nil || c.data[pubsubTopic][contentTopic] == nil {
-		return nil, fmt.Errorf("Not subscribed to pubsubTopic:%s contentTopic: %s", pubsubTopic, contentTopic)
+		return nil, fmt.Errorf("not subscribed to pubsubTopic:%s contentTopic: %s", pubsubTopic, contentTopic)
 	}
 	msgs := c.data[pubsubTopic][contentTopic]
 	c.data[pubsubTopic][contentTopic] = []*pb.WakuMessage{}

--- a/cmd/waku/server/rest/relay.go
+++ b/cmd/waku/server/rest/relay.go
@@ -216,7 +216,6 @@ func (r *RelayService) postV1Message(w http.ResponseWriter, req *http.Request) {
 	}
 	defer req.Body.Close()
 
-	//var err error
 	if topic == "" {
 		topic = relay.DefaultWakuTopic
 	}

--- a/cmd/waku/server/rest/relay.go
+++ b/cmd/waku/server/rest/relay.go
@@ -171,8 +171,13 @@ func (r *RelayService) getV1Messages(w http.ResponseWriter, req *http.Request) {
 		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
-
-	var err error
+	topic, err := url.QueryUnescape(topic)
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		_, err = w.Write([]byte("invalid topic format"))
+		r.log.Error("writing response", zap.Error(err))
+		return
+	}
 
 	r.messagesMutex.Lock()
 	defer r.messagesMutex.Unlock()
@@ -196,7 +201,13 @@ func (r *RelayService) postV1Message(w http.ResponseWriter, req *http.Request) {
 		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
-
+	topic, err := url.QueryUnescape(topic)
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		_, err = w.Write([]byte("invalid topic format"))
+		r.log.Error("writing response", zap.Error(err))
+		return
+	}
 	var message *pb.WakuMessage
 	decoder := json.NewDecoder(req.Body)
 	if err := decoder.Decode(&message); err != nil {
@@ -205,7 +216,7 @@ func (r *RelayService) postV1Message(w http.ResponseWriter, req *http.Request) {
 	}
 	defer req.Body.Close()
 
-	var err error
+	//var err error
 	if topic == "" {
 		topic = relay.DefaultWakuTopic
 	}

--- a/cmd/waku/server/rest/utils.go
+++ b/cmd/waku/server/rest/utils.go
@@ -2,7 +2,12 @@ package rest
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
+	"net/url"
+
+	"github.com/go-chi/chi/v5"
+	"go.uber.org/zap"
 )
 
 func writeErrOrResponse(w http.ResponseWriter, err error, value interface{}) {
@@ -39,4 +44,29 @@ func writeResponse(w http.ResponseWriter, value interface{}, code int) {
 	// so any statusCode apart from 1xx being written to the header, will be ignored.
 	w.WriteHeader(code)
 	_, _ = w.Write(jsonResponse)
+}
+
+func topicFromPath(w http.ResponseWriter, req *http.Request, field string, logger *zap.Logger) string {
+	topic := chi.URLParam(req, field)
+	if topic == "" {
+		errMissing := fmt.Errorf("missing %s", field)
+		writeGetMessageErr(w, errMissing, http.StatusBadRequest, logger)
+		return ""
+	}
+	topic, err := url.QueryUnescape(topic)
+	if err != nil {
+		errInvalid := fmt.Errorf("invalid %s format", field)
+		writeGetMessageErr(w, errInvalid, http.StatusBadRequest, logger)
+		return ""
+	}
+	return topic
+}
+
+func writeGetMessageErr(w http.ResponseWriter, err error, code int, logger *zap.Logger) {
+	// write status before the body
+	w.WriteHeader(code)
+	logger.Error("get message", zap.Error(err))
+	if _, err := w.Write([]byte(err.Error())); err != nil {
+		logger.Error("writing response", zap.Error(err))
+	}
 }


### PR DESCRIPTION
# Description
Topic URL param is not being read properly in relay REST APIs which is causing 500 error. 

```
Hi, I'm trying to use relay via REST API in go-waku (wakuorg/go-waku:latest) as described here https://nagyzoltanpeter.github.io/nwaku-api/index.html#post-/relay/v1/subscriptions but I get errors for relay/v1/messages endpoint
 For example trying to publish a message I get a 500
 curl -vv -X POST "http://127.0.0.1:63970/relay/v1/messages/%2Fwaku%2F2%2Fdefault-waku%2Fproto" -H "content-type: application/json" -d '{"payload":"ZXhhbXBsZQ==","contentTopic":"string","version":0,"timestamp":0}'
 When querying messages I get 404 with not subscribed to topic
 curl -vv -X GET "http://127.0.0.1:63970/relay/v1/messages/%2Fwaku%2F2%2Fdefault-waku%2Fproto" -H "accept: application/json" 
 
If I use nwaku instead of gowaku it works fine. Also If I use gowaku with RPC instead of REST it works fine so the container setup seems correct. 
Also trying to subscribe the node to a topic seems to work fine, I get 200 here:
curl -vv -X POST "http://127.0.0.1:63970/relay/v1/subscriptions" -H "accept: text/plain" -H "content-type: application/json" -d '["/waku/2/default-waku/proto"]' 
```


# Changes

- [ ] decode URL param for post and get messages relay REST API


# Tests

Verified both the APIs with /waku/2/default-waku/proto topic and they seem to work fine.


<!--
## How to test

1.
1.
1.

-->


<!--
## Issue

closes #
-->
