### PR TITLE
fix(lightpush): no response on err

### DIFF
--- a/cmd/waku/server/rest/lightpush_rest.go
+++ b/cmd/waku/server/rest/lightpush_rest.go
@@ -73,7 +73,9 @@ func (serv *LightpushService) postMessagev1(w http.ResponseWriter, req *http.Req
 	if err != nil {
 		w.WriteHeader(http.StatusServiceUnavailable)
 		_, err = w.Write([]byte(err.Error()))
-		serv.log.Error("writing response", zap.Error(err))
+		if err != nil {
+			serv.log.Error("writing response", zap.Error(err))
+		}
 	} else {
 		writeErrOrResponse(w, err, true)
 	}

--- a/waku/v2/protocol/lightpush/waku_lightpush.go
+++ b/waku/v2/protocol/lightpush/waku_lightpush.go
@@ -151,7 +151,6 @@ func (wakuLP *WakuLightPush) onRequest(ctx context.Context) func(network.Stream)
 			wakuLP.metrics.RecordError(messagePushFailure)
 			responseMsg := fmt.Sprintf("Could not publish message: %s", err.Error())
 			responsePushRPC.Response.Info = &responseMsg
-			return
 		} else {
 			responsePushRPC.Response.IsSuccess = true
 			responseMsg := "OK"


### PR DESCRIPTION
# Description
There was an extra `return` that was keeping the connection open, hence the lack of response in case of errors, which manifested in the strange errors seen in #1076 and #1078.


## Issue

fixes #1076
fixes #1078

