### PR TITLE
chore: add unit tests for autosharding relay REST API

### DIFF
--- a/cmd/waku/server/rest/relay.go
+++ b/cmd/waku/server/rest/relay.go
@@ -223,7 +223,7 @@ func (r *RelayService) postV1AutoSubscriptions(w http.ResponseWriter, req *http.
 		_, err := w.Write([]byte(err.Error()))
 		r.log.Error("writing response", zap.Error(err))
 	} else {
-		w.WriteHeader(http.StatusOK)
+		writeErrOrResponse(w, err, true)
 	}
 
 }


### PR DESCRIPTION
Part of #861 

# Changes


- [x] Added Autosharding REST API unit tests
- [x] Fix success response for POST Auto subscription as per yaml

# Tests

<!-- List down any tests that were executed specifically for this pull-request -->



<!--
## How to test

1.
1.
1.

-->


<!--
## Issue

closes #
-->
