### PR TITLE
fix: update lastProcessedBlock even if no RLN membership event is present

### DIFF
--- a/waku/v2/protocol/rln/group_manager/dynamic/dynamic.go
+++ b/waku/v2/protocol/rln/group_manager/dynamic/dynamic.go
@@ -78,6 +78,9 @@ func (gm *DynamicGroupManager) handler(events []*contracts.RLNMemberRegistered, 
 			lastBlockProcessed = event.Raw.BlockNumber
 		}
 	}
+	if len(events) == 0 {
+		lastBlockProcessed = latestProcessBlock
+	}
 
 	err := gm.RemoveMembers(toRemoveTable)
 	if err != nil {

--- a/waku/v2/protocol/rln/group_manager/dynamic/dynamic.go
+++ b/waku/v2/protocol/rln/group_manager/dynamic/dynamic.go
@@ -73,10 +73,9 @@ func (gm *DynamicGroupManager) handler(events []*contracts.RLNMemberRegistered, 
 			}
 			eventsPerBlock = append(eventsPerBlock, event)
 			toInsertTable.Set(event.Raw.BlockNumber, eventsPerBlock)
-
-			if event.Raw.BlockNumber > lastBlockProcessed {
-				lastBlockProcessed = event.Raw.BlockNumber
-			}
+		}
+		if event.Raw.BlockNumber > lastBlockProcessed {
+			lastBlockProcessed = event.Raw.BlockNumber
 		}
 	}
 


### PR DESCRIPTION
Update lastProcessedBlock even if no RLN membership event is present or membership removed event is present.

This is an optimization to handle a scenario of not requiring to sync on restart from blocks which were already processed but not updated due to no events being processed.
