### PR TITLE
feat: setting image deployment to Harbor Registry

### DIFF
--- a/ci/Jenkinsfile.docker
+++ b/ci/Jenkinsfile.docker
@@ -12,7 +12,7 @@ pipeline {
     string(
       name: 'IMAGE_NAME',
       description: 'Docker image name.',
-      defaultValue: params.IMAGE_NAME ?: 'wakuorg/go-waku',
+      defaultValue: params.IMAGE_NAME ?: 'waku-org/go-waku',
     )
     string(
       name: 'IMAGE_TAG',
@@ -21,9 +21,15 @@ pipeline {
     )
     string(
       name: 'DOCKER_CRED',
-      description: 'Name of Docker Hub credential.',
-      defaultValue: params.DOCKER_CRED ?: 'dockerhub-vacorgbot-api-token',
+      description: 'Name of Docker Registry credential.',
+      defaultValue: params.DOCKER_CRED ?: 'harbor-wakuorg-robot',
     )
+    string(
+      name: 'DOCKER_REGISTRY_URL',
+      description: 'URL of the Docker Registry',
+      defaultValue: params.DOCKER_REGISTRY_URL ?: 'https://harbor.status.im'
+    )
+
   }
 
   options {
@@ -48,7 +54,7 @@ pipeline {
       when { expression { params.IMAGE_TAG != '' } }
       steps { script {
         withDockerRegistry([
-          credentialsId: params.DOCKER_CRED, url: ''
+          credentialsId: params.DOCKER_CRED, url: params.DOCKER_REGISTRY_URL
         ]) {
           image.push()
           /* If Git ref is a tag push it as Docker tag too. */


### PR DESCRIPTION
# Description

Using custom registry for hosting Docker images: https://harbor.status.im

# Changes

- [ ] Changing default Docker Registry and adding `DOCKER_REGISTRY_URL` variable
- [ ] Changing default secret used to authentified to the registry
- [ ] Changing image owner from `wakuorg` to `waku-org` to match github repository name.

# Note

Images will be replicated from Harbor repository to Docker Hub