### PR TITLE
chore: increase maxContentFilter limit for Filter protocol to 100

### DIFF
--- a/waku/v2/protocol/filter/filter_subscribe_test.go
+++ b/waku/v2/protocol/filter/filter_subscribe_test.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
-	"github.com/waku-org/go-waku/waku/v2/protocol/filter/pb"
 	"sync"
 	"time"
+
+	"github.com/waku-org/go-waku/waku/v2/protocol/filter/pb"
 
 	"github.com/libp2p/go-libp2p/core/peerstore"
 	"github.com/waku-org/go-waku/tests"
@@ -195,7 +196,7 @@ func (s *FilterTestSuite) TestSubscriptionRefresh() {
 }
 
 func (s *FilterTestSuite) TestContentTopicsLimit() {
-	var maxContentTopics = 30
+	var maxContentTopics = pb.MaxContentTopicsPerRequest
 
 	// Create test context
 	s.ctx, s.ctxCancel = context.WithTimeout(context.Background(), 20*time.Second) // Test can't exceed 10 seconds

--- a/waku/v2/protocol/filter/pb/validation.go
+++ b/waku/v2/protocol/filter/pb/validation.go
@@ -7,7 +7,7 @@ import (
 	"golang.org/x/exp/slices"
 )
 
-const MaxContentTopicsPerRequest = 30
+const MaxContentTopicsPerRequest = 100
 
 var (
 	errMissingRequestID   = errors.New("missing RequestId field")


### PR DESCRIPTION
# Description
Changing this as per https://github.com/waku-org/nwaku/issues/2338
