### PR TITLE
fix(metadata): only verify peer metadata on relay

### DIFF
--- a/waku/v2/node/connectedness_test.go
+++ b/waku/v2/node/connectedness_test.go
@@ -49,6 +49,7 @@ func TestConnectionStatusChanges(t *testing.T) {
 	node1, err := New(
 		WithHostAddress(hostAddr1),
 		WithWakuRelay(),
+		WithClusterID(16),
 		WithTopicHealthStatusChannel(topicHealthStatusChan),
 	)
 	require.NoError(t, err)
@@ -118,6 +119,7 @@ func startNodeAndSubscribe(t *testing.T, ctx context.Context) *WakuNode {
 	node, err := New(
 		WithHostAddress(hostAddr),
 		WithWakuRelay(),
+		WithClusterID(16),
 	)
 	require.NoError(t, err)
 	err = node.Start(ctx)

--- a/waku/v2/node/wakunode2.go
+++ b/waku/v2/node/wakunode2.go
@@ -250,10 +250,11 @@ func New(opts ...WakuNodeOption) (*WakuNode, error) {
 		w.log.Error("creating localnode", zap.Error(err))
 	}
 
-	w.metadata = metadata.NewWakuMetadata(w.opts.clusterID, w.localNode, w.log)
+	metadata := metadata.NewWakuMetadata(w.opts.clusterID, w.localNode, w.log)
+	w.metadata = metadata
 
 	//Initialize peer manager.
-	w.peermanager = peermanager.NewPeerManager(w.opts.maxPeerConnections, w.opts.peerStoreCapacity, w.log)
+	w.peermanager = peermanager.NewPeerManager(w.opts.maxPeerConnections, w.opts.peerStoreCapacity, metadata, w.log)
 
 	w.peerConnector, err = peermanager.NewPeerConnectionStrategy(w.peermanager, discoveryConnectTimeout, w.log)
 	if err != nil {

--- a/waku/v2/peermanager/peer_manager.go
+++ b/waku/v2/peermanager/peer_manager.go
@@ -20,6 +20,7 @@ import (
 	wps "github.com/waku-org/go-waku/waku/v2/peerstore"
 	waku_proto "github.com/waku-org/go-waku/waku/v2/protocol"
 	wenr "github.com/waku-org/go-waku/waku/v2/protocol/enr"
+	"github.com/waku-org/go-waku/waku/v2/protocol/metadata"
 	"github.com/waku-org/go-waku/waku/v2/protocol/relay"
 	"github.com/waku-org/go-waku/waku/v2/service"
 
@@ -68,6 +69,7 @@ type WakuProtoInfo struct {
 // PeerManager applies various controls and manage connections towards peers.
 type PeerManager struct {
 	peerConnector          *PeerConnectionStrategy
+	metadata               *metadata.WakuMetadata
 	maxPeers               int
 	maxRelayPeers          int
 	logger                 *zap.Logger
@@ -167,7 +169,7 @@ func (pm *PeerManager) TopicHealth(pubsubTopic string) (TopicHealth, error) {
 }
 
 // NewPeerManager creates a new peerManager instance.
-func NewPeerManager(maxConnections int, maxPeers int, logger *zap.Logger) *PeerManager {
+func NewPeerManager(maxConnections int, maxPeers int, metadata *metadata.WakuMetadata, logger *zap.Logger) *PeerManager {
 
 	maxRelayPeers, _ := relayAndServicePeers(maxConnections)
 	inRelayPeersTarget, outRelayPeersTarget := inAndOutRelayPeers(maxRelayPeers)
@@ -178,6 +180,7 @@ func NewPeerManager(maxConnections int, maxPeers int, logger *zap.Logger) *PeerM
 
 	pm := &PeerManager{
 		logger:                 logger.Named("peer-manager"),
+		metadata:               metadata,
 		maxRelayPeers:          maxRelayPeers,
 		InRelayPeersTarget:     inRelayPeersTarget,
 		OutRelayPeersTarget:    outRelayPeersTarget,

--- a/waku/v2/peermanager/peer_manager_test.go
+++ b/waku/v2/peermanager/peer_manager_test.go
@@ -46,7 +46,7 @@ func initTest(t *testing.T) (context.Context, *PeerManager, func()) {
 	require.NoError(t, err)
 
 	// host 1 is used by peer manager
-	pm := NewPeerManager(10, 20, utils.Logger())
+	pm := NewPeerManager(10, 20, nil, utils.Logger())
 	pm.SetHost(h1)
 
 	return ctx, pm, func() {
@@ -269,7 +269,7 @@ func createHostWithDiscv5AndPM(t *testing.T, hostName string, topic string, enrF
 
 	err = wenr.Update(localNode, wenr.WithWakuRelaySharding(rs[0]))
 	require.NoError(t, err)
-	pm := NewPeerManager(10, 20, logger)
+	pm := NewPeerManager(10, 20, nil, logger)
 	pm.SetHost(host)
 	peerconn, err := NewPeerConnectionStrategy(pm, 30*time.Second, logger)
 	require.NoError(t, err)

--- a/waku/v2/protocol/lightpush/waku_lightpush_test.go
+++ b/waku/v2/protocol/lightpush/waku_lightpush_test.go
@@ -254,7 +254,7 @@ func TestWakuLightPushCornerCases(t *testing.T) {
 	testContentTopic := "/test/10/my-lp-app/proto"
 
 	// Prepare peer manager instance to include in test
-	pm := peermanager.NewPeerManager(10, 10, utils.Logger())
+	pm := peermanager.NewPeerManager(10, 10, nil, utils.Logger())
 
 	node1, sub1, host1 := makeWakuRelay(t, testTopic)
 	defer node1.Stop()

--- a/waku/v2/protocol/metadata/waku_metadata.go
+++ b/waku/v2/protocol/metadata/waku_metadata.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"math"
+	"sync"
+	"time"
 
 	"github.com/ethereum/go-ethereum/p2p/enode"
 	"github.com/libp2p/go-libp2p/core/host"
@@ -11,6 +13,7 @@ import (
 	"github.com/libp2p/go-libp2p/core/peer"
 	libp2pProtocol "github.com/libp2p/go-libp2p/core/protocol"
 	"github.com/libp2p/go-msgio/pbio"
+	"github.com/multiformats/go-multiaddr"
 	"github.com/waku-org/go-waku/logging"
 	"github.com/waku-org/go-waku/waku/v2/protocol"
 	"github.com/waku-org/go-waku/waku/v2/protocol/enr"
@@ -30,6 +33,9 @@ type WakuMetadata struct {
 	cancel    context.CancelFunc
 	clusterID uint16
 	localnode *enode.LocalNode
+
+	peerShardsMutex sync.RWMutex
+	peerShards      map[peer.ID][]uint16
 
 	log *zap.Logger
 }
@@ -62,8 +68,12 @@ func (wakuM *WakuMetadata) Start(ctx context.Context) error {
 
 	wakuM.ctx = ctx
 	wakuM.cancel = cancel
+	wakuM.peerShards = make(map[peer.ID][]uint16)
 
 	wakuM.h.SetStreamHandlerMatch(MetadataID_v1, protocol.PrefixTextMatch(string(MetadataID_v1)), wakuM.onRequest(ctx))
+
+	wakuM.h.Network().Notify(wakuM)
+
 	wakuM.log.Info("metadata protocol started")
 	return nil
 }
@@ -214,4 +224,118 @@ func (wakuM *WakuMetadata) Stop() {
 	wakuM.cancel()
 	wakuM.h.RemoveStreamHandler(MetadataID_v1)
 
+}
+
+// Listen is called when network starts listening on an addr
+func (wakuM *WakuMetadata) Listen(n network.Network, m multiaddr.Multiaddr) {
+	// Do nothing
+}
+
+// ListenClose is called when network stops listening on an address
+func (wakuM *WakuMetadata) ListenClose(n network.Network, m multiaddr.Multiaddr) {
+	// Do nothing
+}
+
+func (wakuM *WakuMetadata) disconnectPeer(peerID peer.ID, reason error) {
+	logger := wakuM.log.With(logging.HostID("peerID", peerID))
+	logger.Error("disconnecting from peer", zap.Error(reason))
+	wakuM.h.Peerstore().RemovePeer(peerID)
+	if err := wakuM.h.Network().ClosePeer(peerID); err != nil {
+		logger.Error("could not disconnect from peer", zap.Error(err))
+	}
+}
+
+// Connected is called when a connection is opened
+func (wakuM *WakuMetadata) Connected(n network.Network, cc network.Conn) {
+	go func() {
+		// Metadata verification is done only if a clusterID is specified
+		if wakuM.clusterID == 0 {
+			return
+		}
+
+		peerID := cc.RemotePeer()
+
+		shard, err := wakuM.Request(wakuM.ctx, peerID)
+		if err != nil {
+			wakuM.disconnectPeer(peerID, err)
+			return
+		}
+
+		if shard.ClusterID != wakuM.clusterID {
+			wakuM.disconnectPeer(peerID, errors.New("different clusterID reported"))
+			return
+		}
+
+		// Store shards so they're used to verify if a relay peer supports the same shards we do
+		wakuM.peerShardsMutex.Lock()
+		defer wakuM.peerShardsMutex.Unlock()
+		wakuM.peerShards[peerID] = shard.ShardIDs
+	}()
+}
+
+// Disconnected is called when a connection closed
+func (wakuM *WakuMetadata) Disconnected(n network.Network, cc network.Conn) {
+	// We no longer need the shard info for that peer
+	wakuM.peerShardsMutex.Lock()
+	defer wakuM.peerShardsMutex.Unlock()
+	delete(wakuM.peerShards, cc.RemotePeer())
+}
+
+func (wakuM *WakuMetadata) GetPeerShards(ctx context.Context, peerID peer.ID) ([]uint16, error) {
+	// Already connected and we got the shard info, return immediatly
+	wakuM.peerShardsMutex.RLock()
+	shards, ok := wakuM.peerShards[peerID]
+	wakuM.peerShardsMutex.RUnlock()
+	if ok {
+		return shards, nil
+	}
+
+	// Shard info pending. Let's wait
+	t := time.NewTicker(200 * time.Millisecond)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-t.C:
+			wakuM.peerShardsMutex.RLock()
+			shards, ok := wakuM.peerShards[peerID]
+			wakuM.peerShardsMutex.RUnlock()
+			if ok {
+				return shards, nil
+			}
+		}
+	}
+}
+
+func (wakuM *WakuMetadata) disconnect(peerID peer.ID) {
+	wakuM.h.Peerstore().RemovePeer(peerID)
+	err := wakuM.h.Network().ClosePeer(peerID)
+	if err != nil {
+		wakuM.log.Error("disconnecting peer", logging.HostID("peerID", peerID), zap.Error(err))
+	}
+}
+
+func (wakuM *WakuMetadata) DisconnectPeerOnShardMismatch(ctx context.Context, peerID peer.ID) error {
+	peerShards, err := wakuM.GetPeerShards(ctx, peerID)
+	if err != nil {
+		wakuM.log.Error("could not obtain peer shards", zap.Error(err), logging.HostID("peerID", peerID))
+		wakuM.disconnect(peerID)
+		return err
+	}
+
+	rs, err := wakuM.RelayShard()
+	if err != nil {
+		wakuM.log.Error("could not obtain shards", zap.Error(err))
+		wakuM.disconnect(peerID)
+		return err
+	}
+
+	if !rs.ContainsAnyShard(rs.ClusterID, peerShards) {
+		wakuM.log.Info("shard mismatch", logging.HostID("peerID", peerID), zap.Uint16("clusterID", rs.ClusterID), zap.Uint16s("ourShardIDs", rs.ShardIDs), zap.Uint16s("theirShardIDs", peerShards))
+		wakuM.disconnect(peerID)
+		return errors.New("shard mismatch")
+	}
+
+	return nil
 }

--- a/waku/v2/protocol/metadata/waku_metadata_test.go
+++ b/waku/v2/protocol/metadata/waku_metadata_test.go
@@ -5,8 +5,10 @@ import (
 	"crypto/rand"
 	"errors"
 	"testing"
+	"time"
 
 	gcrypto "github.com/ethereum/go-ethereum/crypto"
+	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/libp2p/go-libp2p/core/peerstore"
 	libp2pProtocol "github.com/libp2p/go-libp2p/core/protocol"
 	"github.com/multiformats/go-multistream"
@@ -83,4 +85,74 @@ func TestWakuMetadataRequest(t *testing.T) {
 	// Query a peer not subscribed to any shard
 	_, err = m16_1.Request(context.Background(), m_noRS.h.ID())
 	require.True(t, isProtocolNotSupported(err))
+}
+
+func TestNoNetwork(t *testing.T) {
+	cluster1 := uint16(1)
+
+	rs1, err := protocol.NewRelayShards(cluster1, 1)
+	require.NoError(t, err)
+	m1 := createWakuMetadata(t, &rs1)
+
+	// host2 does not support metadata protocol, so it should be dropped
+	port, err := tests.FindFreePort(t, "", 5)
+	require.NoError(t, err)
+	host2, err := tests.MakeHost(context.Background(), port, rand.Reader)
+	require.NoError(t, err)
+
+	m1.h.Peerstore().AddAddrs(host2.ID(), host2.Network().ListenAddresses(), peerstore.PermanentAddrTTL)
+	_, err = m1.h.Network().DialPeer(context.TODO(), host2.ID())
+	require.NoError(t, err)
+
+	time.Sleep(2 * time.Second)
+
+	// Verifying peer connections
+	require.Len(t, m1.h.Network().Peers(), 0)
+	require.Len(t, host2.Network().Peers(), 0)
+}
+
+func TestDropConnectionOnDiffNetworks(t *testing.T) {
+	cluster1 := uint16(1)
+	cluster2 := uint16(2)
+
+	// Initializing metadata and peer managers
+
+	rs1, err := protocol.NewRelayShards(cluster1, 1)
+	require.NoError(t, err)
+	m1 := createWakuMetadata(t, &rs1)
+
+	rs2, err := protocol.NewRelayShards(cluster2, 1)
+	require.NoError(t, err)
+	m2 := createWakuMetadata(t, &rs2)
+
+	rs3, err := protocol.NewRelayShards(cluster2, 1)
+	require.NoError(t, err)
+	m3 := createWakuMetadata(t, &rs3)
+
+	// Creating connection between peers
+
+	// 1->2 (fails)
+	m1.h.Peerstore().AddAddrs(m2.h.ID(), m2.h.Network().ListenAddresses(), peerstore.PermanentAddrTTL)
+	_, err = m1.h.Network().DialPeer(context.TODO(), m2.h.ID())
+	require.NoError(t, err)
+
+	// 1->3 (fails)
+	m1.h.Peerstore().AddAddrs(m3.h.ID(), m3.h.Network().ListenAddresses(), peerstore.PermanentAddrTTL)
+	_, err = m1.h.Network().DialPeer(context.TODO(), m3.h.ID())
+	require.NoError(t, err)
+
+	// 2->3 (succeeds)
+	m2.h.Peerstore().AddAddrs(m3.h.ID(), m3.h.Network().ListenAddresses(), peerstore.PermanentAddrTTL)
+	_, err = m2.h.Network().DialPeer(context.TODO(), m3.h.ID())
+	require.NoError(t, err)
+
+	time.Sleep(2 * time.Second)
+
+	// Verifying peer connections
+	require.Len(t, m1.h.Network().Peers(), 0)
+	require.Len(t, m2.h.Network().Peers(), 1)
+	require.Len(t, m3.h.Network().Peers(), 1)
+	require.Equal(t, []peer.ID{m3.h.ID()}, m2.h.Network().Peers())
+	require.Equal(t, []peer.ID{m2.h.ID()}, m3.h.Network().Peers())
+
 }

--- a/waku/v2/protocol/metadata/waku_metadata_test.go
+++ b/waku/v2/protocol/metadata/waku_metadata_test.go
@@ -5,10 +5,8 @@ import (
 	"crypto/rand"
 	"errors"
 	"testing"
-	"time"
 
 	gcrypto "github.com/ethereum/go-ethereum/crypto"
-	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/libp2p/go-libp2p/core/peerstore"
 	libp2pProtocol "github.com/libp2p/go-libp2p/core/protocol"
 	"github.com/multiformats/go-multistream"
@@ -62,11 +60,6 @@ func TestWakuMetadataRequest(t *testing.T) {
 	m16_2 := createWakuMetadata(t, &rs16_2)
 	m_noRS := createWakuMetadata(t, nil)
 
-	// Removing notifee to test metadata protocol functionality without having the peers being disconnected by the notify process
-	m16_1.h.Network().StopNotify(m16_1)
-	m16_2.h.Network().StopNotify(m16_2)
-	m_noRS.h.Network().StopNotify(m_noRS)
-
 	m16_1.h.Peerstore().AddAddrs(m16_2.h.ID(), m16_2.h.Network().ListenAddresses(), peerstore.PermanentAddrTTL)
 	m16_1.h.Peerstore().AddAddrs(m_noRS.h.ID(), m_noRS.h.Network().ListenAddresses(), peerstore.PermanentAddrTTL)
 
@@ -90,74 +83,4 @@ func TestWakuMetadataRequest(t *testing.T) {
 	// Query a peer not subscribed to any shard
 	_, err = m16_1.Request(context.Background(), m_noRS.h.ID())
 	require.True(t, isProtocolNotSupported(err))
-}
-
-func TestNoNetwork(t *testing.T) {
-	cluster1 := uint16(1)
-
-	rs1, err := protocol.NewRelayShards(cluster1, 1)
-	require.NoError(t, err)
-	m1 := createWakuMetadata(t, &rs1)
-
-	// host2 does not support metadata protocol, so it should be dropped
-	port, err := tests.FindFreePort(t, "", 5)
-	require.NoError(t, err)
-	host2, err := tests.MakeHost(context.Background(), port, rand.Reader)
-	require.NoError(t, err)
-
-	m1.h.Peerstore().AddAddrs(host2.ID(), host2.Network().ListenAddresses(), peerstore.PermanentAddrTTL)
-	_, err = m1.h.Network().DialPeer(context.TODO(), host2.ID())
-	require.NoError(t, err)
-
-	time.Sleep(2 * time.Second)
-
-	// Verifying peer connections
-	require.Len(t, m1.h.Network().Peers(), 0)
-	require.Len(t, host2.Network().Peers(), 0)
-}
-
-func TestDropConnectionOnDiffNetworks(t *testing.T) {
-	cluster1 := uint16(1)
-	cluster2 := uint16(2)
-
-	// Initializing metadata and peer managers
-
-	rs1, err := protocol.NewRelayShards(cluster1, 1)
-	require.NoError(t, err)
-	m1 := createWakuMetadata(t, &rs1)
-
-	rs2, err := protocol.NewRelayShards(cluster2, 1)
-	require.NoError(t, err)
-	m2 := createWakuMetadata(t, &rs2)
-
-	rs3, err := protocol.NewRelayShards(cluster2, 1)
-	require.NoError(t, err)
-	m3 := createWakuMetadata(t, &rs3)
-
-	// Creating connection between peers
-
-	// 1->2 (fails)
-	m1.h.Peerstore().AddAddrs(m2.h.ID(), m2.h.Network().ListenAddresses(), peerstore.PermanentAddrTTL)
-	_, err = m1.h.Network().DialPeer(context.TODO(), m2.h.ID())
-	require.NoError(t, err)
-
-	// 1->3 (fails)
-	m1.h.Peerstore().AddAddrs(m3.h.ID(), m3.h.Network().ListenAddresses(), peerstore.PermanentAddrTTL)
-	_, err = m1.h.Network().DialPeer(context.TODO(), m3.h.ID())
-	require.NoError(t, err)
-
-	// 2->3 (succeeds)
-	m2.h.Peerstore().AddAddrs(m3.h.ID(), m3.h.Network().ListenAddresses(), peerstore.PermanentAddrTTL)
-	_, err = m2.h.Network().DialPeer(context.TODO(), m3.h.ID())
-	require.NoError(t, err)
-
-	time.Sleep(2 * time.Second)
-
-	// Verifying peer connections
-	require.Len(t, m1.h.Network().Peers(), 0)
-	require.Len(t, m2.h.Network().Peers(), 1)
-	require.Len(t, m3.h.Network().Peers(), 1)
-	require.Equal(t, []peer.ID{m3.h.ID()}, m2.h.Network().Peers())
-	require.Equal(t, []peer.ID{m2.h.ID()}, m3.h.Network().Peers())
-
 }

--- a/waku/v2/protocol/peer_exchange/waku_peer_exchange_test.go
+++ b/waku/v2/protocol/peer_exchange/waku_peer_exchange_test.go
@@ -3,6 +3,9 @@ package peer_exchange
 import (
 	"context"
 	"fmt"
+	"testing"
+	"time"
+
 	"github.com/libp2p/go-libp2p"
 	"github.com/libp2p/go-libp2p/core/host"
 	"github.com/libp2p/go-libp2p/p2p/host/peerstore/pstoremem"
@@ -11,8 +14,6 @@ import (
 	wps "github.com/waku-org/go-waku/waku/v2/peerstore"
 	"go.uber.org/zap"
 	"golang.org/x/exp/slices"
-	"testing"
-	"time"
 
 	"github.com/ethereum/go-ethereum/p2p/enode"
 	"github.com/ethereum/go-ethereum/p2p/enr"
@@ -290,7 +291,7 @@ func TestRetrieveProvidePeerExchangeWithPMAndPeerAddr(t *testing.T) {
 	require.NoError(t, err)
 
 	// Prepare peer manager for host3
-	pm3 := peermanager.NewPeerManager(10, 20, log)
+	pm3 := peermanager.NewPeerManager(10, 20, nil, log)
 	pm3.SetHost(host3)
 	pxPeerConn3, err := peermanager.NewPeerConnectionStrategy(pm3, 30*time.Second, utils.Logger())
 	require.NoError(t, err)
@@ -365,7 +366,7 @@ func TestRetrieveProvidePeerExchangeWithPMOnly(t *testing.T) {
 	require.NoError(t, err)
 
 	// Prepare peer manager for host3
-	pm3 := peermanager.NewPeerManager(10, 20, log)
+	pm3 := peermanager.NewPeerManager(10, 20, nil, log)
 	pm3.SetHost(host3)
 	pxPeerConn3, err := peermanager.NewPeerConnectionStrategy(pm3, 30*time.Second, utils.Logger())
 	require.NoError(t, err)

--- a/waku/v2/protocol/shard.go
+++ b/waku/v2/protocol/shard.go
@@ -64,19 +64,25 @@ func (rs RelayShards) Topics() []WakuPubSubTopic {
 	return result
 }
 
-func (rs RelayShards) Contains(cluster uint16, index uint16) bool {
+func (rs RelayShards) ContainsAnyShard(cluster uint16, indexes []uint16) bool {
 	if rs.ClusterID != cluster {
 		return false
 	}
 
 	found := false
-	for _, idx := range rs.ShardIDs {
-		if idx == index {
-			found = true
+	for _, rsIdx := range rs.ShardIDs {
+		for _, idx := range indexes {
+			if rsIdx == idx {
+				return true
+			}
 		}
 	}
 
 	return found
+}
+
+func (rs RelayShards) Contains(cluster uint16, index uint16) bool {
+	return rs.ContainsAnyShard(cluster, []uint16{index})
 }
 
 func (rs RelayShards) ContainsShardPubsubTopic(topic WakuPubSubTopic) bool {

--- a/waku/v2/protocol/store/waku_store_client_test.go
+++ b/waku/v2/protocol/store/waku_store_client_test.go
@@ -3,6 +3,8 @@ package store
 import (
 	"context"
 	"crypto/rand"
+	"testing"
+
 	"github.com/libp2p/go-libp2p/core/peerstore"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
@@ -13,7 +15,6 @@ import (
 	"github.com/waku-org/go-waku/waku/v2/timesource"
 	"github.com/waku-org/go-waku/waku/v2/utils"
 	"google.golang.org/protobuf/proto"
-	"testing"
 )
 
 func TestQueryOptions(t *testing.T) {
@@ -35,7 +36,7 @@ func TestQueryOptions(t *testing.T) {
 	require.NoError(t, err)
 
 	// Let peer manager reside at host
-	pm := peermanager.NewPeerManager(5, 5, utils.Logger())
+	pm := peermanager.NewPeerManager(5, 5, nil, utils.Logger())
 	pm.SetHost(host)
 
 	// Add host2 to peerstore


### PR DESCRIPTION
# Description
As described here https://github.com/waku-org/nwaku/issues/2491 metadata protocol disconnects light clients.
With this change, instead of doing the metadata verification for all peers, it is done only for relay peers.