### PR TITLE
fix: panic if it is not possible to obtain the merkle root

### DIFF
--- a/waku/v2/protocol/rln/group_manager/dynamic/dynamic.go
+++ b/waku/v2/protocol/rln/group_manager/dynamic/dynamic.go
@@ -244,10 +244,7 @@ func (gm *DynamicGroupManager) InsertMembers(toInsert *om.OrderedMap) error {
 
 		gm.metrics.RecordRegisteredMembership(gm.rln.LeavesSet())
 
-		_, err = gm.rootTracker.UpdateLatestRoot(pair.Key.(uint64))
-		if err != nil {
-			return err
-		}
+		gm.rootTracker.UpdateLatestRoot(pair.Key.(uint64))
 	}
 	return nil
 }

--- a/waku/v2/protocol/rln/group_manager/dynamic/handler_test.go
+++ b/waku/v2/protocol/rln/group_manager/dynamic/handler_test.go
@@ -31,8 +31,7 @@ func TestHandler(t *testing.T) {
 	rlnInstance, err := rln.NewRLN()
 	require.NoError(t, err)
 
-	rootTracker, err := group_manager.NewMerkleRootTracker(5, rlnInstance)
-	require.NoError(t, err)
+	rootTracker := group_manager.NewMerkleRootTracker(5, rlnInstance)
 
 	_, cancel := context.WithCancel(context.TODO())
 	defer cancel()

--- a/waku/v2/protocol/rln/group_manager/dynamic/membership_fetcher_test.go
+++ b/waku/v2/protocol/rln/group_manager/dynamic/membership_fetcher_test.go
@@ -22,9 +22,9 @@ func TestFetchingLogic(t *testing.T) {
 	require.NoError(t, err)
 	rlnInstance, err := rln.NewRLN()
 	require.NoError(t, err)
-	rootTracker, err := group_manager.NewMerkleRootTracker(1, rlnInstance)
-	require.NoError(t, err)
-	//
+
+	rootTracker := group_manager.NewMerkleRootTracker(1, rlnInstance)
+
 	mf := MembershipFetcher{
 		web3Config: &web3.Config{
 			RLNContract: web3.RLNContract{

--- a/waku/v2/protocol/rln/group_manager/static/static.go
+++ b/waku/v2/protocol/rln/group_manager/static/static.go
@@ -68,10 +68,7 @@ func (gm *StaticGroupManager) insertMembers(idCommitments []rln.IDCommitment) er
 
 	latestIndex := gm.nextIndex + uint64(len(idCommitments))
 
-	_, err = gm.rootTracker.UpdateLatestRoot(latestIndex)
-	if err != nil {
-		return err
-	}
+	gm.rootTracker.UpdateLatestRoot(latestIndex)
 
 	gm.nextIndex = latestIndex + 1
 

--- a/waku/v2/protocol/rln/onchain_test.go
+++ b/waku/v2/protocol/rln/onchain_test.go
@@ -140,8 +140,7 @@ func (s *WakuRLNRelayDynamicSuite) TestDynamicGroupManagement() {
 	rlnInstance, err := rln.NewRLN()
 	s.Require().NoError(err)
 
-	rt, err := group_manager.NewMerkleRootTracker(5, rlnInstance)
-	s.Require().NoError(err)
+	rt := group_manager.NewMerkleRootTracker(5, rlnInstance)
 
 	u1Credentials := s.generateCredentials(rlnInstance)
 	appKeystore, err := keystore.New(s.tmpKeystorePath(), dynamic.RLNAppInfo, utils.Logger())

--- a/waku/v2/protocol/rln/rln_relay_test.go
+++ b/waku/v2/protocol/rln/rln_relay_test.go
@@ -88,8 +88,7 @@ func (s *WakuRLNRelaySuite) TestUpdateLogAndHasDuplicate() {
 	rlnInstance, err := r.NewRLN()
 	s.Require().NoError(err)
 
-	rootTracker, err := group_manager.NewMerkleRootTracker(acceptableRootWindowSize, rlnInstance)
-	s.Require().NoError(err)
+	rootTracker := group_manager.NewMerkleRootTracker(acceptableRootWindowSize, rlnInstance)
 
 	rlnRelay := &WakuRLNRelay{
 		nullifierLog: NewNullifierLog(context.TODO(), utils.Logger()),
@@ -184,10 +183,9 @@ func (s *WakuRLNRelaySuite) TestValidateMessage() {
 	// Create a RLN instance
 	rlnInstance, err := r.NewRLN()
 	s.Require().NoError(err)
-	//
-	rootTracker, err := group_manager.NewMerkleRootTracker(acceptableRootWindowSize, rlnInstance)
-	s.Require().NoError(err)
-	//
+
+	rootTracker := group_manager.NewMerkleRootTracker(acceptableRootWindowSize, rlnInstance)
+
 	idCredential := groupKeyPairs[index]
 	groupManager, err := static.NewStaticGroupManager(groupIDCommitments, idCredential, index, rlnInstance, rootTracker, utils.Logger())
 	s.Require().NoError(err)

--- a/waku/v2/protocol/rln/waku_rln_relay.go
+++ b/waku/v2/protocol/rln/waku_rln_relay.go
@@ -47,10 +47,8 @@ func GetRLNInstanceAndRootTracker(treePath string) (*rln.RLN, *group_manager.Mer
 		return nil, nil, err
 	}
 
-	rootTracker, err := group_manager.NewMerkleRootTracker(acceptableRootWindowSize, rlnInstance)
-	if err != nil {
-		return nil, nil, err
-	}
+	rootTracker := group_manager.NewMerkleRootTracker(acceptableRootWindowSize, rlnInstance)
+
 	return rlnInstance, rootTracker, nil
 }
 func New(


### PR DESCRIPTION
# Description
Panics if while retrieving the merkle root, there's a failure. Having an error in RLN at this stage will probably mean that we have an inconsistent state in the merkle tree, so it's better to stop the program execution

## Issue

closes #738

