### PR TITLE
fix: Execution logic for default topic validators in WakuRelay

### DIFF
--- a/waku/v2/protocol/relay/validators.go
+++ b/waku/v2/protocol/relay/validators.go
@@ -67,9 +67,10 @@ func (w *WakuRelay) topicValidator(topic string) func(ctx context.Context, peerI
 		}
 
 		w.topicValidatorMutex.RLock()
-		validators, exists := w.topicValidators[topic]
+		validators := w.topicValidators[topic]
 		validators = append(validators, w.defaultTopicValidators...)
 		w.topicValidatorMutex.RUnlock()
+		exists := len(validators) > 0
 
 		if exists {
 			for _, v := range validators {


### PR DESCRIPTION
# Description
This PR addresses an issue in the WakuRelay's topic validation mechanism. Previously, if topicValidators were not set for a specific topic but defaultTopicValidators were provided, the logic incorrectly bypassed executing these default validators. This was due to the check being performed before merging the defaultTopicValidators. The proposed change ensures we correctly assess the combined list of validators after merging both topicValidators and defaultTopicValidators. This means that all validators will always be considered, regardless of whether specific topic validators are set.
