### PR TITLE
chore: set log level for all loggers based on logger passed

### DIFF
--- a/waku/v2/node/wakuoptions.go
+++ b/waku/v2/node/wakuoptions.go
@@ -155,6 +155,7 @@ func (w WakuNodeParameters) AddressFactory() basichost.AddrsFactory {
 func WithLogger(l *zap.Logger) WakuNodeOption {
 	return func(params *WakuNodeParameters) error {
 		params.logger = l
+		logging.SetAllLoggers(logging.LogLevel(l.Level()))
 		logging.SetPrimaryCore(l.Core())
 		return nil
 	}


### PR DESCRIPTION
# Description
Fixes all loggers to be set to log-level of the logger object passed. 
Also fixes logs in status-desktop for libp2p which are not printed with proper file name for log origin. 
As of now logs are printed as below

```
   DEBUG[01-23|16:06:42.943|go.uber.org/zap/sugar.go:127]                                                   [Fx] SUPPLY    []upgrader.StreamMuxer
   DEBUG[01-23|16:06:42.943|go.uber.org/zap/sugar.go:127]                                                   [Fx] SUPPLY    peer.ID
   DEBUG[01-23|16:06:42.943|go.uber.org/zap/sugar.go:127]                                                   [Fx] PROVIDE   host.Host <= github.com/libp2p/go-libp2p/config.(*Config).addTransports.func2()
   DEBUG[01-23|16:06:42.943|go.uber.org/zap/sugar.go:127]                                                   [Fx] PROVIDE   crypto.PrivKey <= github.com/libp2p/go-libp2p/config.(*Config).addTransports.func3()

```
