### PR TITLE
test: extend timeout for single message

### DIFF
--- a/waku/v2/protocol/filter/filter_push_test.go
+++ b/waku/v2/protocol/filter/filter_push_test.go
@@ -128,7 +128,7 @@ func (s *FilterTestSuite) TestLargePayloadsUTF8() {
 
 	// Generate large string
 	for i := range messages {
-		messages[i].payload, _ = tests.GenerateRandomUTF8String(1048576)
+		messages[i].payload, _ = tests.GenerateRandomUTF8String(153600)
 		s.log.Info("Generated payload with ", zap.String("length", strconv.Itoa(len(messages[i].payload))))
 	}
 

--- a/waku/v2/protocol/filter/filter_push_test.go
+++ b/waku/v2/protocol/filter/filter_push_test.go
@@ -118,7 +118,7 @@ func (s *FilterTestSuite) TestValidPayloadsSQL() {
 
 func (s *FilterTestSuite) TestLargePayloadsUTF8() {
 
-	s.ctx, s.ctxCancel = context.WithTimeout(context.Background(), 20*time.Second)
+	s.ctx, s.ctxCancel = context.WithTimeout(context.Background(), 30*time.Second)
 
 	// Subscribe
 	s.subDetails = s.subscribe(s.testTopic, s.testContentTopic, s.fullNodeHost.ID())

--- a/waku/v2/protocol/filter/filter_push_test.go
+++ b/waku/v2/protocol/filter/filter_push_test.go
@@ -118,7 +118,7 @@ func (s *FilterTestSuite) TestValidPayloadsSQL() {
 
 func (s *FilterTestSuite) TestLargePayloadsUTF8() {
 
-	s.ctx, s.ctxCancel = context.WithTimeout(context.Background(), 30*time.Second)
+	s.ctx, s.ctxCancel = context.WithTimeout(context.Background(), 40*time.Second)
 
 	// Subscribe
 	s.subDetails = s.subscribe(s.testTopic, s.testContentTopic, s.fullNodeHost.ID())

--- a/waku/v2/protocol/filter/filter_test.go
+++ b/waku/v2/protocol/filter/filter_test.go
@@ -191,7 +191,7 @@ func (s *FilterTestSuite) waitForMessages(fn func(), subs []*subscription.Subscr
 					if matchOneOfManyMsg(received, expected) {
 						found++
 					}
-				case <-time.After(2 * time.Second):
+				case <-time.After(4 * time.Second):
 
 				case <-s.ctx.Done():
 					s.Require().Fail("test exceeded allocated time")

--- a/waku/v2/protocol/filter/filter_test.go
+++ b/waku/v2/protocol/filter/filter_test.go
@@ -191,7 +191,7 @@ func (s *FilterTestSuite) waitForMessages(fn func(), subs []*subscription.Subscr
 					if matchOneOfManyMsg(received, expected) {
 						found++
 					}
-				case <-time.After(1 * time.Second):
+				case <-time.After(2 * time.Second):
 
 				case <-s.ctx.Done():
 					s.Require().Fail("test exceeded allocated time")

--- a/waku/v2/protocol/filter/filter_test.go
+++ b/waku/v2/protocol/filter/filter_test.go
@@ -191,7 +191,7 @@ func (s *FilterTestSuite) waitForMessages(fn func(), subs []*subscription.Subscr
 					if matchOneOfManyMsg(received, expected) {
 						found++
 					}
-				case <-time.After(4 * time.Second):
+				case <-time.After(3 * time.Second):
 
 				case <-s.ctx.Done():
 					s.Require().Fail("test exceeded allocated time")


### PR DESCRIPTION
Changes
Adding more time to wait for a message sent during the test. Messages could be up to 1MB and it may take longer on slower computers to receive them.