### PR TITLE
refactor: use ttl of 5m for subscriptions

### DIFF
--- a/waku/v2/protocol/filter/filter_test.go
+++ b/waku/v2/protocol/filter/filter_test.go
@@ -368,49 +368,6 @@ func (s *FilterTestSuite) TearDownTest() {
 	s.ctxCancel()
 }
 
-func (s *FilterTestSuite) TestPeerFailure() {
-	broadcaster2 := relay.NewBroadcaster(10)
-	s.Require().NoError(broadcaster2.Start(context.Background()))
-
-	// Initial subscribe
-	s.subDetails = s.subscribe(s.testTopic, s.testContentTopic, s.fullNodeHost.ID())
-
-	// Simulate there's been a failure before
-	s.fullNode.subscriptions.FlagAsFailure(s.lightNodeHost.ID())
-
-	// Sleep to make sure the filter is subscribed
-	time.Sleep(2 * time.Second)
-
-	s.Require().True(s.fullNode.subscriptions.IsFailedPeer(s.lightNodeHost.ID()))
-
-	s.waitForMsg(func() {
-		s.publishMsg(s.testTopic, s.testContentTopic)
-	}, s.subDetails[0].C)
-
-	// Failure is removed
-	s.Require().False(s.fullNode.subscriptions.IsFailedPeer(s.lightNodeHost.ID()))
-
-	// Kill the subscriber
-	s.lightNodeHost.Close()
-
-	time.Sleep(1 * time.Second)
-
-	s.publishMsg(s.testTopic, s.testContentTopic)
-
-	// TODO: find out how to eliminate this sleep
-	time.Sleep(1 * time.Second)
-	s.Require().True(s.fullNode.subscriptions.IsFailedPeer(s.lightNodeHost.ID()))
-
-	time.Sleep(2 * time.Second)
-
-	s.publishMsg(s.testTopic, s.testContentTopic)
-
-	time.Sleep(2 * time.Second)
-
-	s.Require().True(s.fullNode.subscriptions.IsFailedPeer(s.lightNodeHost.ID())) // Failed peer has been removed
-	s.Require().False(s.fullNode.subscriptions.Has(s.lightNodeHost.ID()))         // Failed peer has been removed
-}
-
 func (s *FilterTestSuite) TestRunningGuard() {
 
 	s.lightNode.Stop()

--- a/waku/v2/protocol/filter/options.go
+++ b/waku/v2/protocol/filter/options.go
@@ -194,7 +194,7 @@ func WithPeerManager(pm *peermanager.PeerManager) Option {
 
 func DefaultOptions() []Option {
 	return []Option{
-		WithTimeout(24 * time.Hour),
+		WithTimeout(5 * time.Minute),
 		WithMaxSubscribers(DefaultMaxSubscriptions),
 	}
 }

--- a/waku/v2/protocol/filter/server.go
+++ b/waku/v2/protocol/filter/server.go
@@ -82,6 +82,8 @@ func (wf *WakuFilterFullNode) start(sub *relay.Subscription) error {
 	wf.WaitGroup().Add(1)
 	go wf.filterListener(wf.Context())
 
+	wf.subscriptions.Start(wf.Context())
+
 	wf.log.Info("filter-subscriber protocol started")
 	return nil
 }
@@ -155,9 +157,11 @@ func (wf *WakuFilterFullNode) reply(ctx context.Context, stream network.Stream, 
 }
 
 func (wf *WakuFilterFullNode) ping(ctx context.Context, stream network.Stream, request *pb.FilterSubscribeRequest) {
-	exists := wf.subscriptions.Has(stream.Conn().RemotePeer())
+	peerID := stream.Conn().RemotePeer()
 
+	exists := wf.subscriptions.Has(peerID)
 	if exists {
+		wf.subscriptions.Refresh(peerID)
 		wf.reply(ctx, stream, request, http.StatusOK)
 	} else {
 		wf.reply(ctx, stream, request, http.StatusNotFound, peerHasNoSubscription)
@@ -265,7 +269,6 @@ func (wf *WakuFilterFullNode) pushMessage(ctx context.Context, logger *zap.Logge
 
 	stream, err := wf.h.NewStream(ctx, peerID, FilterPushID_v20beta1)
 	if err != nil {
-		wf.subscriptions.FlagAsFailure(peerID)
 		if errors.Is(context.DeadlineExceeded, err) {
 			wf.metrics.RecordError(pushTimeoutFailure)
 		} else {
@@ -284,7 +287,6 @@ func (wf *WakuFilterFullNode) pushMessage(ctx context.Context, logger *zap.Logge
 			wf.metrics.RecordError(writeResponseFailure)
 		}
 		logger.Error("pushing messages to peer", zap.Error(err))
-		wf.subscriptions.FlagAsFailure(peerID)
 		if err := stream.Reset(); err != nil {
 			wf.log.Error("resetting connection", zap.Error(err))
 		}
@@ -292,8 +294,6 @@ func (wf *WakuFilterFullNode) pushMessage(ctx context.Context, logger *zap.Logge
 	}
 
 	stream.Close()
-
-	wf.subscriptions.FlagAsSuccess(peerID)
 
 	logger.Debug("message pushed succesfully")
 


### PR DESCRIPTION
Filter subscribers need to ping at least once in the last 4:59m to keep their subscription alive (like in nwaku)