### PR TITLE
fix(store): set pagesize behavior match nwaku

### DIFF
--- a/cmd/waku/server/rest/store.go
+++ b/cmd/waku/server/rest/store.go
@@ -132,7 +132,7 @@ func getStoreParams(r *http.Request) (*store.Query, []store.HistoryRequestOption
 	ascendingStr := r.URL.Query().Get("ascending")
 	if ascendingStr != "" || pageSizeStr != "" {
 		ascending := true
-		pageSize := uint64(store.MaxPageSize)
+		pageSize := uint64(store.DefaultPageSize)
 		if ascendingStr != "" {
 			ascending, err = strconv.ParseBool(ascendingStr)
 			if err != nil {
@@ -144,6 +144,9 @@ func getStoreParams(r *http.Request) (*store.Query, []store.HistoryRequestOption
 			pageSize, err = strconv.ParseUint(pageSizeStr, 10, 64)
 			if err != nil {
 				return nil, nil, err
+			}
+			if pageSize > store.MaxPageSize {
+				pageSize = store.MaxPageSize
 			}
 		}
 

--- a/waku/v2/protocol/store/waku_store_client.go
+++ b/waku/v2/protocol/store/waku_store_client.go
@@ -195,7 +195,7 @@ func DefaultOptions() []HistoryRequestOption {
 	return []HistoryRequestOption{
 		WithAutomaticRequestID(),
 		WithAutomaticPeerSelection(),
-		WithPaging(true, MaxPageSize),
+		WithPaging(true, DefaultPageSize),
 	}
 }
 
@@ -359,7 +359,9 @@ func (store *WakuStore) Query(ctx context.Context, query Query, opts ...HistoryR
 	}
 
 	pageSize := params.pageSize
-	if pageSize == 0 || pageSize > uint64(MaxPageSize) {
+	if pageSize == 0 {
+		pageSize = DefaultPageSize
+	} else if pageSize > uint64(MaxPageSize) {
 		pageSize = MaxPageSize
 	}
 	historyRequest.Query.PagingInfo.PageSize = pageSize

--- a/waku/v2/protocol/store/waku_store_common.go
+++ b/waku/v2/protocol/store/waku_store_common.go
@@ -19,7 +19,9 @@ const StoreID_v20beta4 = libp2pProtocol.ID("/vac/waku/store/2.0.0-beta4")
 const StoreENRField = uint8(1 << 1)
 
 // MaxPageSize is the maximum number of waku messages to return per page
-const MaxPageSize = 20
+const MaxPageSize = 100
+
+const DefaultPageSize = 20
 
 var (
 

--- a/waku/v2/protocol/store/waku_store_protocol.go
+++ b/waku/v2/protocol/store/waku_store_protocol.go
@@ -30,7 +30,9 @@ func findMessages(query *pb.HistoryQuery, msgProvider MessageProvider) ([]*wpb.W
 		}
 	}
 
-	if query.PagingInfo.PageSize == 0 || query.PagingInfo.PageSize > uint64(MaxPageSize) {
+	if query.PagingInfo.PageSize == 0 {
+		query.PagingInfo.PageSize = DefaultPageSize
+	} else if query.PagingInfo.PageSize > uint64(MaxPageSize) {
 		query.PagingInfo.PageSize = MaxPageSize
 	}
 


### PR DESCRIPTION
# Description
While chatting with @igorsirotin, he pointed out the difference in behavior in storenode implementations between go-waku and nwaku. This PR fixes this difference


