### PR TITLE
fix: return appropriate error code for filter subscribe ping

### DIFF
--- a/cmd/waku/server/rest/filter.go
+++ b/cmd/waku/server/rest/filter.go
@@ -178,10 +178,14 @@ func (s *FilterService) subscribe(w http.ResponseWriter, req *http.Request) {
 
 	if err != nil {
 		s.log.Error("subscription failed", zap.Error(err))
+		code := filter.ExtractCodeFromFilterError(err.Error())
+		if code == -1 {
+			code = http.StatusBadRequest
+		}
 		writeResponse(w, filterSubscriptionResponse{
 			RequestID:  message.RequestID,
 			StatusDesc: "subscription failed",
-		}, http.StatusServiceUnavailable)
+		}, code)
 		return
 	}
 
@@ -220,6 +224,12 @@ func (s *FilterService) unsubscribe(w http.ResponseWriter, req *http.Request) {
 
 	if err != nil {
 		s.log.Error("unsubscribe failed", zap.Error(err))
+		if result == nil {
+			writeResponse(w, filterSubscriptionResponse{
+				RequestID:  message.RequestID,
+				StatusDesc: err.Error(),
+			}, http.StatusBadRequest)
+		}
 		writeResponse(w, filterSubscriptionResponse{
 			RequestID:  message.RequestID,
 			StatusDesc: err.Error(),

--- a/cmd/waku/server/rest/filter_test.go
+++ b/cmd/waku/server/rest/filter_test.go
@@ -79,9 +79,9 @@ func TestFilterPingFailure(t *testing.T) {
 	router.ServeHTTP(rr, req)
 	checkJSON(t, filterSubscriptionResponse{
 		RequestID:  requestID,
-		StatusDesc: "ping request failed",
+		StatusDesc: "peer has no subscription",
 	}, getFilterResponse(t, rr.Body))
-	require.Equal(t, http.StatusServiceUnavailable, rr.Code)
+	require.Equal(t, http.StatusNotFound, rr.Code)
 }
 
 // create a filter subscription to the peer and try peer that peer
@@ -230,9 +230,9 @@ func TestFilterAllUnsubscribe(t *testing.T) {
 	router.ServeHTTP(rr, req)
 	checkJSON(t, filterSubscriptionResponse{
 		RequestID:  requestID,
-		StatusDesc: "ping request failed",
+		StatusDesc: "peer has no subscription",
 	}, getFilterResponse(t, rr.Body))
-	require.Equal(t, http.StatusServiceUnavailable, rr.Code)
+	require.Equal(t, http.StatusNotFound, rr.Code)
 }
 
 func checkJSON(t *testing.T, expected, actual interface{}) {

--- a/waku/v2/protocol/filter/common.go
+++ b/waku/v2/protocol/filter/common.go
@@ -22,6 +22,18 @@ func NewFilterError(code int, message string) FilterError {
 	}
 }
 
+const errorStringFmt = "%d - %s"
+
 func (e *FilterError) Error() string {
-	return fmt.Sprintf("%d - %s", e.Code, e.Message)
+	return fmt.Sprintf(errorStringFmt, e.Code, e.Message)
+}
+
+func ExtractCodeFromFilterError(fErr string) int {
+	code := 0
+	var message string
+	_, err := fmt.Sscanf(fErr, errorStringFmt, &code, &message)
+	if err != nil {
+		return -1
+	}
+	return code
 }


### PR DESCRIPTION
# Description
Fixes #970 and #968 and also aligns with error mapping as per nwaku

Tested locally below scenarios:
-  ping without subscription returns 404 
- subscribe request with missing request-ID returns 400
- unsubscribe without content-topic returns 400