### PR TITLE
fix: handle discv5 udp port 0

### DIFF
--- a/waku/v2/discv5/discover.go
+++ b/waku/v2/discv5/discover.go
@@ -178,6 +178,7 @@ func (d *DiscoveryV5) listen(ctx context.Context) error {
 
 	}
 
+	d.params.udpPort = uint(d.udpAddr.Port)
 	d.localnode.SetFallbackUDP(d.udpAddr.Port)
 
 	listener, err := discover.ListenV5(conn, d.localnode, d.config)

--- a/waku/v2/protocol/enr/localnode.go
+++ b/waku/v2/protocol/enr/localnode.go
@@ -79,6 +79,10 @@ func WithIP(ipAddr *net.TCPAddr) ENROption {
 
 func WithUDPPort(udpPort uint) ENROption {
 	return func(localnode *enode.LocalNode) (err error) {
+		if udpPort == 0 {
+			return nil
+		}
+
 		if udpPort > math.MaxUint16 {
 			return errors.New("invalid udp port number")
 		}


### PR DESCRIPTION
# Description
While debugging a message reliability issue in status-go I noticed that the ENRs were lacking the UDP port
This was introduced in https://github.com/status-im/status-go/pull/4610, and in this PR Il update the UDP port used in the params with whatever value is obtained from ListenUDP
