### PR TITLE
fix: service slot  test failure - regression

### DIFF
--- a/waku/v2/peermanager/service_slot_test.go
+++ b/waku/v2/peermanager/service_slot_test.go
@@ -1,7 +1,6 @@
 package peermanager
 
 import (
-	"github.com/waku-org/go-waku/waku/v2/protocol/relay"
 	"testing"
 
 	"github.com/libp2p/go-libp2p/core/peer"
@@ -13,7 +12,7 @@ import (
 func TestServiceSlot(t *testing.T) {
 	slots := NewServiceSlot()
 
-	protocol := relay.WakuRelayID_v200
+	protocol := libp2pProtocol.ID("/vac/waku/test/2.0.0")
 
 	peerID := peer.ID("peerId")
 
@@ -56,8 +55,8 @@ func TestServiceSlot(t *testing.T) {
 func TestServiceSlotRemovePeerFromAll(t *testing.T) {
 	slots := NewServiceSlot()
 
-	protocol := libp2pProtocol.ID("test/protocol")
-	protocol1 := libp2pProtocol.ID("test/protocol1")
+	protocol := libp2pProtocol.ID("/vac/waku/test/2.0.0")
+	protocol1 := libp2pProtocol.ID("/vac/waku/test/2.0.2")
 
 	peerID := peer.ID("peerId")
 

--- a/waku/v2/peermanager/service_slot_test.go
+++ b/waku/v2/peermanager/service_slot_test.go
@@ -1,13 +1,11 @@
 package peermanager
 
 import (
-	"testing"
-	"time"
-
 	"github.com/libp2p/go-libp2p/core/peer"
 	libp2pProtocol "github.com/libp2p/go-libp2p/core/protocol"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/exp/maps"
+	"testing"
 )
 
 func TestServiceSlot(t *testing.T) {
@@ -42,10 +40,10 @@ func TestServiceSlot(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 2, len(maps.Keys(fetchedPeers)))
 
-	time.Sleep(100 * time.Millisecond)
+	fetchedPeersSerialized := maps.Keys(fetchedPeers)
 
 	// Check for uniqueness
-	require.NotEqual(t, maps.Keys(fetchedPeers)[0], maps.Keys(fetchedPeers)[1])
+	require.NotEqual(t, fetchedPeersSerialized[0], fetchedPeersSerialized[1])
 
 	slots.getPeers(protocol).remove(peerID2)
 

--- a/waku/v2/peermanager/service_slot_test.go
+++ b/waku/v2/peermanager/service_slot_test.go
@@ -1,6 +1,7 @@
 package peermanager
 
 import (
+	"github.com/waku-org/go-waku/waku/v2/protocol/relay"
 	"testing"
 
 	"github.com/libp2p/go-libp2p/core/peer"
@@ -12,7 +13,7 @@ import (
 func TestServiceSlot(t *testing.T) {
 	slots := NewServiceSlot()
 
-	protocol := libp2pProtocol.ID("test/protocol")
+	protocol := relay.WakuRelayID_v200
 
 	peerID := peer.ID("peerId")
 

--- a/waku/v2/peermanager/service_slot_test.go
+++ b/waku/v2/peermanager/service_slot_test.go
@@ -9,6 +9,49 @@ import (
 	"golang.org/x/exp/maps"
 )
 
+func TestServiceSlot(t *testing.T) {
+	slots := NewServiceSlot()
+
+	protocol := libp2pProtocol.ID("/vac/waku/test/2.0.0")
+
+	peerID := peer.ID("peerId")
+
+	//
+	slots.getPeers(protocol).add(peerID)
+	//
+	fetchedPeers, err := slots.getPeers(protocol).getRandom(1)
+	require.NoError(t, err)
+	require.Equal(t, peerID, maps.Keys(fetchedPeers)[0])
+	//
+	slots.getPeers(protocol).remove(peerID)
+	//
+	_, err = slots.getPeers(protocol).getRandom(1)
+	require.Equal(t, err, ErrNoPeersAvailable)
+
+	// Test with more peers
+	peerID2 := peer.ID("peerId2")
+	peerID3 := peer.ID("peerId3")
+
+	//
+	slots.getPeers(protocol).add(peerID2)
+	slots.getPeers(protocol).add(peerID3)
+	//
+
+	fetchedPeers, err = slots.getPeers(protocol).getRandom(2)
+	require.NoError(t, err)
+	require.Equal(t, 2, len(maps.Keys(fetchedPeers)))
+
+	// Check for uniqueness
+	//require.NotEqual(t, maps.Keys(fetchedPeers)[0], maps.Keys(fetchedPeers)[1])
+
+	slots.getPeers(protocol).remove(peerID2)
+
+	fetchedPeers, err = slots.getPeers(protocol).getRandom(10)
+	require.NoError(t, err)
+	require.Equal(t, peerID3, maps.Keys(fetchedPeers)[0])
+
+}
+
 func TestServiceSlotRemovePeerFromAll(t *testing.T) {
 	slots := NewServiceSlot()
 

--- a/waku/v2/peermanager/service_slot_test.go
+++ b/waku/v2/peermanager/service_slot_test.go
@@ -9,48 +9,48 @@ import (
 	"golang.org/x/exp/maps"
 )
 
-func TestServiceSlot(t *testing.T) {
-	slots := NewServiceSlot()
-
-	protocol := libp2pProtocol.ID("/vac/waku/test/2.0.0")
-
-	peerID := peer.ID("peerId")
-
-	//
-	slots.getPeers(protocol).add(peerID)
-	//
-	fetchedPeers, err := slots.getPeers(protocol).getRandom(1)
-	require.NoError(t, err)
-	require.Equal(t, peerID, maps.Keys(fetchedPeers)[0])
-	//
-	slots.getPeers(protocol).remove(peerID)
-	//
-	_, err = slots.getPeers(protocol).getRandom(1)
-	require.Equal(t, err, ErrNoPeersAvailable)
-
-	// Test with more peers
-	peerID2 := peer.ID("peerId2")
-	peerID3 := peer.ID("peerId3")
-
-	//
-	slots.getPeers(protocol).add(peerID2)
-	slots.getPeers(protocol).add(peerID3)
-	//
-
-	fetchedPeers, err = slots.getPeers(protocol).getRandom(2)
-	require.NoError(t, err)
-	require.Equal(t, 2, len(maps.Keys(fetchedPeers)))
-
-	// Check for uniqueness
-	require.NotEqual(t, maps.Keys(fetchedPeers)[0], maps.Keys(fetchedPeers)[1])
-
-	slots.getPeers(protocol).remove(peerID2)
-
-	fetchedPeers, err = slots.getPeers(protocol).getRandom(10)
-	require.NoError(t, err)
-	require.Equal(t, peerID3, maps.Keys(fetchedPeers)[0])
-
-}
+//func TestServiceSlot(t *testing.T) {
+//	slots := NewServiceSlot()
+//
+//	protocol := libp2pProtocol.ID("/vac/waku/test/2.0.0")
+//
+//	peerID := peer.ID("peerId")
+//
+//	//
+//	slots.getPeers(protocol).add(peerID)
+//	//
+//	fetchedPeers, err := slots.getPeers(protocol).getRandom(1)
+//	require.NoError(t, err)
+//	require.Equal(t, peerID, maps.Keys(fetchedPeers)[0])
+//	//
+//	slots.getPeers(protocol).remove(peerID)
+//	//
+//	_, err = slots.getPeers(protocol).getRandom(1)
+//	require.Equal(t, err, ErrNoPeersAvailable)
+//
+//	// Test with more peers
+//	peerID2 := peer.ID("peerId2")
+//	peerID3 := peer.ID("peerId3")
+//
+//	//
+//	slots.getPeers(protocol).add(peerID2)
+//	slots.getPeers(protocol).add(peerID3)
+//	//
+//
+//	fetchedPeers, err = slots.getPeers(protocol).getRandom(2)
+//	require.NoError(t, err)
+//	require.Equal(t, 2, len(maps.Keys(fetchedPeers)))
+//
+//	// Check for uniqueness
+//	require.NotEqual(t, maps.Keys(fetchedPeers)[0], maps.Keys(fetchedPeers)[1])
+//
+//	slots.getPeers(protocol).remove(peerID2)
+//
+//	fetchedPeers, err = slots.getPeers(protocol).getRandom(10)
+//	require.NoError(t, err)
+//	require.Equal(t, peerID3, maps.Keys(fetchedPeers)[0])
+//
+//}
 
 func TestServiceSlotRemovePeerFromAll(t *testing.T) {
 	slots := NewServiceSlot()

--- a/waku/v2/peermanager/service_slot_test.go
+++ b/waku/v2/peermanager/service_slot_test.go
@@ -1,8 +1,6 @@
 package peermanager
 
 import (
-	"github.com/waku-org/go-waku/waku/v2/utils"
-	"go.uber.org/zap"
 	"testing"
 
 	"github.com/libp2p/go-libp2p/core/peer"
@@ -42,12 +40,6 @@ func TestServiceSlot(t *testing.T) {
 	fetchedPeers, err = slots.getPeers(protocol).getRandom(2)
 	require.NoError(t, err)
 	require.Equal(t, 2, len(maps.Keys(fetchedPeers)))
-
-	log := utils.Logger()
-
-	for peer := range fetchedPeers {
-		log.Info("Fetched peers", zap.String("ID", peer.String()))
-	}
 
 	// Check for uniqueness
 	require.NotEqual(t, maps.Keys(fetchedPeers)[0], maps.Keys(fetchedPeers)[1])

--- a/waku/v2/peermanager/service_slot_test.go
+++ b/waku/v2/peermanager/service_slot_test.go
@@ -1,6 +1,8 @@
 package peermanager
 
 import (
+	"github.com/waku-org/go-waku/waku/v2/utils"
+	"go.uber.org/zap"
 	"testing"
 
 	"github.com/libp2p/go-libp2p/core/peer"
@@ -41,8 +43,14 @@ func TestServiceSlot(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 2, len(maps.Keys(fetchedPeers)))
 
+	log := utils.Logger()
+
+	for peer := range fetchedPeers {
+		log.Info("Fetched peers", zap.String("ID", peer.String()))
+	}
+
 	// Check for uniqueness
-	//require.NotEqual(t, maps.Keys(fetchedPeers)[0], maps.Keys(fetchedPeers)[1])
+	require.NotEqual(t, maps.Keys(fetchedPeers)[0], maps.Keys(fetchedPeers)[1])
 
 	slots.getPeers(protocol).remove(peerID2)
 

--- a/waku/v2/peermanager/service_slot_test.go
+++ b/waku/v2/peermanager/service_slot_test.go
@@ -9,49 +9,6 @@ import (
 	"golang.org/x/exp/maps"
 )
 
-//func TestServiceSlot(t *testing.T) {
-//	slots := NewServiceSlot()
-//
-//	protocol := libp2pProtocol.ID("/vac/waku/test/2.0.0")
-//
-//	peerID := peer.ID("peerId")
-//
-//	//
-//	slots.getPeers(protocol).add(peerID)
-//	//
-//	fetchedPeers, err := slots.getPeers(protocol).getRandom(1)
-//	require.NoError(t, err)
-//	require.Equal(t, peerID, maps.Keys(fetchedPeers)[0])
-//	//
-//	slots.getPeers(protocol).remove(peerID)
-//	//
-//	_, err = slots.getPeers(protocol).getRandom(1)
-//	require.Equal(t, err, ErrNoPeersAvailable)
-//
-//	// Test with more peers
-//	peerID2 := peer.ID("peerId2")
-//	peerID3 := peer.ID("peerId3")
-//
-//	//
-//	slots.getPeers(protocol).add(peerID2)
-//	slots.getPeers(protocol).add(peerID3)
-//	//
-//
-//	fetchedPeers, err = slots.getPeers(protocol).getRandom(2)
-//	require.NoError(t, err)
-//	require.Equal(t, 2, len(maps.Keys(fetchedPeers)))
-//
-//	// Check for uniqueness
-//	require.NotEqual(t, maps.Keys(fetchedPeers)[0], maps.Keys(fetchedPeers)[1])
-//
-//	slots.getPeers(protocol).remove(peerID2)
-//
-//	fetchedPeers, err = slots.getPeers(protocol).getRandom(10)
-//	require.NoError(t, err)
-//	require.Equal(t, peerID3, maps.Keys(fetchedPeers)[0])
-//
-//}
-
 func TestServiceSlotRemovePeerFromAll(t *testing.T) {
 	slots := NewServiceSlot()
 

--- a/waku/v2/peermanager/service_slot_test.go
+++ b/waku/v2/peermanager/service_slot_test.go
@@ -2,6 +2,7 @@ package peermanager
 
 import (
 	"testing"
+	"time"
 
 	"github.com/libp2p/go-libp2p/core/peer"
 	libp2pProtocol "github.com/libp2p/go-libp2p/core/protocol"
@@ -40,6 +41,8 @@ func TestServiceSlot(t *testing.T) {
 	fetchedPeers, err = slots.getPeers(protocol).getRandom(2)
 	require.NoError(t, err)
 	require.Equal(t, 2, len(maps.Keys(fetchedPeers)))
+
+	time.Sleep(100 * time.Millisecond)
 
 	// Check for uniqueness
 	require.NotEqual(t, maps.Keys(fetchedPeers)[0], maps.Keys(fetchedPeers)[1])


### PR DESCRIPTION
# Description
Check for uniqueness was incorrectly done as comparison of non-serialized map elements.

# Changes
Fetched peers map serialized before comparison.

# Log
```
2024-03-20T01:38:59.293Z	INFO	gowaku	peermanager/peer_manager.go:192	PeerManager init values	{"maxConnections": 10, "maxRelayPeers": 8, "outRelayPeersTarget": 10, "inRelayPeersTarget": -2, "maxPeers": 20}
2024-03-20T01:38:59.305Z	WARN	p2p-config	config/config.go:304	rcmgr limit conflicts with connmgr limit: conn manager high watermark limit: 192, exceeds the system connection limit of: 1
2024-03-20T01:38:59.310Z	INFO	gowaku.host1	peermanager/peer_manager.go:192	PeerManager init values	{"maxConnections": 10, "maxRelayPeers": 8, "outRelayPeersTarget": 10, "inRelayPeersTarget": -2, "maxPeers": 20}
2024-03-20T01:38:59.311Z	WARN	p2p-config	config/config.go:304	rcmgr limit conflicts with connmgr limit: conn manager high watermark limit: 192, exceeds the system connection limit of: 1
2024-03-20T01:38:59.314Z	INFO	gowaku.host2	peermanager/peer_manager.go:192	PeerManager init values	{"maxConnections": 10, "maxRelayPeers": 8, "outRelayPeersTarget": 10, "inRelayPeersTarget": -2, "maxPeers": 20}
2024-03-20T01:38:59.317Z	WARN	p2p-config	config/config.go:304	rcmgr limit conflicts with connmgr limit: conn manager high watermark limit: 192, exceeds the system connection limit of: 1
2024-03-20T01:38:59.322Z	INFO	gowaku.host3	peermanager/peer_manager.go:192	PeerManager init values	{"maxConnections": 10, "maxRelayPeers": 8, "outRelayPeersTarget": 10, "inRelayPeersTarget": -2, "maxPeers": 20}
2024-03-20T01:38:59.323Z	INFO	gowaku.host1.discv5	discv5/discover.go:190	started Discovery V5	{"listening": "[::]:54869", "advertising": "127.0.0.1:36463"}
2024-03-20T01:38:59.323Z	INFO	gowaku.host1.discv5	discv5/discover.go:193	Discovery V5: discoverable ENR 	{"enr": "enr:-KG4QMwq-mZM3Ku2aZn9z6JULdDFngr65ulILRECcSs83B1WLG4bXNYAqJqKW9wGn60MMST0yw2UoY5hrPnnJ59jPWOGAY5ZgvhvgmlkgnY0gmlwhH8AAAGCcnOFAAEBAAGJc2VjcDI1NmsxoQNlk61l1YEp1GYjANB74TCCM1iTXDSOKri2opOm3HPpbIN0Y3CCjm-DdWRwgtZVhXdha3UyDQ"}
2024-03-20T01:38:59.324Z	INFO	gowaku.host2.discv5	discv5/discover.go:190	started Discovery V5	{"listening": "[::]:49753", "advertising": "127.0.0.1:41521"}
2024-03-20T01:38:59.324Z	INFO	gowaku.host2.discv5	discv5/discover.go:193	Discovery V5: discoverable ENR 	{"enr": "enr:-KG4QHCI4r0sS76gYpEBbXrvC9VmfcJEjtgOdzWbPVrTGTOwJux3RWtnbQczgsEOcVhaUxY2tmYJR-EAynQc4C1pMk6GAY5ZgvhzgmlkgnY0gmlwhH8AAAGCcnOFAAEBAAGJc2VjcDI1NmsxoQKcWbW-IXD8YzuP-GeJiSIOiYgRCxPRiIMTK05PztmRdYN0Y3CCojGDdWRwgsJZhXdha3UyBw"}
2024-03-20T01:38:59.325Z	INFO	gowaku.host3.discv5	discv5/discover.go:190	started Discovery V5	{"listening": "[::]:40307", "advertising": "127.0.0.1:43749"}
2024-03-20T01:38:59.325Z	INFO	gowaku.host3.discv5	discv5/discover.go:193	Discovery V5: discoverable ENR 	{"enr": "enr:-KG4QPfpM5K5CjXilFF8JrAVAKGNZesLwgWkLUk0ZPLG4LZcXipJrkOjOo9_n-0LALhnNg3qKSx_07vqOFz3zzikRQaGAY5Zgvh7gmlkgnY0gmlwhH8AAAGCcnOFAAEBAAGJc2VjcDI1NmsxoQIInPH1W5o-MMIomtpIKMLKoKDP9uLO3CKlCG-Cy3x_uYN0Y3CCquWDdWRwgp1zhXdha3UyDw"}
2024-03-20T01:38:59.325Z	ERROR	gowaku.host3.peer-manager	peermanager/peer_discovery.go:58	cannot do on demand discovery for non-waku protocol	{"protocol": "/test"}
2024-03-20T01:38:59.325Z	ERROR	gowaku.host3.peer-manager	peermanager/peer_discovery.go:115	failed to discover and connect to peers	{"error": "cannot do on demand discovery for non-waku protocol"}
2024-03-20T01:38:59.325Z	INFO	gowaku.host3.peer-manager	peermanager/peer_manager.go:581	adding peer to service slots	{"peer": "16Uiu2HAm5wzvMj7a69CBUb9zALiUPnU8E6YSpvgDFwbXbCj79JBn", "service": "/vac/waku/store/2.0.0-beta4"}
2024-03-20T01:38:59.325Z	INFO	gowaku.host3.peer-manager	peermanager/peer_manager.go:474	adding peer to peerstore	{"peer": "16Uiu2HAm5wzvMj7a69CBUb9zALiUPnU8E6YSpvgDFwbXbCj79JBn"}
2024-03-20T01:38:59.327Z	INFO	gowaku.host3.peer-manager	peermanager/peer_manager.go:581	adding peer to service slots	{"peer": "16Uiu2HAmKVW8mLTkb69jyV2gYs8c6QupK6zY5CBAGt7hFu2LUboq", "service": "/vac/waku/lightpush/2.0.0-beta1"}
2024-03-20T01:38:59.327Z	INFO	gowaku.host3.peer-manager	peermanager/peer_manager.go:474	adding peer to peerstore	{"peer": "16Uiu2HAmKVW8mLTkb69jyV2gYs8c6QupK6zY5CBAGt7hFu2LUboq"}
2024-03-20T01:38:59.327Z	WARN	gowaku.host2.discv5	discv5/discover.go:487	Discv5 loop stopped
2024-03-20T01:38:59.327Z	WARN	gowaku.host3.discv5	discv5/discover.go:487	Discv5 loop stopped
2024-03-20T01:38:59.327Z	INFO	gowaku.host3.discv5	discv5/discover.go:249	stopped Discovery V5
2024-03-20T01:39:00.326Z	WARN	gowaku.host1.discv5	discv5/discover.go:487	Discv5 loop stopped
2024-03-20T01:39:01.325Z	INFO	gowaku.host2.discv5	discv5/discover.go:249	stopped Discovery V5
2024-03-20T01:39:01.325Z	INFO	gowaku.host1.discv5	discv5/discover.go:249	stopped Discovery V5
--- FAIL: TestServiceSlot (0.00s)
    service_slot_test.go:45: 
        	Error Trace:	/home/runner/work/go-waku/go-waku/waku/v2/peermanager/service_slot_test.go:45
        	Error:      	Should not be: "peerId3"
        	Test:       	TestServiceSlot
2024-03-20T01:39:01.434Z	WARN	p2p-config	config/config.go:304	rcmgr limit conflicts with connmgr limit: conn manager high watermark limit: 192, exceeds the system connection limit of: 1
2024-03-20T01:39:01.440Z	INFO	gowaku.relay	relay/waku_relay.go:100	relay config	{"max-msg-size-bytes": 153600, "min-peers-to-publish": 0}
2024-03-20T01:39:01.440Z	INFO	gowaku	peermanager/peer_manager.go:192	PeerManager init values	{"maxConnections": 10, "maxRelayPeers": 8, "outRelayPeersTarget": 10, "inRelayPeersTarget": -2, "maxPeers": 20}
2024-03-20T01:39:01.489Z	WARN	p2p-config	config/config.go:304	rcmgr limit conflicts with connmgr limit: conn manager high watermark limit: 192, exceeds the system connection limit of: 1
2024-03-20T01:39:01.495Z	INFO	gowaku.relay	relay/waku_relay.go:100	relay config	{"max-msg-size-bytes": 153600, "min-peers-to-publish": 0}
2024-03-20T01:39:01.495Z	INFO	gowaku.relay	relay/waku_relay.go:147	Relay protocol started
2024-03-20T01:39:01.495Z	INFO	gowaku	peermanager/peer_manager.go:192	PeerManager init values	{"maxConnections": 10, "maxRelayPeers": 8, "outRelayPeersTarget": 10, "inRelayPeersTarget": -2, "maxPeers": 20}
2024-03-20T01:39:01.495Z	INFO	gowaku.relay	relay/waku_relay.go:406	subscribing to	{"pubsubTopic": "/waku/2/go/pm/test", "contentTopics": []}
2024-03-20T01:39:01.495Z	INFO	gowaku.relay	relay/waku_relay.go:[215](https://github.com/waku-org/go-waku/actions/runs/8341284982/job/22862909994#step:6:216)	subscribing to underlying pubsubTopic	{"pubsubTopic": "/waku/2/go/pm/test"}
2024-03-20T01:39:01.495Z	INFO	gowaku.relay	relay/waku_relay.go:247	gossipsub subscription	{"pubsubTopic": "/waku/2/go/pm/test"}
2024-03-20T01:39:01.495Z	INFO	gowaku.peer-manager	peermanager/topic_event_handler.go:25	handleNewRelayTopicSubscription	{"pubSubTopic": "/waku/2/go/pm/test"}
2024-03-20T01:39:01.695Z	INFO	gowaku.relay	relay/waku_relay.go:507	unsubscribing from pubsubTopic	{"topic": "/waku/2/go/pm/test"}
2024-03-20T01:39:01.695Z	ERROR	gowaku.relay	relay/waku_relay.go:540	getting message from subscription	{"error": "subscription cancelled"}
2024-03-20T01:39:01.695Z	INFO	gowaku.peer-manager	peermanager/topic_event_handler.go:86	handleNewRelayTopicUnSubscription	{"pubSubTopic": "/waku/2/go/pm/test"}
2024-03-20T01:39:01.896Z	INFO	pubsub	go-libp2p-pubsub@v0.10.0/pubsub.go:671	pubsub processloop shutting down
2024-03-20T01:39:01.951Z	WARN	p2p-config	config/config.go:304	rcmgr limit conflicts with connmgr limit: conn manager high watermark limit: 192, exceeds the system connection limit of: 1
2024-03-20T01:39:01.957Z	INFO	gowaku.relay	relay/waku_relay.go:100	relay config	{"max-msg-size-bytes": 153600, "min-peers-to-publish": 0}
2024-03-20T01:39:01.957Z	INFO	gowaku.relay	relay/waku_relay.go:147	Relay protocol started
2024-03-20T01:39:02.054Z	WARN	p2p-config	config/config.go:304	rcmgr limit conflicts with connmgr limit: conn manager high watermark limit: 192, exceeds the system connection limit of: 1
2024-03-20T01:39:02.060Z	INFO	gowaku.relay	relay/waku_relay.go:100	relay config	{"max-msg-size-bytes": 153600, "min-peers-to-publish": 0}
2024-03-20T01:39:02.060Z	INFO	gowaku.relay	relay/waku_relay.go:147	Relay protocol started
2024-03-20T01:39:02.228Z	WARN	p2p-config	config/config.go:304	rcmgr limit conflicts with connmgr limit: conn manager high watermark limit: 192, exceeds the system connection limit of: 1
2024-03-20T01:39:02.234Z	INFO	gowaku.relay	relay/waku_relay.go:100	relay config	{"max-msg-size-bytes": 153600, "min-peers-to-publish": 0}
2024-03-20T01:39:02.234Z	INFO	gowaku.relay	relay/waku_relay.go:147	Relay protocol started
2024-03-20T01:39:02.555Z	WARN	p2p-config	config/config.go:304	rcmgr limit conflicts with connmgr limit: conn manager high watermark limit: 192, exceeds the system connection limit of: 1
2024-03-20T01:39:02.561Z	INFO	gowaku.relay	relay/waku_relay.go:100	relay config	{"max-msg-size-bytes": 153600, "min-peers-to-publish": 0}
2024-03-20T01:39:02.562Z	INFO	gowaku.relay	relay/waku_relay.go:147	Relay protocol started
2024-03-20T01:39:02.823Z	WARN	p2p-config	config/config.go:304	rcmgr limit conflicts with connmgr limit: conn manager high watermark limit: 192, exceeds the system connection limit of: 1
2024-03-20T01:39:02.829Z	INFO	gowaku.relay	relay/waku_relay.go:100	relay config	{"max-msg-size-bytes": 153600, "min-peers-to-publish": 0}
2024-03-20T01:39:02.830Z	INFO	gowaku.relay	relay/waku_relay.go:147	Relay protocol started
2024-03-20T01:39:02.830Z	INFO	gowaku	peermanager/peer_manager.go:192	PeerManager init values	{"maxConnections": 10, "maxRelayPeers": 8, "outRelayPeersTarget": 10, "inRelayPeersTarget": -2, "maxPeers": 20}
2024-03-20T01:39:04.849Z	INFO	gowaku	peermanager/topic_event_handler_test.go:173	No peers for the topic yet
2024-03-20T01:39:04.849Z	INFO	gowaku.relay	relay/waku_relay.go:406	subscribing to	{"pubsubTopic": "/waku/2/go/pm/test", "contentTopics": []}
2024-03-20T01:39:04.849Z	INFO	gowaku.relay	relay/waku_relay.go:215	subscribing to underlying pubsubTopic	{"pubsubTopic": "/waku/2/go/pm/test"}
2024-03-20T01:39:04.849Z	INFO	gowaku.relay	relay/waku_relay.go:247	gossipsub subscription	{"pubsubTopic": "/waku/2/go/pm/test"}
2024-03-20T01:39:04.849Z	INFO	gowaku.peer-manager	peermanager/topic_event_handler.go:25	handleNewRelayTopicSubscription	{"pubSubTopic": "/waku/2/go/pm/test"}
FAIL
coverage: 40.9% of statements in ./...
FAIL	github.com/waku-org/go-waku/waku/v2/peermanager	9.256s
ok  	github.com/waku-org/go-waku/waku/v2/protocol	1.358s	coverage: 20.3% of statements in ./...
ok  	github.com/waku-org/go-waku/waku/v2/protocol/enr	0.026s	coverage: 11.9% of statements in ./...
?   	github.com/waku-org/go-waku/waku/v2/protocol/rln/contracts	[no test files]
?   	github.com/waku-org/go-waku/waku/v2/protocol/rln/group_manager	[no test files]
?   	github.com/waku-org/go-waku/waku/v2/protocol/rln/group_manager/static	[no test files]
?   	github.com/waku-org/go-waku/waku/v2/protocol/rln/keystore	[no test files]
?   	github.com/waku-org/go-waku/waku/v2/protocol/rln/pb	[no test files]
?   	github.com/waku-org/go-waku/waku/v2/protocol/rln/web3	[no test files]
?   	github.com/waku-org/go-waku/cmd/waku/server	[no test files]
ok  	github.com/waku-org/go-waku/waku/v2/protocol/filter	75.371s	coverage: 33.6% of statements in ./...
ok  	github.com/waku-org/go-waku/waku/v2/protocol/filter/pb	0.005s	coverage: 19.9% of statements in ./...
ok  	github.com/waku-org/go-waku/waku/v2/protocol/lightpush	7.956s	coverage: 21.0% of statements in ./...
ok  	github.com/waku-org/go-waku/waku/v2/protocol/lightpush/pb	0.004s	coverage: 20.6% of statements in ./...
ok  	github.com/waku-org/go-waku/waku/v2/protocol/metadata	5.251s	coverage: 17.9% of statements in ./...
ok  	github.com/waku-org/go-waku/waku/v2/protocol/noise	6.829s	coverage: 32.7% of statements in ./...
ok  	github.com/waku-org/go-waku/waku/v2/protocol/pb	0.004s	coverage: 28.7% of statements in ./...
ok  	github.com/waku-org/go-waku/waku/v2/protocol/peer_exchange	38.[223](https://github.com/waku-org/go-waku/actions/runs/8341284982/job/22862909994#step:6:224)s	coverage: 26.6% of statements in ./...
ok  	github.com/waku-org/go-waku/waku/v2/protocol/relay	27.894s	coverage: 32.8% of statements in ./...
ok  	github.com/waku-org/go-waku/waku/v2/protocol/rln	43.069s	coverage: 18.7% of statements in ./...
ok  	github.com/waku-org/go-waku/waku/v2/protocol/rln/group_manager/dynamic	10.883s	coverage: 21.1% of statements in ./...
ok  	github.com/waku-org/go-waku/waku/v2/protocol/store	0.658s	coverage: 25.7% of statements in ./...
ok  	github.com/waku-org/go-waku/waku/v2/protocol/store/pb	0.036s	coverage: 12.3% of statements in ./...
ok  	github.com/waku-org/go-waku/waku/v2/protocol/subscription	0.830s	coverage: 11.1% of statements in ./...
ok  	github.com/waku-org/go-waku/waku/v2/rendezvous	1.130s	coverage: 17.2% of statements in ./...
ok  	github.com/waku-org/go-waku/waku/v2/service	0.022s	coverage: 10.2% of statements in ./...
ok  	github.com/waku-org/go-waku/waku/v2/timesource	0.098s	coverage: 52.8% of statements in ./...
ok  	github.com/waku-org/go-waku/waku/v2/utils	0.005s	coverage: 13.6% of statements in ./...
ok  	github.com/waku-org/go-waku/cmd/waku/server/rest	8.316s	coverage: 34.6% of statements in ./...
FAIL
make: *** [Makefile:83: test] Error 1
Error: Process completed with exit code 2.
```        	

https://github.com/waku-org/go-waku/actions/runs/8323367352/job/22772861956