### PR TITLE
chore: add logs for peer connection backoff

### DIFF
--- a/waku/v2/peermanager/peer_connector.go
+++ b/waku/v2/peermanager/peer_connector.go
@@ -130,7 +130,7 @@ func (c *PeerConnectionStrategy) consumeSubscription(s subscription) {
 				if len(c.host.Network().Peers()) < waku_proto.GossipSubOptimalFullMeshSize {
 					triggerImmediateConnection = true
 				}
-				c.logger.Debug("adding discovered peer", logging.HostID("peer", p.AddrInfo.ID))
+				c.logger.Debug("adding discovered peer", logging.HostID("peerID", p.AddrInfo.ID))
 				c.pm.AddDiscoveredPeer(p, triggerImmediateConnection)
 
 			case <-time.After(1 * time.Second):
@@ -198,13 +198,18 @@ func (c *PeerConnectionStrategy) canDialPeer(pi peer.AddrInfo) bool {
 		tv := val.(*connCacheData)
 		now := time.Now()
 		if now.Before(tv.nextTry) {
+			c.logger.Debug("Skipping connecting to peer due to backoff strategy",
+				zap.Time("currentTime", now), zap.Time("until", tv.nextTry))
 			return false
 		}
-
+		c.logger.Debug("Proceeding with connecting to peer",
+			zap.Time("currentTime", now), zap.Time("nextTry", tv.nextTry))
 		tv.nextTry = now.Add(tv.strat.Delay())
 	} else {
 		cachedPeer = &connCacheData{strat: c.backoff()}
 		cachedPeer.nextTry = time.Now().Add(cachedPeer.strat.Delay())
+		c.logger.Debug("Initializing connectionCache for peer ",
+			logging.HostID("peerID", pi.ID), zap.Time("until", cachedPeer.nextTry))
 		c.cache.Add(pi.ID, cachedPeer)
 	}
 	return true

--- a/waku/v2/peermanager/peer_discovery.go
+++ b/waku/v2/peermanager/peer_discovery.go
@@ -112,7 +112,7 @@ func (pm *PeerManager) discoverPeersByPubsubTopics(pubsubTopics []string, proto 
 		for _, shardInfo := range shardsInfo {
 			err = pm.DiscoverAndConnectToPeers(ctx, shardInfo.ClusterID, shardInfo.ShardIDs[0], proto, maxCount)
 			if err != nil {
-				pm.logger.Error("failed to discover and conenct to peers", zap.Error(err))
+				pm.logger.Error("failed to discover and connect to peers", zap.Error(err))
 			}
 		}
 	} else {


### PR DESCRIPTION
Noticing sometimes on my status desktop that there are no peer connections.
Wanted to add these logs that would help debug situations where backoff is causing issues with connecting to peers.