### PR TITLE
feat: include pubsubTopics supported by peer in getPeers REST API 

### DIFF
--- a/cmd/waku/server/rest/admin.go
+++ b/cmd/waku/server/rest/admin.go
@@ -23,10 +23,11 @@ type AdminService struct {
 }
 
 type WakuPeer struct {
-	ID         string   `json:"id"`
-	MultiAddrs []string `json:"multiaddrs"`
-	Protocols  []string `json:"protocols"`
-	Connected  bool     `json:"connected"`
+	ID           string   `json:"id"`
+	MultiAddrs   []string `json:"multiaddrs"`
+	Protocols    []string `json:"protocols"`
+	Connected    bool     `json:"connected"`
+	PubsubTopics []string `json:"pubsubTopics"`
 }
 
 type WakuPeerInfo struct {
@@ -76,6 +77,7 @@ func (a *AdminService) getV1Peers(w http.ResponseWriter, req *http.Request) {
 			}
 			wPeer.Protocols = append(wPeer.Protocols, string(proto))
 		}
+		wPeer.PubsubTopics = peer.PubsubTopics
 		response = append(response, wPeer)
 	}
 

--- a/cmd/waku/server/rest/admin_api.yaml
+++ b/cmd/waku/server/rest/admin_api.yaml
@@ -86,3 +86,7 @@ components:
             type: string
         connected:
           type: boolean
+        pubsubTopics:
+          type: array
+          items:
+            type: string

--- a/waku/v2/node/wakunode2.go
+++ b/waku/v2/node/wakunode2.go
@@ -860,7 +860,9 @@ func (w *WakuNode) Peers() ([]*Peer, error) {
 
 		addrs := utils.EncapsulatePeerID(peerId, w.host.Peerstore().Addrs(peerId)...)
 		topics, err := w.host.Peerstore().(*wps.WakuPeerstoreImpl).PubSubTopics(peerId)
-
+		if err != nil {
+			return nil, err
+		}
 		peers = append(peers, &Peer{
 			ID:           peerId,
 			Protocols:    protocols,

--- a/waku/v2/node/wakunode2.go
+++ b/waku/v2/node/wakunode2.go
@@ -53,10 +53,11 @@ import (
 const discoveryConnectTimeout = 20 * time.Second
 
 type Peer struct {
-	ID        peer.ID        `json:"peerID"`
-	Protocols []protocol.ID  `json:"protocols"`
-	Addrs     []ma.Multiaddr `json:"addrs"`
-	Connected bool           `json:"connected"`
+	ID           peer.ID        `json:"peerID"`
+	Protocols    []protocol.ID  `json:"protocols"`
+	Addrs        []ma.Multiaddr `json:"addrs"`
+	Connected    bool           `json:"connected"`
+	PubsubTopics []string       `json:"pubsubTopics"`
 }
 
 type storeFactory func(w *WakuNode) store.Store
@@ -858,11 +859,14 @@ func (w *WakuNode) Peers() ([]*Peer, error) {
 		}
 
 		addrs := utils.EncapsulatePeerID(peerId, w.host.Peerstore().Addrs(peerId)...)
+		topics, err := w.host.Peerstore().(*wps.WakuPeerstoreImpl).PubSubTopics(peerId)
+
 		peers = append(peers, &Peer{
-			ID:        peerId,
-			Protocols: protocols,
-			Connected: connected,
-			Addrs:     addrs,
+			ID:           peerId,
+			Protocols:    protocols,
+			Connected:    connected,
+			Addrs:        addrs,
+			PubsubTopics: topics,
 		})
 	}
 	return peers, nil


### PR DESCRIPTION
While debugging, felt the need for this change.

Fixes #830 