### PR TITLE
fix: WakuMessage json encoding

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -29,7 +29,7 @@
           ];
           doCheck = false;
           # FIXME: This needs to be manually changed when updating modules.
-          vendorSha256 = "sha256-4xChSKAkwwrFp5/ZMnhtvsR4drVfw1cLE3YXwVHeW0A=";
+          vendorSha256 = "sha256-1m5byn1CVD8Awzbo9XY94FgitC+uetTfon/8bBh5DiE=";
           # Fix for 'nix run' trying to execute 'go-waku'.
           meta = { mainProgram = "waku"; };
         };

--- a/waku/v2/protocol/pb/codec.go
+++ b/waku/v2/protocol/pb/codec.go
@@ -1,0 +1,29 @@
+package pb
+
+import (
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+)
+
+func (m *WakuMessage) MarshalJSON() ([]byte, error) {
+	return (protojson.MarshalOptions{}).Marshal(m)
+}
+
+func Unmarshal(data []byte) (*WakuMessage, error) {
+	msg := &WakuMessage{}
+	err := proto.Unmarshal(data, msg)
+	if err != nil {
+		return nil, err
+	}
+
+	err = msg.Validate()
+	if err != nil {
+		return nil, err
+	}
+
+	return msg, nil
+}
+
+func (m *WakuMessage) UnmarshalJSON(data []byte) error {
+	return (protojson.UnmarshalOptions{}).Unmarshal(data, m)
+}

--- a/waku/v2/protocol/pb/validation.go
+++ b/waku/v2/protocol/pb/validation.go
@@ -2,8 +2,6 @@ package pb
 
 import (
 	"errors"
-
-	"google.golang.org/protobuf/proto"
 )
 
 const MaxMetaAttrLength = 64
@@ -28,20 +26,4 @@ func (msg *WakuMessage) Validate() error {
 	}
 
 	return nil
-}
-
-func Unmarshal(data []byte) (*WakuMessage, error) {
-	msg := &WakuMessage{}
-	err := proto.Unmarshal(data, msg)
-	if err != nil {
-		return nil, err
-	}
-
-	err = msg.Validate()
-	if err != nil {
-		return nil, err
-	}
-
-	return msg, nil
-
 }


### PR DESCRIPTION
# Description
Fixes an issue reported by @fbarbu15 in which the waku message content topic field was not being decoded correctly in the REST API
