### PR TITLE
fix: ENR seq check to skip adding already existing peer

### DIFF
--- a/waku/v2/peermanager/peer_manager.go
+++ b/waku/v2/peermanager/peer_manager.go
@@ -350,8 +350,9 @@ func (pm *PeerManager) AddDiscoveredPeer(p service.PeerData, connectNow bool) {
 	_, err := pm.host.Peerstore().(wps.WakuPeerstore).Origin(p.AddrInfo.ID)
 	if err == nil {
 		enr, err := pm.host.Peerstore().(wps.WakuPeerstore).ENR(p.AddrInfo.ID)
+		pm.logger.Info("already found peer in peerstore", logging.HostID("peer", p.AddrInfo.ID), zap.Error(err), zap.Uint64("p.ENR.Seq()", p.ENR.Seq()), zap.Uint64("enr.Record().Seq()", enr.Record().Seq()))
 		// Verifying if the enr record is more recent (DiscV5 and peer exchange can return peers already seen)
-		if err == nil && enr.Record().Seq() > p.ENR.Seq() {
+		if err == nil && enr.Record().Seq() >= p.ENR.Seq() {
 			return
 		}
 	}

--- a/waku/v2/peermanager/peer_manager.go
+++ b/waku/v2/peermanager/peer_manager.go
@@ -350,11 +350,12 @@ func (pm *PeerManager) AddDiscoveredPeer(p service.PeerData, connectNow bool) {
 	_, err := pm.host.Peerstore().(wps.WakuPeerstore).Origin(p.AddrInfo.ID)
 	if err == nil {
 		enr, err := pm.host.Peerstore().(wps.WakuPeerstore).ENR(p.AddrInfo.ID)
-		pm.logger.Info("already found peer in peerstore", logging.HostID("peer", p.AddrInfo.ID), zap.Error(err), zap.Uint64("p.ENR.Seq()", p.ENR.Seq()), zap.Uint64("enr.Record().Seq()", enr.Record().Seq()))
 		// Verifying if the enr record is more recent (DiscV5 and peer exchange can return peers already seen)
 		if err == nil && enr.Record().Seq() >= p.ENR.Seq() {
 			return
 		}
+		pm.logger.Info("peer already found in peerstore, but re-adding it as ENR sequence is higher than locally stored",
+			logging.HostID("peer", p.AddrInfo.ID), zap.Uint64("newENRSeq", p.ENR.Seq()), zap.Uint64("storedENRSeq", enr.Record().Seq()))
 	}
 
 	supportedProtos := []protocol.ID{}


### PR DESCRIPTION
# Description
While running local go-waku node, had noticed that same peer was getting added again and again despite checks for duplicates and ENR updates.
Noticed that ENR update check was failing even if sequence number of ENR is not updated.
