### PR TITLE
chore: upgrade CI from Nix 2.14 to 2.19

### DIFF
--- a/ci/Jenkinsfile.nix-flake
+++ b/ci/Jenkinsfile.nix-flake
@@ -2,7 +2,7 @@ library 'status-jenkins-lib@v1.7.0'
 
 pipeline {
   agent {
-    label 'linux && nix-2.14 && x86_64'
+    label 'linux && nix-2.19 && x86_64'
   }
 
   options {


### PR DESCRIPTION
Related infra change:

- [`infra-ci#37c6ce47`](https://github.com/status-im/infra-ci/commit/37c6ce47) - nix-setup: upgrade from 2.14.1 to 2.19.2