### PR TITLE
fix: take into account the ENR seq to determine if a peer is new or not

### DIFF
--- a/waku/v2/peermanager/peer_manager.go
+++ b/waku/v2/peermanager/peer_manager.go
@@ -341,9 +341,14 @@ func (pm *PeerManager) AddDiscoveredPeer(p service.PeerData, connectNow bool) {
 	//Check if the peer is already present, if so skip adding
 	_, err := pm.host.Peerstore().(wps.WakuPeerstore).Origin(p.AddrInfo.ID)
 	if err == nil {
-		pm.logger.Debug("peer already in peerStore", logging.HostID("peer", p.AddrInfo.ID))
-		return
+		enr, err := pm.host.Peerstore().(wps.WakuPeerstore).ENR(p.AddrInfo.ID)
+		// Verifying if the enr record is more recent (DiscV5 and peer exchange can return peers already seen)
+		if err == nil && enr.Record().Seq() > p.ENR.Seq() {
+			pm.logger.Debug("found discovered peer already in peerStore", logging.HostID("peer", p.AddrInfo.ID))
+			return
+		}
 	}
+
 	supportedProtos := []protocol.ID{}
 	if len(p.PubsubTopics) == 0 && p.ENR != nil {
 		// Try to fetch shard info and supported protocols from ENR to arrive at pubSub topics.


### PR DESCRIPTION
# Description
We were assuming that if a peer already existed on the store, it was already seen, regardless of the ENR being updated or not.
