### PR TITLE
fix: verify if metadata exists before checking for shard mismatch

### DIFF
--- a/waku/v2/peermanager/topic_event_handler.go
+++ b/waku/v2/peermanager/topic_event_handler.go
@@ -121,24 +121,20 @@ func (pm *PeerManager) handlerPeerTopicEvent(peerEvt relay.EvtPeerTopic) {
 	wps := pm.host.Peerstore().(*wps.WakuPeerstoreImpl)
 	peerID := peerEvt.PeerID
 	if peerEvt.State == relay.PEER_JOINED {
-		rs, err := pm.metadata.RelayShard()
-		if err != nil {
-			pm.logger.Error("could not obtain the cluster and shards of wakunode", zap.Error(err))
-			return
-		} else if rs == nil {
-			pm.logger.Info("not using sharding")
-			return
-		}
-
-		if pm.metadata != nil && rs.ClusterID != 0 {
-			ctx, cancel := context.WithTimeout(pm.ctx, 7*time.Second)
-			defer cancel()
-			if err := pm.metadata.DisconnectPeerOnShardMismatch(ctx, peerEvt.PeerID); err != nil {
-				return
+		if pm.metadata != nil {
+			rs, err := pm.metadata.RelayShard()
+			if err != nil {
+				pm.logger.Error("could not obtain the cluster and shards of wakunode", zap.Error(err))
+			} else if rs != nil && rs.ClusterID != 0 {
+				ctx, cancel := context.WithTimeout(pm.ctx, 7*time.Second)
+				defer cancel()
+				if err := pm.metadata.DisconnectPeerOnShardMismatch(ctx, peerEvt.PeerID); err != nil {
+					return
+				}
 			}
 		}
 
-		err = wps.AddPubSubTopic(peerID, peerEvt.PubsubTopic)
+		err := wps.AddPubSubTopic(peerID, peerEvt.PubsubTopic)
 		if err != nil {
 			pm.logger.Error("failed to add pubSubTopic for peer",
 				logging.HostID("peerID", peerID), zap.String("topic", peerEvt.PubsubTopic), zap.Error(err))


### PR DESCRIPTION
# Description
Only executes the shard mismatch verification if the metadata protocol was actually mounted

## Issue

closes #1055

