### PR TITLE
feat: discv5 filter out nodes that have empty waku capabilities

### DIFF
--- a/waku/v2/discv5/discover.go
+++ b/waku/v2/discv5/discover.go
@@ -21,6 +21,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/ethereum/go-ethereum/p2p/enode"
+	"github.com/ethereum/go-ethereum/p2p/enr"
 	"github.com/ethereum/go-ethereum/p2p/nat"
 )
 
@@ -250,23 +251,21 @@ func (d *DiscoveryV5) Stop() {
 	})
 }
 
-/*
 func isWakuNode(node *enode.Node) bool {
-	enrField := new(utils.WakuEnrBitfield)
-	if err := node.Record().Load(enr.WithEntry(utils.WakuENRField, &enrField)); err != nil {
+	enrField := new(wenr.WakuEnrBitfield)
+	if err := node.Record().Load(enr.WithEntry(wenr.WakuENRField, &enrField)); err != nil {
 		if !enr.IsNotFound(err) {
-			utils.Logger().Named("discv5").Error("could not retrieve port for enr ", zap.Any("node", node))
+			utils.Logger().Named("discv5").Error("could not retrieve waku2 ENR field for enr ", zap.Any("node", node))
 		}
 		return false
 	}
 
 	if enrField != nil {
-		return *enrField != uint8(0)
+		return *enrField != uint8(0) // #RFC 31 requirement
 	}
 
 	return false
 }
-*/
 
 func (d *DiscoveryV5) evaluateNode() func(node *enode.Node) bool {
 	return func(node *enode.Node) bool {
@@ -274,10 +273,10 @@ func (d *DiscoveryV5) evaluateNode() func(node *enode.Node) bool {
 			return false
 		}
 
-		//  TODO: consider node filtering based on ENR; we do not filter based on ENR in the first waku discv5 beta stage
-		/*if !isWakuNode(node) {
+		//  node filtering based on ENR; we do not filter based on ENR in the first waku discv5 beta stage
+		if !isWakuNode(node) {
 			return false
-		}*/
+		}
 
 		_, err := wenr.EnodeToPeerInfo(node)
 

--- a/waku/v2/discv5/discover_test.go
+++ b/waku/v2/discv5/discover_test.go
@@ -101,6 +101,7 @@ func extractIP(addr multiaddr.Multiaddr) (*net.TCPAddr, error) {
 
 func TestDiscV5(t *testing.T) {
 	// Host1 <-> Host2 <-> Host3
+	// Host4(No waku capabilities) <-> Host2
 
 	// H1
 	host1, _, prvKey1 := createHost(t)
@@ -138,9 +139,22 @@ func TestDiscV5(t *testing.T) {
 	require.NoError(t, err)
 	d3.SetHost(host3)
 
+	// H4 doesn't have any Waku capabilities
+	host4, _, prvKey4 := createHost(t)
+	ip4, _ := extractIP(host2.Addrs()[0])
+	udpPort4, err := tests.FindFreeUDPPort(t, "127.0.0.1", 3)
+	require.NoError(t, err)
+	l4, err := newLocalnode(prvKey4, ip4, udpPort4, 0, nil, utils.Logger())
+	require.NoError(t, err)
+	peerconn4 := peermanager.NewTestPeerDiscoverer()
+	d4, err := NewDiscoveryV5(prvKey4, l4, peerconn4, prometheus.DefaultRegisterer, utils.Logger(), WithUDPPort(uint(udpPort4)), WithBootnodes([]*enode.Node{d2.localnode.Node()}))
+	require.NoError(t, err)
+	d2.SetHost(host2)
+
 	defer d1.Stop()
 	defer d2.Stop()
 	defer d3.Stop()
+	defer d4.Stop()
 
 	err = d1.Start(context.Background())
 	require.NoError(t, err)
@@ -151,9 +165,13 @@ func TestDiscV5(t *testing.T) {
 	err = d3.Start(context.Background())
 	require.NoError(t, err)
 
+	err = d4.Start(context.Background())
+	require.NoError(t, err)
+
 	time.Sleep(2 * time.Second) // Wait for nodes to be discovered
 
 	require.True(t, peerconn3.HasPeer(host1.ID()) && peerconn3.HasPeer(host2.ID()))
+	require.False(t, peerconn3.HasPeer(host4.ID())) //host4 should not be discoverable, rather filtered out.
 
 	d3.Stop()
 	peerconn3.Clear()
@@ -165,4 +183,6 @@ func TestDiscV5(t *testing.T) {
 	time.Sleep(2 * time.Second) // Wait for nodes to be discovered
 
 	require.True(t, peerconn3.HasPeer(host1.ID()) && peerconn3.HasPeer(host2.ID()))
+	require.False(t, peerconn3.HasPeer(host4.ID())) //host4 should not be discoverable, rather filtered out.
+
 }


### PR DESCRIPTION
# Description
Refer #863 

# Changes

<!-- List of detailed changes -->

- [x] DiscoveryV5 evaluation to include check for Waku2 ENR field and fail if field is present and empty
- [x] Add test to validate discv5 filtering for node without waku capability.

# Tests

<!-- List down any tests that were executed specifically for this pull-request -->



<!--
## How to test

1.
1.
1.

-->


<!--
## Issue

closes #
-->
