### PR TITLE
fix: use both filter and legacyFilter flags to determine if filter is enabled and set Waku2 ENR field

### DIFF
--- a/waku/v2/node/wakunode2.go
+++ b/waku/v2/node/wakunode2.go
@@ -200,7 +200,7 @@ func New(opts ...WakuNodeOption) (*WakuNode, error) {
 	w.log = params.logger.Named("node2")
 	w.wg = &sync.WaitGroup{}
 	w.keepAliveFails = make(map[peer.ID]int)
-	w.wakuFlag = enr.NewWakuEnrBitfield(w.opts.enableLightPush, w.opts.enableLegacyFilter, w.opts.enableStore, w.opts.enableRelay)
+	w.wakuFlag = enr.NewWakuEnrBitfield(w.opts.enableLightPush, w.opts.enableFilterFullNode || w.opts.enableLegacyFilter, w.opts.enableStore, w.opts.enableRelay)
 	w.circuitRelayNodes = make(chan peer.AddrInfo)
 	w.metrics = newMetrics(params.prometheusReg)
 


### PR DESCRIPTION
Florin ran into an issue which has 2-fold solution. 

As per https://github.com/waku-org/go-waku/issues/988#issuecomment-1876810340 , the Filter-Subscribe REST API was timing out in node2 eventhough it is connected to node1(which has Filterv2 enabled).

But since node1's ENR is not settings Filter bit in Waku2 field, node2 doesn't consider node1 as filter node as it is only found via discovery.

Second problem is his request times-out because node2 goes into on-demand discovery and does till REST API times out.
This will have to improved for dev-ex, by having an internal timeout for on-demand discovery and responding back with error.