### PR TITLE
chore: removing tests with postgres as it keeps failing in CI 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,8 +165,3 @@ jobs:
         run: |
           docker compose -f .github/docker-compose/ganache.yml up -d
           make test-onchain${{ matrix.tests == 'test-with-race' && '-with-race' || '' }}
-
-      - name: "Run tests with postgres"
-        run: |
-          docker compose -f .github/docker-compose/postgres.yml up -d
-          make test-postgres${{ matrix.tests == 'test-with-race' && '-with-race' || '' }}


### PR DESCRIPTION
Postgres or StoreNode is not used by status and go-waku is descoped for serviceNode.
