### PR TITLE
fix: return error in relay publish if exceeding max-msg-size

### DIFF
--- a/waku/metrics/http.go
+++ b/waku/metrics/http.go
@@ -43,7 +43,7 @@ func NewMetricsServer(address string, port int, log *zap.Logger) *Server {
 
 // Start executes the HTTP server in the background.
 func (p *Server) Start() {
-	p.log.Info("server stopped ", zap.Error(p.server.ListenAndServe()))
+	p.log.Info("server started ", zap.Error(p.server.ListenAndServe()))
 }
 
 // Stop shuts down the prometheus server

--- a/waku/v2/protocol/relay/waku_relay.go
+++ b/waku/v2/protocol/relay/waku_relay.go
@@ -289,6 +289,10 @@ func (w *WakuRelay) Publish(ctx context.Context, message *pb.WakuMessage, opts .
 		return nil, err
 	}
 
+	if len(out) > pubsub.DefaultMaxMessageSize {
+		return nil, errors.New("message size exceeds gossipsub max message size")
+	}
+
 	err = pubSubTopic.Publish(ctx, out)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
# Description
gossipsub internally drops a message from being published to peers if it exceed maxMessageSize which is by default set to 1MB. This doesn't give a good dev ex as user of Waku relay assumes that message is successfully published even it is greater than msgSize. 

Similar observation is made in https://github.com/status-im/status-go/issues/4355

Hence, a size check is done before publishing the message to return error if the messageSize is greater than pubsub DefaultMaxMsgSize

