### PR TITLE
fix(rest): use custom struct for messages instead of protobuffer

### DIFF
--- a/cmd/waku/server/rest/filter.go
+++ b/cmd/waku/server/rest/filter.go
@@ -76,10 +76,12 @@ func (r *FilterService) Stop() {
 
 // NewFilterService returns an instance of FilterService
 func NewFilterService(node *node.WakuNode, m *chi.Mux, cacheCapacity int, log *zap.Logger) *FilterService {
+	logger := log.Named("filter")
+
 	s := &FilterService{
 		node:  node,
-		log:   log.Named("filter"),
-		cache: newFilterCache(cacheCapacity),
+		log:   logger,
+		cache: newFilterCache(cacheCapacity, logger),
 	}
 
 	m.Get(filterv2Ping, s.ping)
@@ -129,9 +131,6 @@ func (s *FilterService) ping(w http.ResponseWriter, req *http.Request) {
 		StatusDesc: http.StatusText(http.StatusOK),
 	}, http.StatusOK)
 }
-
-///////////////////////
-///////////////////////
 
 // same for FilterUnsubscribeRequest
 type filterSubscriptionRequest struct {

--- a/cmd/waku/server/rest/lightpush_rest_test.go
+++ b/cmd/waku/server/rest/lightpush_rest_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/waku-org/go-waku/waku/v2/node"
 	wakupeerstore "github.com/waku-org/go-waku/waku/v2/peerstore"
 	"github.com/waku-org/go-waku/waku/v2/protocol/lightpush"
-	"github.com/waku-org/go-waku/waku/v2/protocol/pb"
 	"github.com/waku-org/go-waku/waku/v2/utils"
 )
 
