### PR TITLE
chore: add messages logging subsystem

### DIFF
--- a/cmd/waku/relay.go
+++ b/cmd/waku/relay.go
@@ -142,7 +142,7 @@ func bridgeTopics(ctx context.Context, wg *sync.WaitGroup, wakuNode *node.WakuNo
 						env.Message().Meta = append(env.Message().Meta, fwdMetaTag...)
 						_, err := wakuNode.Relay().Publish(ctx, env.Message(), relay.WithPubSubTopic(topic))
 						if err != nil {
-							utils.Logger().Warn("could not bridge message", logging.HexString("hash", env.Hash()),
+							utils.Logger().Warn("could not bridge message", logging.HexBytes("hash", env.Hash()),
 								zap.String("fromTopic", env.PubsubTopic()), zap.String("toTopic", topic),
 								zap.String("contentTopic", env.Message().ContentTopic), zap.Error(err))
 						}

--- a/cmd/waku/rlngenerate/command_rln.go
+++ b/cmd/waku/rlngenerate/command_rln.go
@@ -77,14 +77,14 @@ func execute(ctx context.Context) error {
 
 	if logger.Level() == zap.DebugLevel {
 		logger.Info("registered credentials into the membership contract",
-			logging.HexString("IDCommitment", identityCredential.IDCommitment[:]),
-			logging.HexString("IDNullifier", identityCredential.IDNullifier[:]),
-			logging.HexString("IDSecretHash", identityCredential.IDSecretHash[:]),
-			logging.HexString("IDTrapDoor", identityCredential.IDTrapdoor[:]),
+			logging.HexBytes("IDCommitment", identityCredential.IDCommitment[:]),
+			logging.HexBytes("IDNullifier", identityCredential.IDNullifier[:]),
+			logging.HexBytes("IDSecretHash", identityCredential.IDSecretHash[:]),
+			logging.HexBytes("IDTrapDoor", identityCredential.IDTrapdoor[:]),
 			zap.Uint("index", membershipIndex),
 		)
 	} else {
-		logger.Info("registered credentials into the membership contract", logging.HexString("idCommitment", identityCredential.IDCommitment[:]), zap.Uint("index", membershipIndex))
+		logger.Info("registered credentials into the membership contract", logging.HexBytes("idCommitment", identityCredential.IDCommitment[:]), zap.Uint("index", membershipIndex))
 	}
 
 	web3Config.ETHClient.Close()

--- a/cmd/waku/rlngenerate/web3.go
+++ b/cmd/waku/rlngenerate/web3.go
@@ -124,7 +124,7 @@ func register(ctx context.Context, web3Config *web3.Config, idComm rln.IDCommitm
 
 	var eventIDComm rln.IDCommitment = rln.BigIntToBytes32(evt.IdCommitment)
 
-	log.Debug("information extracted from tx log", zap.Uint64("blockNumber", evt.Raw.BlockNumber), logging.HexString("idCommitment", eventIDComm[:]), zap.Uint64("index", evt.Index.Uint64()))
+	log.Debug("information extracted from tx log", zap.Uint64("blockNumber", evt.Raw.BlockNumber), logging.HexBytes("idCommitment", eventIDComm[:]), zap.Uint64("index", evt.Index.Uint64()))
 
 	if eventIDComm != idComm {
 		return 0, errors.New("invalid id commitment key")

--- a/cmd/waku/server/rpc/relay.go
+++ b/cmd/waku/server/rpc/relay.go
@@ -160,7 +160,7 @@ func (r *RelayService) GetV1AutoMessages(req *http.Request, args *TopicArgs, rep
 		}
 		rpcMsg, err := ProtoToRPC(msg.Message())
 		if err != nil {
-			r.log.Warn("could not include message in response", logging.HexString("hash", msg.Hash()), zap.Error(err))
+			r.log.Warn("could not include message in response", logging.HexBytes("hash", msg.Hash()), zap.Error(err))
 		} else {
 			*reply = append(*reply, rpcMsg)
 		}

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -35,16 +35,6 @@ func (bArr byteArr) MarshalLogArray(encoder zapcore.ArrayEncoder) error {
 	return nil
 }
 
-type hexByte []byte
-
-func HexString(key string, byteVal hexByte) zapcore.Field {
-	return zap.Stringer(key, hexByte(byteVal))
-}
-
-func (h hexByte) String() string {
-	return "0x" + hex.EncodeToString(h)
-}
-
 // List of multiaddrs
 type multiaddrs []multiaddr.Multiaddr
 

--- a/waku/v2/protocol/lightpush/waku_lightpush.go
+++ b/waku/v2/protocol/lightpush/waku_lightpush.go
@@ -18,6 +18,7 @@ import (
 	"github.com/waku-org/go-waku/waku/v2/protocol/lightpush/pb"
 	wpb "github.com/waku-org/go-waku/waku/v2/protocol/pb"
 	"github.com/waku-org/go-waku/waku/v2/protocol/relay"
+	"github.com/waku-org/go-waku/waku/v2/utils"
 	"go.uber.org/zap"
 )
 
@@ -292,7 +293,7 @@ func (wakuLP *WakuLightPush) Publish(ctx context.Context, message *wpb.WakuMessa
 
 	if response.IsSuccess {
 		hash := message.Hash(params.pubsubTopic)
-		wakuLP.log.Info("waku.lightpush published", logging.HexString("hash", hash))
+		utils.MessagesLogger("lightpush").Debug("waku.lightpush published", logging.HexBytes("hash", hash))
 		return hash, nil
 	}
 

--- a/waku/v2/protocol/relay/metrics.go
+++ b/waku/v2/protocol/relay/metrics.go
@@ -53,6 +53,6 @@ func (m *metricsImpl) RecordMessage(envelope *waku_proto.Envelope) {
 		messageSize.Observe(payloadSizeInKb)
 		pubsubTopic := envelope.PubsubTopic()
 		messages.WithLabelValues(pubsubTopic).Inc()
-		m.log.Debug("waku.relay received", zap.String("pubsubTopic", pubsubTopic), logging.HexString("hash", envelope.Hash()), zap.Int64("receivedTime", envelope.Index().ReceiverTime), zap.Int("payloadSizeBytes", payloadSizeInBytes))
+		m.log.Debug("waku.relay received", zap.String("pubsubTopic", pubsubTopic), logging.HexBytes("hash", envelope.Hash()), zap.Int64("receivedTime", envelope.Index().ReceiverTime), zap.Int("payloadSizeBytes", payloadSizeInBytes))
 	}()
 }

--- a/waku/v2/protocol/relay/waku_relay.go
+++ b/waku/v2/protocol/relay/waku_relay.go
@@ -20,6 +20,7 @@ import (
 	"github.com/waku-org/go-waku/waku/v2/protocol/pb"
 	"github.com/waku-org/go-waku/waku/v2/service"
 	"github.com/waku-org/go-waku/waku/v2/timesource"
+	"github.com/waku-org/go-waku/waku/v2/utils"
 )
 
 // WakuRelayID_v200 is the current protocol ID used for WakuRelay
@@ -41,7 +42,8 @@ type WakuRelay struct {
 	timesource          timesource.Timesource
 	metrics             Metrics
 
-	log *zap.Logger
+	log         *zap.Logger
+	logMessages *zap.Logger
 
 	bcaster Broadcaster
 
@@ -80,8 +82,9 @@ func NewWakuRelay(bcaster Broadcaster, minPeersToPublish int, timesource timesou
 	w.minPeersToPublish = minPeersToPublish
 	w.CommonService = service.NewCommonService()
 	w.log = log.Named("relay")
+	w.logMessages = utils.MessagesLogger("relay")
 	w.events = eventbus.NewBus()
-	w.metrics = newMetrics(reg, w.log)
+	w.metrics = newMetrics(reg, w.logMessages)
 
 	// default options required by WakuRelay
 	w.opts = append(w.defaultPubsubOptions(), opts...)
@@ -276,7 +279,7 @@ func (w *WakuRelay) Publish(ctx context.Context, message *pb.WakuMessage, opts .
 
 	hash := message.Hash(params.pubsubTopic)
 
-	w.log.Debug("waku.relay published", zap.String("pubsubTopic", params.pubsubTopic), logging.HexString("hash", hash), zap.Int64("publishTime", w.timesource.Now().UnixNano()), zap.Int("payloadSizeBytes", len(message.Payload)))
+	w.logMessages.Debug("waku.relay published", zap.String("pubsubTopic", params.pubsubTopic), logging.HexBytes("hash", hash), zap.Int64("publishTime", w.timesource.Now().UnixNano()), zap.Int("payloadSizeBytes", len(message.Payload)))
 
 	return hash, nil
 }

--- a/waku/v2/protocol/relay/waku_relay_test.go
+++ b/waku/v2/protocol/relay/waku_relay_test.go
@@ -53,7 +53,7 @@ func TestWakuRelay(t *testing.T) {
 	go func() {
 		defer cancel()
 		env := <-subs[0].Ch
-		t.Log("received msg", logging.HexString("hash", env.Hash()))
+		t.Log("received msg", logging.HexBytes("hash", env.Hash()))
 	}()
 
 	msg := &pb.WakuMessage{


### PR DESCRIPTION
Adds a separate logging subsystem for relay/filter messages, to rely on https://github.com/ipfs/go-log#golog_log_level.

Also removes `logging.HexString` in favour of `logging.HexBytes`.