### PR TITLE
fix: panic when discv5 is enabled while running service node

### DIFF
--- a/waku/v2/peermanager/peer_manager.go
+++ b/waku/v2/peermanager/peer_manager.go
@@ -467,7 +467,7 @@ func (pm *PeerManager) AddPeer(address ma.Multiaddr, origin wps.Origin, pubsubTo
 	return pData, nil
 }
 
-// Connect establishes a connection to a peer.
+// Connect establishes a connection to a
 func (pm *PeerManager) Connect(pData *service.PeerData) {
 	go pm.peerConnector.PushToChan(*pData)
 }
@@ -486,7 +486,7 @@ func (pm *PeerManager) RemovePeer(peerID peer.ID) {
 // If relay proto is passed, it is not added to serviceSlot.
 func (pm *PeerManager) addPeerToServiceSlot(proto protocol.ID, peerID peer.ID) {
 	if proto == relay.WakuRelayID_v200 {
-		pm.logger.Warn("Cannot add Relay peer to service peer slots")
+		pm.logger.Debug("cannot add Relay peer to service peer slots")
 		return
 	}
 


### PR DESCRIPTION
# Description
When discv5 is enabled, build/waku command was panicking due to invalid memory reference.

@harsh-98 , this got introduced in #884 . 

Whenever we make changes to cmd related code, better to validate it by running a service node with options tht are affected.

# Changes

<!-- List of detailed changes -->

- [ ] Moved discv5 node options to before wakuNode is created.

# Tests

<!-- List down any tests that were executed specifically for this pull-request -->



<!--
## How to test

1.
1.
1.

-->


<!--
## Issue

closes #
-->
