### PR TITLE
fix: content topic validation as per rfc 51

### DIFF
--- a/examples/basic2/main.go
+++ b/examples/basic2/main.go
@@ -25,7 +25,7 @@ import (
 var log = utils.Logger().Named("basic2")
 
 func main() {
-	var cTopic, err = protocol.NewContentTopic("basic2", 1, "test", "proto")
+	var cTopic, err = protocol.NewContentTopic("basic2", "1", "test", "proto")
 	if err != nil {
 		fmt.Println("Invalid contentTopic")
 		return

--- a/examples/c-bindings/main.c
+++ b/examples/c-bindings/main.c
@@ -18,8 +18,10 @@ char *bobPubKey =
     "0x045eef61a98ba1cf44a2736fac91183ea2bd86e67de20fe4bff467a71249a8a0c05f795d"
     "d7f28ced7c15eaa69c89d4212cc4f526ca5e9a62e88008f506d850cccd";
 
-void on_error(int ret, const char *result, void *user_data) {
-  if (ret == 0) {
+void on_error(int ret, const char *result, void *user_data)
+{
+  if (ret == 0)
+  {
     return;
   }
 
@@ -27,8 +29,10 @@ void on_error(int ret, const char *result, void *user_data) {
   exit(1);
 }
 
-void on_response(int ret, const char *result, void *user_data) {
-  if (ret != 0) {
+void on_response(int ret, const char *result, void *user_data)
+{
+  if (ret != 0)
+  {
     printf("function execution failed. Returned code: %d\n", ret);
     exit(1);
   }
@@ -46,7 +50,8 @@ void on_response(int ret, const char *result, void *user_data) {
   strcpy(*data_ref, result);
 }
 
-void callBack(int ret, const char *signal, void *user_data) {
+void callBack(int ret, const char *signal, void *user_data)
+{
   // This callback will be executed each time a new message is received
 
   // Example signal:
@@ -65,7 +70,8 @@ void callBack(int ret, const char *signal, void *user_data) {
       }
     }*/
 
-  if (ret != 0) {
+  if (ret != 0)
+  {
     printf("function execution failed. Returned code: %d\n", ret);
     exit(1);
   }
@@ -73,13 +79,15 @@ void callBack(int ret, const char *signal, void *user_data) {
   const nx_json *json = nx_json_parse((char *)signal, 0);
   const char *type = nx_json_get(json, "type")->text_value;
 
-  if (strcmp(type, "message") == 0) {
+  if (strcmp(type, "message") == 0)
+  {
     const nx_json *wakuMsgJson =
         nx_json_get(nx_json_get(json, "event"), "wakuMessage");
     const char *contentTopic =
         nx_json_get(wakuMsgJson, "contentTopic")->text_value;
 
-    if (strcmp(contentTopic, "/example/1/default/rfc26") == 0) {
+    if (strcmp(contentTopic, "/example/1/default/rfc26") == 0)
+    {
       char *msg = utils_extract_wakumessage_from_signal(wakuMsgJson);
 
       // Decode a message using asymmetric encryption
@@ -109,7 +117,8 @@ void callBack(int ret, const char *signal, void *user_data) {
   nx_json_free(json);
 }
 
-int main(int argc, char *argv[]) {
+int main(int argc, char *argv[])
+{
   // Set callback to be executed each time a message is received
   waku_set_event_callback(callBack);
 
@@ -134,7 +143,7 @@ int main(int argc, char *argv[]) {
 
   // Build a content topic
   char *contentTopic = NULL;
-  waku_content_topic("example", 1, "default", "rfc26", on_response,
+  waku_content_topic("example", "1", "default", "rfc26", on_response,
                      (void *)&contentTopic);
   printf("Content Topic: %s\n", contentTopic);
 
@@ -166,14 +175,15 @@ int main(int argc, char *argv[]) {
   // waku_store_query(query, NULL, 0, on_response, (void*)&query_result);
   // printf("%s\n", query_result);
   char contentFilter[1000];
-    sprintf(contentFilter,
-            "{\"pubsubTopic\":\"%s\",\"contentTopics\":[\"%s\"]}",
-            defaultPubsubTopic, contentTopic);
+  sprintf(contentFilter,
+          "{\"pubsubTopic\":\"%s\",\"contentTopics\":[\"%s\"]}",
+          defaultPubsubTopic, contentTopic);
   waku_relay_subscribe(contentFilter, on_error, NULL);
 
   int i = 0;
   int version = 1;
-  while (i < 5) {
+  while (i < 5)
+  {
     i++;
 
     char wakuMsg[1000];

--- a/examples/chat2/flags.go
+++ b/examples/chat2/flags.go
@@ -34,7 +34,7 @@ func getFlags() []cli.Flag {
 	// Defaults
 	options.Fleet = fleetProd
 
-	testCT, err := protocol.NewContentTopic("toy-chat", 3, "mingde", "proto")
+	testCT, err := protocol.NewContentTopic("toy-chat", "3", "mingde", "proto")
 	if err != nil {
 		panic("invalid contentTopic")
 	}

--- a/examples/rln/main.go
+++ b/examples/rln/main.go
@@ -32,7 +32,7 @@ var contractAddress = "0xF471d71E9b1455bBF4b85d475afb9BB0954A29c4"
 var keystorePath = "./rlnKeystore.json"
 var keystorePassword = "password"
 var membershipIndex = uint(0)
-var contentTopic, _ = protocol.NewContentTopic("rln", 1, "test", "proto")
+var contentTopic, _ = protocol.NewContentTopic("rln", "1", "test", "proto")
 var pubsubTopic = protocol.DefaultPubsubTopic{}
 
 // ============================================================================

--- a/library/c/api.go
+++ b/library/c/api.go
@@ -194,11 +194,10 @@ func waku_peer_cnt(cb C.WakuCallBack, userData unsafe.Pointer) C.int {
 // Create a content topic string according to RFC 23
 //
 //export waku_content_topic
-func waku_content_topic(applicationName *C.char, applicationVersion C.uint, contentTopicName *C.char, encoding *C.char, cb C.WakuCallBack, userData unsafe.Pointer) C.int {
-	contentTopic, _ := protocol.NewContentTopic(C.GoString(applicationName), uint32(applicationVersion), C.GoString(contentTopicName), C.GoString(encoding))
+func waku_content_topic(applicationName *C.char, applicationVersion *C.char, contentTopicName *C.char, encoding *C.char, cb C.WakuCallBack, userData unsafe.Pointer) C.int {
+	contentTopic, _ := protocol.NewContentTopic(C.GoString(applicationName), C.GoString(applicationVersion), C.GoString(contentTopicName), C.GoString(encoding))
 	return onSuccesfulResponse(contentTopic.String(), cb, userData)
 }
-
 
 // Get the default pubsub topic used in waku2: /waku/2/default-waku/proto
 //

--- a/library/mobile/api.go
+++ b/library/mobile/api.go
@@ -73,8 +73,8 @@ func PeerCnt() string {
 }
 
 // ContentTopic creates a content topic string according to RFC 23
-func ContentTopic(applicationName string, applicationVersion int, contentTopicName string, encoding string) string {
-	contentTopic, _ := protocol.NewContentTopic(applicationName, uint32(applicationVersion), contentTopicName, encoding)
+func ContentTopic(applicationName string, applicationVersion string, contentTopicName string, encoding string) string {
+	contentTopic, _ := protocol.NewContentTopic(applicationName, applicationVersion, contentTopicName, encoding)
 	return contentTopic.String()
 }
 

--- a/library/node.go
+++ b/library/node.go
@@ -335,8 +335,8 @@ func PeerCnt() (int, error) {
 }
 
 // ContentTopic creates a content topic string according to RFC 23
-func ContentTopic(applicationName string, applicationVersion int, contentTopicName string, encoding string) string {
-	contentTopic, _ := protocol.NewContentTopic(applicationName, uint32(applicationVersion), contentTopicName, encoding)
+func ContentTopic(applicationName string, applicationVersion string, contentTopicName string, encoding string) string {
+	contentTopic, _ := protocol.NewContentTopic(applicationName, applicationVersion, contentTopicName, encoding)
 	return contentTopic.String()
 }
 

--- a/waku/v2/protocol/envelope_test.go
+++ b/waku/v2/protocol/envelope_test.go
@@ -1,7 +1,6 @@
 package protocol
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -22,7 +21,6 @@ func TestEnvelope(t *testing.T) {
 	topic := e.PubsubTopic()
 	require.Equal(t, "test", topic)
 	hash := e.Hash()
-	fmt.Println(hash)
 
 	require.Equal(
 		t,

--- a/waku/v2/protocol/relay/waku_relay_test.go
+++ b/waku/v2/protocol/relay/waku_relay_test.go
@@ -3,7 +3,6 @@ package relay
 import (
 	"context"
 	"crypto/rand"
-	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -53,7 +52,6 @@ func TestWakuRelay(t *testing.T) {
 	bytesToSend := []byte{1}
 	go func() {
 		defer cancel()
-
 		env := <-subs[0].Ch
 		t.Log("received msg", logging.HexString("hash", env.Hash()))
 	}()
@@ -114,7 +112,7 @@ func TestGossipsubScore(t *testing.T) {
 			for {
 				_, err := sub.Next(context.Background())
 				if err != nil {
-					fmt.Println(err)
+					t.Log(err)
 				}
 			}
 		}()

--- a/waku/v2/protocol/shard.go
+++ b/waku/v2/protocol/shard.go
@@ -225,7 +225,7 @@ func FromBitVector(buf []byte) (RelayShards, error) {
 // This is based on Autosharding algorithm defined in RFC 51
 func GetShardFromContentTopic(topic ContentTopic, shardCount int) StaticShardingPubsubTopic {
 	bytes := []byte(topic.ApplicationName)
-	bytes = append(bytes, []byte(fmt.Sprintf("%d", topic.ApplicationVersion))...)
+	bytes = append(bytes, []byte(topic.ApplicationVersion)...)
 
 	hash := hash.SHA256(bytes)
 	//We only use the last 64 bits of the hash as having more shards is unlikely.

--- a/waku/v2/protocol/topic_test.go
+++ b/waku/v2/protocol/topic_test.go
@@ -9,28 +9,28 @@ import (
 )
 
 func TestContentTopicAndSharding(t *testing.T) {
-	ct, err := NewContentTopic("waku", 2, "test", "proto")
+	ct, err := NewContentTopic("waku", "2", "test", "proto")
 	require.NoError(t, err)
 	require.Equal(t, ct.String(), "/waku/2/test/proto")
 
 	_, err = StringToContentTopic("/waku/-1/a/b")
-	require.Error(t, ErrInvalidFormat, err)
+	require.NoError(t, err)
 
 	_, err = StringToContentTopic("waku/1/a/b")
-	require.Error(t, ErrInvalidFormat, err)
+	require.Error(t, err, ErrInvalidFormat)
 
 	_, err = StringToContentTopic("////")
-	require.Error(t, ErrInvalidFormat, err)
+	require.Error(t, err, ErrInvalidFormat)
 
 	_, err = StringToContentTopic("/waku/1/a")
-	require.Error(t, ErrInvalidFormat, err)
+	require.Error(t, err, ErrInvalidFormat)
 
 	ct2, err := StringToContentTopic("/waku/2/test/proto")
 	require.NoError(t, err)
 	require.Equal(t, ct.String(), ct2.String())
 	require.True(t, ct.Equal(ct2))
 
-	ct3, err := NewContentTopic("waku", 2, "test2", "proto")
+	ct3, err := NewContentTopic("waku", "2a", "test2", "proto")
 	require.NoError(t, err)
 	require.False(t, ct.Equal(ct3))
 
@@ -45,12 +45,12 @@ func TestContentTopicAndSharding(t *testing.T) {
 	require.Equal(t, NewStaticShardingPubsubTopic(ClusterIndex, 3), nsPubSubT1)
 
 	_, err = StringToContentTopic("/abc/toychat/2/huilong/proto")
-	require.Error(t, ErrInvalidGeneration, err)
+	require.Error(t, err, ErrInvalidGeneration)
 
 	_, err = StringToContentTopic("/1/toychat/2/huilong/proto")
-	require.Error(t, ErrInvalidGeneration, err)
+	require.Error(t, err, ErrInvalidGeneration)
 
-	ct5, err := NewContentTopic("waku", 2, "test2", "proto", WithGeneration(0))
+	ct5, err := NewContentTopic("waku", "2b", "test2", "proto", WithGeneration(0))
 	require.NoError(t, err)
 	require.Equal(t, ct5.Generation, 0)
 }
@@ -65,7 +65,7 @@ func randomContentTopic() (ContentTopic, error) {
 		randomChar := 'a' + rune(rand.Intn(26))
 		app = app + string(randomChar)
 	}
-	version := uint32(1)
+	version := "1"
 
 	var name = ""
 


### PR DESCRIPTION
# Description
Allow application version to be string in contentTopic as per rfc 51 https://rfc.vac.dev/spec/51/#automatic-sharding

# Changes

<!-- List of detailed changes -->

- [x] Fix contentTopic parsing
- [x] Update tests
- [x] Update Examples

Note: rust-bindings will have to be updated accordingly. @richard-ramos 

# Tests

<!-- List down any tests that were executed specifically for this pull-request -->



<!--
## How to test

1.
1.
1.

-->


<!--
## Issue

closes #
-->
