### PR TITLE
fix(peer-manager): discovering peers should not lock the peer manager

### DIFF
--- a/waku/v2/peermanager/peer_manager.go
+++ b/waku/v2/peermanager/peer_manager.go
@@ -304,7 +304,7 @@ func (pm *PeerManager) ensureMinRelayConnsPerTopic() {
 			notConnectedPeers := pm.getNotConnectedPers(topicStr)
 			if notConnectedPeers.Len() == 0 {
 				pm.logger.Debug("could not find any peers in peerstore to connect to, discovering more", zap.String("pubSubTopic", topicStr))
-				pm.discoverPeersByPubsubTopics([]string{topicStr}, relay.WakuRelayID_v200, pm.ctx, 2)
+				go pm.discoverPeersByPubsubTopics([]string{topicStr}, relay.WakuRelayID_v200, pm.ctx, 2)
 				continue
 			}
 			pm.logger.Debug("connecting to eligible peers in peerstore", zap.String("pubSubTopic", topicStr))


### PR DESCRIPTION
# Description
While debugging #1077 I noticed that the relay connectivity loop locks for reading the topicMutex. This means that while this lock is RLocked, it will not be possible to lock it for writing (which happens when we subscribe to topics).  Profiling this code, I saw that when this function attempts to discover new peers, it ends up locking the mutex for as long as there are not enough peers for a topic. Since discovering peers is a potentially long operation, I decided to run it into a separate goroutine to avoid having the topicsMutex locked longer than necessary. 



## Issue

closes #1077

