### PR TITLE
fix: use node's clusterId when adding peer from admin REST API & don't subscribe to default pubsub topic for non-zero clusterID

### DIFF
--- a/cmd/waku/node.go
+++ b/cmd/waku/node.go
@@ -478,7 +478,7 @@ func processTopics(options NodeOptions) (map[string][]string, error) {
 		pubSubTopicMap[pTopic.String()] = append(pubSubTopicMap[pTopic.String()], cTopic)
 	}
 	//If no topics are passed, then use default waku topic.
-	if len(pubSubTopicMap) == 0 {
+	if len(pubSubTopicMap) == 0 && options.ClusterID == 0 {
 		pubSubTopicMap[relay.DefaultWakuTopic] = []string{}
 	}
 

--- a/cmd/waku/server/rest/admin.go
+++ b/cmd/waku/server/rest/admin.go
@@ -105,7 +105,7 @@ func (a *AdminService) postV1Peer(w http.ResponseWriter, req *http.Request) {
 	}
 
 	for _, shard := range pInfo.Shards {
-		topic := waku_proto.NewStaticShardingPubsubTopic(waku_proto.ClusterIndex, uint16(shard))
+		topic := waku_proto.NewStaticShardingPubsubTopic(a.node.ClusterID(), uint16(shard))
 		topics = append(topics, topic.String())
 	}
 

--- a/waku/v2/node/wakunode2.go
+++ b/waku/v2/node/wakunode2.go
@@ -978,3 +978,7 @@ func GetDiscv5Option(dnsDiscoveredNodes []dnsdisc.DiscoveredNode, discv5Nodes []
 
 	return WithDiscoveryV5(port, bootnodes, autoUpdate), nil
 }
+
+func (w *WakuNode) ClusterID() uint16 {
+	return w.opts.clusterID
+}


### PR DESCRIPTION
# Changes

- Admin REST API to add peer was using default clusterID rather than node's configured clusterID.
- If clusterID is set to non-zero, do not subscribe to default pubsubTopic `/waku/2/default-waku/proto`

