### PR TITLE
fix: allow to use `postgres` in DB url

### DIFF
--- a/waku/persistence/utils/db.go
+++ b/waku/persistence/utils/db.go
@@ -52,7 +52,7 @@ func ExtractDBAndMigration(databaseURL string, dbSettings DBSettings, logger *za
 	case "sqlite3":
 		db, err = sqlite.NewDB(dbParams, logger)
 		migrationFn = sqlite.Migrations
-	case "postgresql":
+	case "postgres", "postgresql":
 		db, err = postgres.NewDB(dbURL, logger)
 		migrationFn = postgres.Migrations
 	default:


### PR DESCRIPTION
# Description
Allow using `postgres` in the db connection string to match nwaku. 
(`postgresql` and `postgres` are valid db url prefixes according to `libpq`)
