### PR TITLE
fix: service slot tests

### DIFF
--- a/waku/v2/peermanager/service_slot_test.go
+++ b/waku/v2/peermanager/service_slot_test.go
@@ -1,7 +1,6 @@
 package peermanager
 
 import (
-	"github.com/waku-org/go-waku/waku/v2/protocol/relay"
 	"testing"
 
 	"github.com/libp2p/go-libp2p/core/peer"
@@ -13,7 +12,7 @@ import (
 func TestServiceSlot(t *testing.T) {
 	slots := NewServiceSlot()
 
-	protocol := relay.WakuRelayID_v200
+	protocol := libp2pProtocol.ID("/vac/waku/test/2.0.0")
 
 	peerID := peer.ID("peerId")
 
@@ -56,8 +55,8 @@ func TestServiceSlot(t *testing.T) {
 func TestServiceSlotRemovePeerFromAll(t *testing.T) {
 	slots := NewServiceSlot()
 
-	protocol := libp2pProtocol.ID("test/protocol")
-	protocol1 := libp2pProtocol.ID("test/protocol1")
+	protocol := libp2pProtocol.ID("/vac/waku/test/2.0.0")
+	protocol1 := libp2pProtocol.ID("/vac/waku/test/2.0.2")
 
 	peerID := peer.ID("peerId")
 

--- a/waku/v2/peermanager/service_slot_test.go
+++ b/waku/v2/peermanager/service_slot_test.go
@@ -1,6 +1,7 @@
 package peermanager
 
 import (
+	"github.com/waku-org/go-waku/waku/v2/protocol/relay"
 	"testing"
 
 	"github.com/libp2p/go-libp2p/core/peer"
@@ -12,7 +13,7 @@ import (
 func TestServiceSlot(t *testing.T) {
 	slots := NewServiceSlot()
 
-	protocol := libp2pProtocol.ID("test/protocol")
+	protocol := relay.WakuRelayID_v200
 
 	peerID := peer.ID("peerId")
 


### PR DESCRIPTION
# Description
Fixing test related to service slot failing sometimes on race condition.  Reason:
2024-03-18T16:36:07.752+0800	ERROR	gowaku.host3.peer-manager	peermanager/peer_discovery.go:58	cannot do on demand discovery for non-waku protocol	{"protocol": "/test"}
2024-03-18T16:36:07.752+0800	ERROR	gowaku.host3.peer-manager	peermanager/peer_discovery.go:115	failed to discover and connect to peers	{"error": "cannot do on demand discovery for non-waku protocol"}

# Changes
Use Waku protocol "/vac/waku/test/[version]" instead of "test/protocol".

# Log
```
2024-03-18T08:24:23.393Z	INFO	gowaku.host3.discv5	discv5/discover.go:193	Discovery V5: discoverable ENR 	{"enr": "enr:-KG4QCUJgO_m_1NB16nyXD1JoKPWSV8gyAKRcKAQC14OBRivHzGlEiphugbj5e9ajk6glsT0TlDwE0rhyfKD0twa-biGAY5QqWhegmlkgnY0gmlwhH8AAAGCcnOFAAEBAAGJc2VjcDI1NmsxoQIL5iPiznZlFnwvVZa-8y-K8aPmfuhSrzLvOgA3xiX52YN0Y3CCg0GDdWRwgrUehXdha3UyDw"}
2024-03-18T08:24:23.394Z	ERROR	gowaku.host3.peer-manager	peermanager/peer_discovery.go:58	cannot do on demand discovery for non-waku protocol	{"protocol": "/test"}
2024-03-18T08:24:23.394Z	ERROR	gowaku.host3.peer-manager	peermanager/peer_discovery.go:115	failed to discover and connect to peers	{"error": "cannot do on demand discovery for non-waku protocol"}
2024-03-18T08:24:23.395Z	INFO	gowaku.host3.peer-manager	peermanager/peer_manager.go:581	adding peer to service slots	{"peer": "16Uiu2HAkuXrSLpqpnV8gjgSPZJHs6buZT7h4idngnKq69qzcN3k6", "service": "/vac/waku/store/2.0.0-beta4"}
2024-03-18T08:24:23.395Z	INFO	gowaku.host3.peer-manager	peermanager/peer_manager.go:474	adding peer to peerstore	{"peer": "16Uiu2HAkuXrSLpqpnV8gjgSPZJHs6buZT7h4idngnKq69qzcN3k6"}
2024-03-18T08:24:23.402Z	INFO	gowaku.host3.peer-manager	peermanager/peer_manager.go:581	adding peer to service slots	{"peer": "16Uiu2HAmTcF4SBP7UzMjWShxZhZXqXo4aPgkGiVsGtHPVwLgvbjX", "service": "/vac/waku/lightpush/2.0.0-beta1"}
2024-03-18T08:24:23.402Z	INFO	gowaku.host3.peer-manager	peermanager/peer_manager.go:474	adding peer to peerstore	{"peer": "16Uiu2HAmTcF4SBP7UzMjWShxZhZXqXo4aPgkGiVsGtHPVwLgvbjX"}
2024-03-18T08:24:23.402Z	WARN	gowaku.host2.discv5	discv5/discover.go:487	Discv5 loop stopped
2024-03-18T08:24:23.402Z	WARN	gowaku.host3.discv5	discv5/discover.go:487	Discv5 loop stopped
2024-03-18T08:24:23.404Z	INFO	gowaku.host3.discv5	discv5/discover.go:249	stopped Discovery V5
2024-03-18T08:24:25.398Z	INFO	gowaku.host2.discv5	discv5/discover.go:249	stopped Discovery V5
2024-03-18T08:24:25.398Z	INFO	gowaku.host1.discv5	discv5/discover.go:249	stopped Discovery V5
2024-03-18T08:24:25.398Z	WARN	gowaku.host1.discv5	discv5/discover.go:487	Discv5 loop stopped
--- FAIL: TestServiceSlot (0.00s)
    service_slot_test.go:45: 
        	Error Trace:	/home/runner/work/go-waku/go-waku/waku/v2/peermanager/service_slot_test.go:45
        	Error:      	Should not be: "peerId2"
        	Test:       	TestServiceSlot
```        	

https://github.com/waku-org/go-waku/actions/runs/8323367352/job/22772861956