### PR TITLE
chore: add rate limiter option to lightpush

### DIFF
--- a/examples/chat2/chat.go
+++ b/examples/chat2/chat.go
@@ -324,7 +324,7 @@ func (c *Chat) publish(ctx context.Context, message string) error {
 	}
 
 	if c.options.LightPush.Enable {
-		lightOpt := []lightpush.Option{lightpush.WithDefaultPubsubTopic()}
+		lightOpt := []lightpush.RequestOption{lightpush.WithDefaultPubsubTopic()}
 		var peerID peer.ID
 		peerID, err = options.LightPush.NodePeerID()
 		if err != nil {

--- a/library/lightpush.go
+++ b/library/lightpush.go
@@ -26,7 +26,7 @@ func lightpushPublish(instance *WakuInstance, msg *pb.WakuMessage, pubsubTopic s
 		ctx = instance.ctx
 	}
 
-	var lpOptions []lightpush.Option
+	var lpOptions []lightpush.RequestOption
 	if peerID != "" {
 		p, err := peer.Decode(peerID)
 		if err != nil {

--- a/waku/v2/protocol/lightpush/metrics.go
+++ b/waku/v2/protocol/lightpush/metrics.go
@@ -53,6 +53,7 @@ var (
 	writeRequestFailure  metricsErrCategory = "write_request_failure"
 	writeResponseFailure metricsErrCategory = "write_response_failure"
 	dialFailure          metricsErrCategory = "dial_failure"
+	rateLimitFailure     metricsErrCategory = "ratelimit_failure"
 	messagePushFailure   metricsErrCategory = "message_push_failure"
 	requestBodyFailure   metricsErrCategory = "request_failure"
 	responseBodyFailure  metricsErrCategory = "response_body_failure"

--- a/waku/v2/protocol/lightpush/waku_lightpush.go
+++ b/waku/v2/protocol/lightpush/waku_lightpush.go
@@ -22,6 +22,7 @@ import (
 	"github.com/waku-org/go-waku/waku/v2/protocol/relay"
 	"github.com/waku-org/go-waku/waku/v2/utils"
 	"go.uber.org/zap"
+	"golang.org/x/time/rate"
 )
 
 // LightPushID_v20beta1 is the current Waku LightPush protocol identifier
@@ -37,6 +38,7 @@ var (
 type WakuLightPush struct {
 	h       host.Host
 	relay   *relay.WakuRelay
+	limiter *rate.Limiter
 	cancel  context.CancelFunc
 	pm      *peermanager.PeerManager
 	metrics Metrics
@@ -47,12 +49,19 @@ type WakuLightPush struct {
 // NewWakuLightPush returns a new instance of Waku Lightpush struct
 // Takes an optional peermanager if WakuLightPush is being created along with WakuNode.
 // If using libp2p host, then pass peermanager as nil
-func NewWakuLightPush(relay *relay.WakuRelay, pm *peermanager.PeerManager, reg prometheus.Registerer, log *zap.Logger) *WakuLightPush {
+func NewWakuLightPush(relay *relay.WakuRelay, pm *peermanager.PeerManager, reg prometheus.Registerer, log *zap.Logger, opts ...Option) *WakuLightPush {
 	wakuLP := new(WakuLightPush)
 	wakuLP.relay = relay
 	wakuLP.log = log.Named("lightpush")
 	wakuLP.pm = pm
 	wakuLP.metrics = newMetrics(reg)
+
+	params := &LightpushParameters{}
+	for _, opt := range opts {
+		opt(params)
+	}
+
+	wakuLP.limiter = params.limiter
 
 	if pm != nil {
 		wakuLP.pm.RegisterWakuProtocol(LightPushID_v20beta1, LightPushENRField)
@@ -91,6 +100,18 @@ func (wakuLP *WakuLightPush) onRequest(ctx context.Context) func(network.Stream)
 		logger := wakuLP.log.With(logging.HostID("peer", stream.Conn().RemotePeer()))
 		requestPushRPC := &pb.PushRpc{}
 
+		responsePushRPC := &pb.PushRpc{
+			Response: &pb.PushResponse{},
+		}
+
+		if wakuLP.limiter != nil && !wakuLP.limiter.Allow() {
+			wakuLP.metrics.RecordError(rateLimitFailure)
+			responseMsg := "exceeds the rate limit"
+			responsePushRPC.Response.Info = &responseMsg
+			wakuLP.reply(stream, responsePushRPC, logger)
+			return
+		}
+
 		reader := pbio.NewDelimitedReader(stream, math.MaxInt32)
 
 		err := reader.ReadMsg(requestPushRPC)
@@ -103,11 +124,7 @@ func (wakuLP *WakuLightPush) onRequest(ctx context.Context) func(network.Stream)
 			return
 		}
 
-		responsePushRPC := &pb.PushRpc{
-			RequestId: requestPushRPC.RequestId,
-			Response:  &pb.PushResponse{},
-		}
-
+		responsePushRPC.RequestId = requestPushRPC.RequestId
 		if err := requestPushRPC.ValidateRequest(); err != nil {
 			responseMsg := err.Error()
 			responsePushRPC.Response.Info = &responseMsg
@@ -170,7 +187,7 @@ func (wakuLP *WakuLightPush) reply(stream network.Stream, responsePushRPC *pb.Pu
 }
 
 // request sends a message via lightPush protocol to either a specified peer or peer that is selected.
-func (wakuLP *WakuLightPush) request(ctx context.Context, req *pb.PushRequest, params *lightPushParameters) (*pb.PushResponse, error) {
+func (wakuLP *WakuLightPush) request(ctx context.Context, req *pb.PushRequest, params *lightPushRequestParameters) (*pb.PushResponse, error) {
 	if params == nil {
 		return nil, errors.New("lightpush params are mandatory")
 	}
@@ -233,8 +250,8 @@ func (wakuLP *WakuLightPush) Stop() {
 	wakuLP.h.RemoveStreamHandler(LightPushID_v20beta1)
 }
 
-func (wakuLP *WakuLightPush) handleOpts(ctx context.Context, message *wpb.WakuMessage, opts ...Option) (*lightPushParameters, error) {
-	params := new(lightPushParameters)
+func (wakuLP *WakuLightPush) handleOpts(ctx context.Context, message *wpb.WakuMessage, opts ...RequestOption) (*lightPushRequestParameters, error) {
+	params := new(lightPushRequestParameters)
 	params.host = wakuLP.h
 	params.log = wakuLP.log
 	params.pm = wakuLP.pm
@@ -294,7 +311,7 @@ func (wakuLP *WakuLightPush) handleOpts(ctx context.Context, message *wpb.WakuMe
 // Publish is used to broadcast a WakuMessage to the pubSubTopic (which is derived from the
 // contentTopic) via lightpush protocol. If auto-sharding is not to be used, then the
 // `WithPubSubTopic` option should be provided to publish the message to an specific pubSubTopic
-func (wakuLP *WakuLightPush) Publish(ctx context.Context, message *wpb.WakuMessage, opts ...Option) ([]byte, error) {
+func (wakuLP *WakuLightPush) Publish(ctx context.Context, message *wpb.WakuMessage, opts ...RequestOption) ([]byte, error) {
 	if message == nil {
 		return nil, errors.New("message can't be null")
 	}

--- a/waku/v2/protocol/lightpush/waku_lightpush_option_test.go
+++ b/waku/v2/protocol/lightpush/waku_lightpush_option_test.go
@@ -18,7 +18,7 @@ func TestLightPushOption(t *testing.T) {
 	host, err := tests.MakeHost(context.Background(), port, rand.Reader)
 	require.NoError(t, err)
 
-	options := []Option{
+	options := []RequestOption{
 		WithPeer("QmWLxGxG65CZ7vRj5oNXCJvbY9WkF9d9FxuJg8cg8Y7q3"),
 		WithAutomaticPeerSelection(),
 		WithFastestPeerSelection(),
@@ -26,7 +26,7 @@ func TestLightPushOption(t *testing.T) {
 		WithAutomaticRequestID(),
 	}
 
-	params := new(lightPushParameters)
+	params := new(lightPushRequestParameters)
 	params.host = host
 	params.log = utils.Logger()
 
@@ -42,7 +42,7 @@ func TestLightPushOption(t *testing.T) {
 	maddr, err := multiaddr.NewMultiaddr("/ip4/127.0.0.1/tcp/12345/p2p/16Uiu2HAm8KUwGRruseAaEGD6xGg6XKrDo8Py5dwDoL9wUpCxawGy")
 	require.NoError(t, err)
 
-	options = []Option{
+	options = []RequestOption{
 		WithPeer("16Uiu2HAm8KUwGRruseAaEGD6xGg6XKrDo8Py5dwDoL9wUpCxawGy"),
 		WithPeerAddr(maddr),
 	}

--- a/waku/v2/protocol/lightpush/waku_lightpush_test.go
+++ b/waku/v2/protocol/lightpush/waku_lightpush_test.go
@@ -3,11 +3,12 @@ package lightpush
 import (
 	"context"
 	"crypto/rand"
-	"github.com/waku-org/go-waku/waku/v2/peermanager"
-	"go.uber.org/zap"
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/waku-org/go-waku/waku/v2/peermanager"
+	"go.uber.org/zap"
 
 	"github.com/libp2p/go-libp2p/core/host"
 	"github.com/libp2p/go-libp2p/core/peerstore"
@@ -122,7 +123,7 @@ func TestWakuLightPush(t *testing.T) {
 		<-sub2.Ch
 	}()
 
-	var lpOptions []Option
+	var lpOptions []RequestOption
 	lpOptions = append(lpOptions, WithPubSubTopic(testTopic))
 	lpOptions = append(lpOptions, WithPeer(host2.ID()))
 
@@ -156,7 +157,7 @@ func TestWakuLightPushNoPeers(t *testing.T) {
 	require.NoError(t, err)
 	client := NewWakuLightPush(nil, nil, prometheus.DefaultRegisterer, utils.Logger())
 	client.SetHost(clientHost)
-	var lpOptions []Option
+	var lpOptions []RequestOption
 	lpOptions = append(lpOptions, WithPubSubTopic(testTopic))
 
 	_, err = client.Publish(ctx, tests.CreateWakuMessage("test", utils.GetUnixEpoch()), lpOptions...)
@@ -234,7 +235,7 @@ func TestWakuLightPushAutoSharding(t *testing.T) {
 		<-sub2.Ch
 
 	}()
-	var lpOptions []Option
+	var lpOptions []RequestOption
 	lpOptions = append(lpOptions, WithPeer(host2.ID()))
 	// Verifying successful request
 	hash1, err := client.Publish(ctx, msg1, lpOptions...)
@@ -295,7 +296,7 @@ func TestWakuLightPushCornerCases(t *testing.T) {
 
 	var wg sync.WaitGroup
 
-	var lpOptions []Option
+	var lpOptions []RequestOption
 	lpOptions = append(lpOptions, WithPubSubTopic(testTopic))
 	lpOptions = append(lpOptions, WithPeer(host2.ID()))
 
@@ -314,7 +315,7 @@ func TestWakuLightPushCornerCases(t *testing.T) {
 	host3, err := tests.MakeHost(context.Background(), 12345, rand.Reader)
 	require.NoError(t, err)
 
-	var lpOptions2 []Option
+	var lpOptions2 []RequestOption
 
 	// Test error case with empty options
 	_, err = client.Publish(ctx, msg2, lpOptions2...)


### PR DESCRIPTION
# Description
Adds an optional rate limit (that we should set in status-go).
Fixes https://github.com/waku-org/go-waku/issues/667
