### PR TITLE
chore: remove `--store-message-db-vacuum` 

### DIFF
--- a/cmd/waku/flags.go
+++ b/cmd/waku/flags.go
@@ -330,12 +330,6 @@ var (
 		Destination: &options.Store.DatabaseURL,
 		EnvVars:     []string{"WAKUNODE2_STORE_MESSAGE_DB_URL"},
 	})
-	StoreMessageDBVacuum = altsrc.NewBoolFlag(&cli.BoolFlag{
-		Name:        "store-message-db-vacuum",
-		Usage:       "Enable database vacuuming at start.",
-		Destination: &options.Store.Vacuum,
-		EnvVars:     []string{"WAKUNODE2_STORE_MESSAGE_DB_VACUUM"},
-	})
 	StoreMessageDBMigration = altsrc.NewBoolFlag(&cli.BoolFlag{
 		Name:        "store-message-db-migration",
 		Usage:       "Enable database migration at start.",

--- a/cmd/waku/main.go
+++ b/cmd/waku/main.go
@@ -65,7 +65,6 @@ func main() {
 		StoreMessageDBURL,
 		StoreMessageRetentionTime,
 		StoreMessageRetentionCapacity,
-		StoreMessageDBVacuum,
 		StoreMessageDBMigration,
 		FilterFlag,
 		FilterNode,

--- a/cmd/waku/node.go
+++ b/cmd/waku/node.go
@@ -110,9 +110,7 @@ func Execute(options NodeOptions) error {
 	var db *sql.DB
 	var migrationFn func(*sql.DB) error
 	if requiresDB(options) && options.Store.Migration {
-		dbSettings := dbutils.DBSettings{
-			Vacuum: options.Store.Vacuum,
-		}
+		dbSettings := dbutils.DBSettings{}
 		db, migrationFn, err = dbutils.ExtractDBAndMigration(options.Store.DatabaseURL, dbSettings, logger)
 		if err != nil {
 			return nonRecoverErrorMsg("could not connect to DB: %w", err)

--- a/cmd/waku/options.go
+++ b/cmd/waku/options.go
@@ -81,7 +81,6 @@ type StoreOptions struct {
 	RetentionMaxMessages int
 	//ResumeNodes          []multiaddr.Multiaddr
 	Nodes     []multiaddr.Multiaddr
-	Vacuum    bool
 	Migration bool
 }
 

--- a/cmd/waku/server/rest/utils_test.go
+++ b/cmd/waku/server/rest/utils_test.go
@@ -13,7 +13,7 @@ import (
 
 func MemoryDB(t *testing.T) *persistence.DBStore {
 	var db *sql.DB
-	db, err := sqlite.NewDB(":memory:", false, utils.Logger())
+	db, err := sqlite.NewDB(":memory:", utils.Logger())
 	require.NoError(t, err)
 
 	dbStore, err := persistence.NewDBStore(prometheus.DefaultRegisterer, utils.Logger(), persistence.WithDB(db), persistence.WithMigrations(sqlite.Migrations))

--- a/library/node.go
+++ b/library/node.go
@@ -128,7 +128,7 @@ func NewNode(configJSON string) error {
 	if *config.EnableStore {
 		var db *sql.DB
 		var migrationFn func(*sql.DB) error
-		db, migrationFn, err = dbutils.ExtractDBAndMigration(*config.DatabaseURL, dbutils.DBSettings{Vacuum: true}, utils.Logger())
+		db, migrationFn, err = dbutils.ExtractDBAndMigration(*config.DatabaseURL, dbutils.DBSettings{}, utils.Logger())
 		if err != nil {
 			return err
 		}

--- a/waku/persistence/utils/db.go
+++ b/waku/persistence/utils/db.go
@@ -22,7 +22,7 @@ func validateDBUrl(val string) error {
 
 // DBSettings hold db specific configuration settings required during the db initialization
 type DBSettings struct {
-	Vacuum bool
+	// TODO: add any DB specific setting here
 }
 
 // ExtractDBAndMigration will return a database connection, and migration function that should be used depending on a database connection string
@@ -50,10 +50,10 @@ func ExtractDBAndMigration(databaseURL string, dbSettings DBSettings, logger *za
 	dbParams := dbURLParts[1]
 	switch dbEngine {
 	case "sqlite3":
-		db, err = sqlite.NewDB(dbParams, dbSettings.Vacuum, logger)
+		db, err = sqlite.NewDB(dbParams, logger)
 		migrationFn = sqlite.Migrations
 	case "postgresql":
-		db, err = postgres.NewDB(dbURL, dbSettings.Vacuum, logger)
+		db, err = postgres.NewDB(dbURL, logger)
 		migrationFn = postgres.Migrations
 	default:
 		err = errors.New("unsupported database engine")

--- a/waku/v2/node/connectedness_test.go
+++ b/waku/v2/node/connectedness_test.go
@@ -70,7 +70,7 @@ func TestConnectionStatusChanges(t *testing.T) {
 	err = node2.Start(ctx)
 	require.NoError(t, err)
 
-	db, err := sqlite.NewDB(":memory:", false, utils.Logger())
+	db, err := sqlite.NewDB(":memory:", utils.Logger())
 	require.NoError(t, err)
 	dbStore, err := persistence.NewDBStore(prometheus.DefaultRegisterer, utils.Logger(), persistence.WithDB(db), persistence.WithMigrations(sqlite.Migrations))
 	require.NoError(t, err)

--- a/waku/v2/node/wakunode2_test.go
+++ b/waku/v2/node/wakunode2_test.go
@@ -242,7 +242,7 @@ func TestDecoupledStoreFromRelay(t *testing.T) {
 	defer subs[0].Unsubscribe()
 
 	// NODE2: Filter Client/Store
-	db, err := sqlite.NewDB(":memory:", false, utils.Logger())
+	db, err := sqlite.NewDB(":memory:", utils.Logger())
 	require.NoError(t, err)
 	dbStore, err := persistence.NewDBStore(prometheus.DefaultRegisterer, utils.Logger(), persistence.WithDB(db), persistence.WithMigrations(sqlite.Migrations))
 	require.NoError(t, err)

--- a/waku/v2/protocol/store/utils_test.go
+++ b/waku/v2/protocol/store/utils_test.go
@@ -13,7 +13,7 @@ import (
 
 func MemoryDB(t *testing.T) *persistence.DBStore {
 	var db *sql.DB
-	db, err := sqlite.NewDB(":memory:", false, utils.Logger())
+	db, err := sqlite.NewDB(":memory:", utils.Logger())
 	require.NoError(t, err)
 
 	dbStore, err := persistence.NewDBStore(prometheus.DefaultRegisterer, utils.Logger(), persistence.WithDB(db), persistence.WithMigrations(sqlite.Migrations))

--- a/waku/v2/rendezvous/rendezvous_test.go
+++ b/waku/v2/rendezvous/rendezvous_test.go
@@ -45,7 +45,7 @@ func TestRendezvous(t *testing.T) {
 	host1, err := tests.MakeHost(ctx, port1, rand.Reader)
 	require.NoError(t, err)
 
-	db, err := sqlite.NewDB(":memory:", false, utils.Logger())
+	db, err := sqlite.NewDB(":memory:", utils.Logger())
 	require.NoError(t, err)
 
 	err = sqlite.Migrations(db)


### PR DESCRIPTION
# Description
`VACUUM`, as described in https://github.com/waku-org/nwaku/pull/2165 is an operation that takes a substantial amount of time to be executed depending on the number of rows in the database. Based on the experience so far since the introduction of this flag, It's for the better to execute this command as an operation done via cron or manually, instead of having it be part of the code of waku.

# Changes

- [x] Remove flag
- [x] Remove DB specific implementation of vacuum command
- [x] Left the `DBSettings` struct, since we might end up having to setup some RDBMS specific setting in the future?
