### PR TITLE
feat: fill msg timestamp while appending RLN proof it is not set

### DIFF
--- a/waku/v2/protocol/rln/waku_rln_relay.go
+++ b/waku/v2/protocol/rln/waku_rln_relay.go
@@ -217,6 +217,10 @@ func (rlnRelay *WakuRLNRelay) AppendRLNProof(msg *pb.WakuMessage, senderEpochTim
 	}
 
 	msg.RateLimitProof = b
+	//If msgTimeStamp is not set, then set it to timestamp of proof
+	if msg.Timestamp == nil {
+		msg.Timestamp = proto.Int64(senderEpochTime.Unix())
+	}
 
 	return nil
 }


### PR DESCRIPTION
# Description

If message timestamp is not set, then as part of appending RLN proof to the message, the timestamp is also set based on which the RLN proof is calculated.

Fixes #926 and not just REST API but for all API's.

cc @waku-org/nwaku-developers This would have to be addressed in nwaku REST API as well. 
