### PR TITLE
fix : issues with get messages API

### DIFF
--- a/cmd/waku/server/rest/relay.go
+++ b/cmd/waku/server/rest/relay.go
@@ -131,7 +131,9 @@ func (r *RelayService) getV1Messages(w http.ResponseWriter, req *http.Request) {
 			r.log.Error("consume channel is closed for subscription", zap.String("pubsubTopic", topic))
 			w.WriteHeader(http.StatusNotFound)
 			_, err = w.Write([]byte("consume channel is closed for subscription"))
-			r.log.Error("writing response", zap.Error(err))
+			if err != nil {
+				r.log.Error("writing response", zap.Error(err))
+			}
 			return
 		}
 		response = append(response, msg.Message())

--- a/cmd/waku/server/rpc/relay.go
+++ b/cmd/waku/server/rpc/relay.go
@@ -13,6 +13,8 @@ import (
 	"go.uber.org/zap"
 )
 
+var errChannelClosed = errors.New("consume channel is closed for subscription")
+
 // RelayService represents the JSON RPC service for WakuRelay
 type RelayService struct {
 	node *node.WakuNode
@@ -154,7 +156,7 @@ func (r *RelayService) GetV1AutoMessages(req *http.Request, args *TopicArgs, rep
 	case msg, open := <-sub.Ch:
 		if !open {
 			r.log.Error("consume channel is closed for subscription", zap.String("pubsubTopic", args.Topic))
-			return errors.New("consume channel is closed for subscription")
+			return errChannelClosed
 		}
 		rpcMsg, err := ProtoToRPC(msg.Message())
 		if err != nil {
@@ -214,7 +216,7 @@ func (r *RelayService) GetV1Messages(req *http.Request, args *TopicArgs, reply *
 	case msg, open := <-sub.Ch:
 		if !open {
 			r.log.Error("consume channel is closed for subscription", zap.String("pubsubTopic", args.Topic))
-			return errors.New("consume channel is closed for subscription")
+			return errChannelClosed
 		}
 		m, err := ProtoToRPC(msg.Message())
 		if err == nil {

--- a/cmd/waku/server/rpc/relay.go
+++ b/cmd/waku/server/rpc/relay.go
@@ -210,7 +210,6 @@ func (r *RelayService) GetV1Messages(req *http.Request, args *TopicArgs, reply *
 	if err != nil {
 		return err
 	}
-	fmt.Println("subscription is ", sub)
 	select {
 	case msg, open := <-sub.Ch:
 		if !open {

--- a/waku/v2/protocol/relay/waku_relay.go
+++ b/waku/v2/protocol/relay/waku_relay.go
@@ -292,6 +292,9 @@ func (w *WakuRelay) GetSubscriptionWithPubsubTopic(pubsubTopic string, contentTo
 	cSubs := w.contentSubs[pubsubTopic]
 	for _, sub := range cSubs {
 		if sub.contentFilter.Equals(contentFilter) {
+			if sub.noConsume { //This check is to ensure that default no-consumer subscription is not returned
+				continue
+			}
 			return sub, nil
 		}
 	}
@@ -308,6 +311,9 @@ func (w *WakuRelay) GetSubscription(contentTopic string) (*Subscription, error) 
 	cSubs := w.contentSubs[pubsubTopic]
 	for _, sub := range cSubs {
 		if sub.contentFilter.Equals(contentFilter) {
+			if sub.noConsume { //This check is to ensure that default no-consumer subscription is not returned
+				continue
+			}
 			return sub, nil
 		}
 	}


### PR DESCRIPTION
# Description
@fbarbu15 reported few issues he faced while testing RPC and REST API for relay with latest go-waku image.
These are fixes for some of the issues noticed. 


# Changes

<!-- List of detailed changes -->

- [x] Do not use request context in subscribe API as that would finish as soon as request is done which would close the subscription channel as well.
- [x] Add checks for channel open status and return error for RPC and REST APIs to avoid panic
- [x] Get Subscription API to not return subscription which has noConsume flag set(which indicates that this subscription is not created via an API rather only during node initialization) 

# Tests

<!-- List down any tests that were executed specifically for this pull-request -->



<!--
## How to test

1.
1.
1.

-->


<!--
## Issue

closes #
-->