@@ -46,7 +45,7 @@ func TestLightpushMessagev1(t *testing.T) {
 
 	msg := lightpushRequest{
 		PubSubTopic: pubSubTopic,
-		Message: &pb.WakuMessage{
+		Message: &RestWakuMessage{
 			Payload:      []byte{1, 2, 3},
 			ContentTopic: "abc",
 			Timestamp:    utils.GetUnixEpoch(),

--- a/cmd/waku/server/rest/message.go
+++ b/cmd/waku/server/rest/message.go
@@ -1,0 +1,46 @@
+package rest
+
+import (
+	"errors"
+
+	"github.com/waku-org/go-waku/cmd/waku/server"
+	"github.com/waku-org/go-waku/waku/v2/protocol/pb"
+)
+
+type RestWakuMessage struct {
+	Payload      server.Base64URLByte `json:"payload"`
+	ContentTopic string               `json:"contentTopic"`
+	Version      *uint32              `json:"version,omitempty"`
+	Timestamp    *int64               `json:"timestamp,omitempty"`
+	Meta         []byte               `json:"meta,omitempty"`
+}
+
+func (r *RestWakuMessage) FromProto(input *pb.WakuMessage) error {
+	if err := input.Validate(); err != nil {
+		return err
+	}
+
+	r.Payload = input.Payload
+	r.ContentTopic = input.ContentTopic
+	r.Timestamp = input.Timestamp
+	r.Version = input.Version
+	r.Meta = input.Meta
+
+	return nil
+}
+
+func (r *RestWakuMessage) ToProto() (*pb.WakuMessage, error) {
+	if r == nil {
+		return nil, errors.New("wakumessage is missing")
+	}
+
+	msg := &pb.WakuMessage{
+		Payload:      r.Payload,
+		ContentTopic: r.ContentTopic,
+		Version:      r.Version,
+		Timestamp:    r.Timestamp,
+		Meta:         r.Meta,
+	}
+
+	return msg, nil
+}

--- a/cmd/waku/server/rest/relay.go
+++ b/cmd/waku/server/rest/relay.go
@@ -9,7 +9,6 @@ import (
 	"github.com/waku-org/go-waku/cmd/waku/server"
 	"github.com/waku-org/go-waku/waku/v2/node"
 	"github.com/waku-org/go-waku/waku/v2/protocol"
-	"github.com/waku-org/go-waku/waku/v2/protocol/pb"
 	"github.com/waku-org/go-waku/waku/v2/protocol/relay"
 	"go.uber.org/zap"
 )
@@ -124,9 +123,9 @@ func (r *RelayService) getV1Messages(w http.ResponseWriter, req *http.Request) {
 		r.log.Error("writing response", zap.Error(err))
 		return
 	}
-	var response []*pb.WakuMessage
+	var response []*RestWakuMessage
 	select {
-	case msg, open := <-sub.Ch:
+	case envelope, open := <-sub.Ch:
 		if !open {
 			r.log.Error("consume channel is closed for subscription", zap.String("pubsubTopic", topic))
 			w.WriteHeader(http.StatusNotFound)
@@ -136,7 +135,14 @@ func (r *RelayService) getV1Messages(w http.ResponseWriter, req *http.Request) {
 			}
 			return
 		}
-		response = append(response, msg.Message())
+
+		message := &RestWakuMessage{}
+		if err := message.FromProto(envelope.Message()); err != nil {
+			r.log.Error("converting protobuffer msg into rest msg", zap.Error(err))
+		} else {
+			response = append(response, message)
+		}
+
 	default:
 		break
 	}
@@ -150,9 +156,9 @@ func (r *RelayService) postV1Message(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	var message *pb.WakuMessage
+	var restMessage *RestWakuMessage
 	decoder := json.NewDecoder(req.Body)
-	if err := decoder.Decode(&message); err != nil {
+	if err := decoder.Decode(&restMessage); err != nil {
 		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
@@ -162,12 +168,18 @@ func (r *RelayService) postV1Message(w http.ResponseWriter, req *http.Request) {
 		topic = relay.DefaultWakuTopic
 	}
 
+	message, err := restMessage.ToProto()
+	if err != nil {
+		writeErrOrResponse(w, err, nil)
+		return
+	}
+
 	if err := server.AppendRLNProof(r.node, message); err != nil {
 		writeErrOrResponse(w, err, nil)
 		return
 	}
 
-	_, err := r.node.Relay().Publish(req.Context(), message, relay.WithPubSubTopic(strings.Replace(topic, "\n", "", -1)))
+	_, err = r.node.Relay().Publish(req.Context(), message, relay.WithPubSubTopic(strings.Replace(topic, "\n", "", -1)))
 	if err != nil {
 		r.log.Error("publishing message", zap.Error(err))
 	}
@@ -227,10 +239,15 @@ func (r *RelayService) getV1AutoMessages(w http.ResponseWriter, req *http.Reques
 		r.log.Error("writing response", zap.Error(err))
 		return
 	}
-	var response []*pb.WakuMessage
+	var response []*RestWakuMessage
 	select {
-	case msg := <-sub.Ch:
-		response = append(response, msg.Message())
+	case envelope := <-sub.Ch:
+		message := &RestWakuMessage{}
+		if err := message.FromProto(envelope.Message()); err != nil {
+			r.log.Error("converting protobuffer msg into rest msg", zap.Error(err))
+		} else {
+			response = append(response, message)
+		}
 	default:
 		break
 	}
@@ -240,15 +257,21 @@ func (r *RelayService) getV1AutoMessages(w http.ResponseWriter, req *http.Reques
 
 func (r *RelayService) postV1AutoMessage(w http.ResponseWriter, req *http.Request) {
 
-	var message *pb.WakuMessage
+	var restMessage *RestWakuMessage
 	decoder := json.NewDecoder(req.Body)
-	if err := decoder.Decode(&message); err != nil {
+	if err := decoder.Decode(&restMessage); err != nil {
 		r.log.Error("decoding message failure", zap.Error(err))
 		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
 	defer req.Body.Close()
-	var err error
+
+	message, err := restMessage.ToProto()
+	if err != nil {
+		writeErrOrResponse(w, err, nil)
+		return
+	}
+
 	if err = server.AppendRLNProof(r.node, message); err != nil {
 		writeErrOrResponse(w, err, nil)
 		return

--- a/cmd/waku/server/rest/relay_test.go
+++ b/cmd/waku/server/rest/relay_test.go
@@ -36,7 +36,7 @@ func TestPostV1Message(t *testing.T) {
 	router := chi.NewRouter()
 
 	_ = makeRelayService(t, router)
-	msg := &pb.WakuMessage{
+	msg := &RestWakuMessage{
 		Payload:      []byte{1, 2, 3},
 		ContentTopic: "abc",
 		Timestamp:    utils.GetUnixEpoch(),
@@ -127,7 +127,7 @@ func TestRelayGetV1Messages(t *testing.T) {
 	// Wait for the subscription to be started
 	time.Sleep(1 * time.Second)
 
-	msg := &pb.WakuMessage{
+	msg := &RestWakuMessage{
 		Payload:      []byte{1, 2, 3},
 		ContentTopic: "test",
 		Timestamp:    utils.GetUnixEpoch(),
@@ -164,7 +164,7 @@ func TestPostAutoV1Message(t *testing.T) {
 	router := chi.NewRouter()
 
 	_ = makeRelayService(t, router)
-	msg := &pb.WakuMessage{
+	msg := &RestWakuMessage{
 		Payload:      []byte{1, 2, 3},
 		ContentTopic: "/toychat/1/huilong/proto",
 		Timestamp:    utils.GetUnixEpoch(),
@@ -262,7 +262,7 @@ func TestRelayGetV1AutoMessages(t *testing.T) {
 	// Wait for the subscription to be started
 	time.Sleep(1 * time.Second)
 
-	msg := &pb.WakuMessage{
+	msg := &RestWakuMessage{
 		Payload:      []byte{1, 2, 3},
 		ContentTopic: cTopic1,
 		Timestamp:    utils.GetUnixEpoch(),

--- a/cmd/waku/server/rest/store.go
+++ b/cmd/waku/server/rest/store.go
@@ -30,18 +30,18 @@ type StoreResponse struct {
 }
 
 type HistoryCursor struct {
-	PubsubTopic string `json:"pubsub_topic"`
-	SenderTime  string `json:"sender_time"`
-	StoreTime   string `json:"store_time"`
+	PubsubTopic string `json:"pubsubTopic"`
+	SenderTime  string `json:"senderTime"`
+	StoreTime   string `json:"storeTime"`
 	Digest      []byte `json:"digest"`
 }
 
 type StoreWakuMessage struct {
-	Payload      []byte `json:"payload"`
-	ContentTopic string `json:"content_topic"`
-	Version      uint32 `json:"version"`
-	Timestamp    int64  `json:"timestamp"`
-	Meta         []byte `json:"meta"`
+	Payload      []byte  `json:"payload"`
+	ContentTopic string  `json:"contentTopic"`
+	Version      *uint32 `json:"version,omitempty"`
+	Timestamp    *int64  `json:"timestamp,omitempty"`
+	Meta         []byte  `json:"meta,omitempty"`
 }
 
 const routeStoreMessagesV1 = "/store/v1/messages"
@@ -180,8 +180,8 @@ func toStoreResponse(result *store.Result) StoreResponse {
 		response.Messages = append(response.Messages, StoreWakuMessage{
 			Payload:      m.Payload,
 			ContentTopic: m.ContentTopic,
-			Version:      m.GetVersion(),
-			Timestamp:    m.GetTimestamp(),
+			Version:      m.Version,
+			Timestamp:    m.Timestamp,
 			Meta:         m.Meta,
 		})
 	}

--- a/cmd/waku/server/rpc/utils.go
+++ b/cmd/waku/server/rpc/utils.go
@@ -3,6 +3,7 @@ package rpc
 import (
 	"errors"
 
+	"github.com/waku-org/go-waku/cmd/waku/server"
 	"github.com/waku-org/go-waku/waku/v2/protocol/pb"
 	rlnpb "github.com/waku-org/go-waku/waku/v2/protocol/rln/pb"
 
@@ -20,12 +21,12 @@ type RateLimitProof struct {
 }
 
 type RPCWakuMessage struct {
-	Payload        Base64URLByte   `json:"payload,omitempty"`
-	ContentTopic   string          `json:"contentTopic,omitempty"`
-	Version        uint32          `json:"version"`
-	Timestamp      int64           `json:"timestamp,omitempty"`
-	RateLimitProof *RateLimitProof `json:"rateLimitProof,omitempty"`
-	Ephemeral      bool            `json:"ephemeral,omitempty"`
+	Payload        server.Base64URLByte `json:"payload,omitempty"`
+	ContentTopic   string               `json:"contentTopic,omitempty"`
+	Version        uint32               `json:"version"`
+	Timestamp      int64                `json:"timestamp,omitempty"`
+	RateLimitProof *RateLimitProof      `json:"rateLimitProof,omitempty"`
+	Ephemeral      bool                 `json:"ephemeral,omitempty"`
 }
 
 func ProtoToRPC(input *pb.WakuMessage) (*RPCWakuMessage, error) {

--- a/cmd/waku/server/utils.go
+++ b/cmd/waku/server/utils.go
@@ -1,6 +1,9 @@
 package server
 
 import (
+	"encoding/base64"
+	"strings"
+
 	"github.com/libp2p/go-libp2p/core/protocol"
 	"github.com/waku-org/go-waku/waku/v2/protocol/filter"
 	"github.com/waku-org/go-waku/waku/v2/protocol/legacy_filter"
@@ -16,4 +19,32 @@ func IsWakuProtocol(protocol protocol.ID) bool {
 		protocol == relay.WakuRelayID_v200 ||
 		protocol == lightpush.LightPushID_v20beta1 ||
 		protocol == store.StoreID_v20beta4
+}
+
+type Base64URLByte []byte
+
+// UnmarshalText is used by json.Unmarshal to decode both url-safe and standard
+// base64 encoded strings with and without padding
+func (h *Base64URLByte) UnmarshalText(b []byte) error {
+	inputValue := ""
+	if b != nil {
+		inputValue = string(b)
+	}
+
+	enc := base64.StdEncoding
+	if strings.ContainsAny(inputValue, "-_") {
+		enc = base64.URLEncoding
+	}
+	if len(inputValue)%4 != 0 {
+		enc = enc.WithPadding(base64.NoPadding)
+	}
+
+	decodedBytes, err := enc.DecodeString(inputValue)
+	if err != nil {
+		return err
+	}
+
+	*h = decodedBytes
+
+	return nil
 }


### PR DESCRIPTION
# Description
Previously, marshalling the protobuffer to json, ended up including a lot of fields that are not part of the rest api described in .yml files. With this PR, we use a struct `RestWakuMessage` which contains the fields described in the API
