### PR TITLE
refactor: reuse query and cursor instead of specifying each pb field

### DIFF
--- a/waku/v2/protocol/store/waku_store_client.go
+++ b/waku/v2/protocol/store/waku_store_client.go
@@ -452,23 +452,9 @@ func (store *WakuStore) Next(ctx context.Context, r *Result) (*Result, error) {
 
 	historyRequest := &pb.HistoryRPC{
 		RequestId: hex.EncodeToString(protocol.GenerateRequestID()),
-		Query: &pb.HistoryQuery{
-			PubsubTopic:    r.Query().PubsubTopic,
-			ContentFilters: r.Query().ContentFilters,
-			StartTime:      r.Query().StartTime,
-			EndTime:        r.Query().EndTime,
-			PagingInfo: &pb.PagingInfo{
-				PageSize:  r.Query().PagingInfo.PageSize,
-				Direction: r.Query().PagingInfo.Direction,
-				Cursor: &pb.Index{
-					Digest:       r.Cursor().Digest,
-					ReceiverTime: r.Cursor().ReceiverTime,
-					SenderTime:   r.Cursor().SenderTime,
-					PubsubTopic:  r.Cursor().PubsubTopic,
-				},
-			},
-		},
+		Query:     r.Query(),
 	}
+	historyRequest.Query.PagingInfo.Cursor = r.Cursor()
 
 	response, err := store.queryFrom(ctx, historyRequest, r.PeerID())
 	if err != nil {

--- a/waku/v2/protocol/store/waku_store_protocol_test.go
+++ b/waku/v2/protocol/store/waku_store_protocol_test.go
@@ -79,7 +79,7 @@ func TestWakuStoreProtocolQuery(t *testing.T) {
 
 	require.NoError(t, err)
 	require.Len(t, response.Messages, 1)
-	require.Equal(t, msg, response.Messages[0])
+	require.True(t, proto.Equal(msg, response.Messages[0]))
 }
 
 func TestWakuStoreProtocolLocalQuery(t *testing.T) {


### PR DESCRIPTION
# Description
While debugging store queries with @Ivansete-status, i realized that specifying each field for subsequent queries is not a good idea because maybe the protocol will change in the future, and we might end up missing attributes here. With this change we reuse the query fields and the cursor
