### PR TITLE
chore(nix): refactor, fix library packages

### DIFF
--- a/ci/Jenkinsfile.nix-flake
+++ b/ci/Jenkinsfile.nix-flake
@@ -1,4 +1,4 @@
-library 'status-jenkins-lib@v1.7.0'
+library 'status-jenkins-lib@v1.9.3'
 
 pipeline {
   agent {
@@ -27,10 +27,7 @@ pipeline {
       stages {
         stage('Build') {
           steps { script {
-            sh("""#!/usr/bin/env bash
-              ${nix._sourceProfileInline()}
-              nix build --print-out-paths .#node
-            """)
+            nix.flake('node')
           } }
         }
         stage('Check') {
@@ -45,15 +42,12 @@ pipeline {
       stages {
         stage('Build') {
           steps { script {
-            sh("""#!/usr/bin/env bash
-              ${nix._sourceProfileInline()}
-              nix build --print-out-paths .#library
-            """)
+            nix.flake('static-library')
           } }
         }
         stage('Check') {
           steps {
-            sh 'ldd ./result/bin/c'
+            sh 'readelf -h ./result/bin/libgowaku.a'
           }
         }
       }

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,33 @@
+{
+  pkgs ? import <nixpkgs> { },
+  self ? ./.,
+  subPkgs ? "cmd/waku",
+  ldflags ? [],
+  output ? null,
+  commit ? builtins.substring 0 7 (self.rev or "dirty"),
+  version ? builtins.readFile ./VERSION,
+}:
+
+pkgs.buildGo121Module {
+  name = "go-waku";
+  src = self;
+
+  subPackages = subPkgs;
+  tags = ["gowaku_no_rln"];
+  ldflags = [
+    "-X github.com/waku-org/go-waku/waku/v2/node.GitCommit=${commit}"
+    "-X github.com/waku-org/go-waku/waku/v2/node.Version=${version}"
+  ] ++ ldflags;
+  doCheck = false;
+
+  # Otherwise library would be just called bin/c.
+  postInstall = if builtins.isString output then ''
+    mv $out/bin/* $out/bin/${output}
+  '' else "";
+
+  # FIXME: This needs to be manually changed when updating modules.
+  vendorHash = "sha256-zwvZVTiwv7cc4vAM2Fil+qAG1v1J8q4BqX5lCgCStIc=";
+
+  # Fix for 'nix run' trying to execute 'go-waku'.
+  meta = { mainProgram = "waku"; };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -11,11 +11,11 @@
       ];
       forAllSystems = f: nixpkgs.lib.genAttrs supportedSystems (system: f system);
 
-      nixpkgsFor = forAllSystems (system: import nixpkgs { inherit system; });
+      pkgsFor = forAllSystems (system: import nixpkgs { inherit system; });
 
       buildPackage = system: subPackages:
         let
-          pkgs = nixpkgsFor.${system};
+          pkgs = pkgsFor.${system};
           commit = builtins.substring 0 7 (self.rev or "dirty");
           version = builtins.readFile ./VERSION;
         in pkgs.buildGo121Module {
@@ -34,17 +34,37 @@
           meta = { mainProgram = "waku"; };
         };
     in rec {
-      packages = forAllSystems (system: {
-        node    = buildPackage system ["cmd/waku"];
-        library = buildPackage system ["library/c"];
+      packages = forAllSystems (system: let
+        pkgs = pkgsFor.${system};
+        os = pkgs.stdenv.hostPlatform.uname.system;
+        sttLibExtMap = { Windows = "lib"; Darwin = "a";     Linux = "a";  };
+        dynLibExtMap = { Windows = "dll"; Darwin = "dylib"; Linux = "so"; };
+        buildPackage = pkgs.callPackage ./default.nix;
+      in rec {
+        default = node;
+        node = buildPackage {
+          inherit self;
+          subPkgs = ["cmd/waku"];
+        };
+        static-library = buildPackage {
+          inherit self;
+          subPkgs = ["library/c"];
+          ldflags = ["-buildmode=c-archive"];
+          output = "libgowaku.${sttLibExtMap.${os}}";
+        };
+        # FIXME: Compilation fails with:
+        #   relocation R_X86_64_TPOFF32 against runtime.tlsg can not be
+        #   used when making a shared object; recompile with -fPIC
+        dynamic-library = buildPackage {
+          inherit self;
+          subPkgs = ["library/c"];
+          ldflags = ["-buildmode=c-shared"];
+          output = "libgowaku.${dynLibExtMap.${os}}";
+        };
       });
 
-      defaultPackage = forAllSystems (system:
-        buildPackage system ["cmd/waku"]
-      );
-
       devShells = forAllSystems (system: let
-        pkgs = nixpkgsFor.${system};
+        pkgs = pkgsFor.${system};
         inherit (pkgs) lib stdenv mkShell;
       in {
         default = mkShell {


### PR DESCRIPTION
Bit of a cleanup to make it more readable and also fix building of libraries.

Moving the actual build to `default.nix` makes `flake.nix` more readable.