### PR TITLE
fix: rest get messages not returning more than 1 message

### DIFF
--- a/cmd/waku/flags.go
+++ b/cmd/waku/flags.go
@@ -549,7 +549,7 @@ var (
 	})
 	RESTRelayCacheCapacity = altsrc.NewIntFlag(&cli.IntFlag{
 		Name:        "rest-relay-cache-capacity",
-		Value:       30,
+		Value:       1000,
 		Usage:       "Capacity of the Relay REST API message cache",
 		Destination: &options.RESTServer.RelayCacheCapacity,
 		EnvVars:     []string{"WAKUNODE2_REST_RELAY_CACHE_CAPACITY"},


### PR DESCRIPTION
# Description
Getting relay messages via REST API was not working correctly as it would only return a single message due to having a select with a default case without having a loop to drain the channel.

# Changes

<!-- List of detailed changes -->

- [ ] Added a loop to drain the channel until cacheCapacity or context is done
- [ ] Increase default relay cache capacity

# Tests

Tested locally using default pubsubtopic and noticed that messages were returned until channel is drained.


<!--
## How to test

1.
1.
1.

-->


<!--
## Issue

closes #
-->
