### PR TITLE
fix(rest/store): allow local queries

### DIFF
--- a/cmd/waku/server/rest/store.go
+++ b/cmd/waku/server/rest/store.go
@@ -67,7 +67,13 @@ func getStoreParams(r *http.Request) (*store.Query, []store.HistoryRequestOption
 			return nil, nil, err
 		}
 		options = append(options, store.WithPeerAddr(m))
+	} else {
+		// The user didn't specify a peer address and self-node is configured as a store node.
+		// In this case we assume that the user is willing to retrieve the messages stored by
+		// the local/self store node.
+		options = append(options, store.WithLocalQuery())
 	}
+
 	query.PubsubTopic = r.URL.Query().Get("pubsubTopic")
 
 	contentTopics := r.URL.Query().Get("contentTopics")

--- a/waku/v2/protocol/lightpush/waku_lightpush.go
+++ b/waku/v2/protocol/lightpush/waku_lightpush.go
@@ -63,10 +63,6 @@ func NewWakuLightPush(relay *relay.WakuRelay, pm *peermanager.PeerManager, reg p
 
 	wakuLP.limiter = params.limiter
 
-	if pm != nil {
-		wakuLP.pm.RegisterWakuProtocol(LightPushID_v20beta1, LightPushENRField)
-	}
-
 	return wakuLP
 }
 
@@ -79,6 +75,10 @@ func (wakuLP *WakuLightPush) SetHost(h host.Host) {
 func (wakuLP *WakuLightPush) Start(ctx context.Context) error {
 	if wakuLP.relayIsNotAvailable() {
 		return errors.New("relay is required, without it, it is only a client and cannot be started")
+	}
+
+	if wakuLP.pm != nil {
+		wakuLP.pm.RegisterWakuProtocol(LightPushID_v20beta1, LightPushENRField)
 	}
 
 	ctx, cancel := context.WithCancel(ctx)

--- a/waku/v2/protocol/store/waku_store_common.go
+++ b/waku/v2/protocol/store/waku_store_common.go
@@ -67,8 +67,5 @@ func NewWakuStore(p MessageProvider, pm *peermanager.PeerManager, timesource tim
 	wakuStore.pm = pm
 	wakuStore.metrics = newMetrics(reg)
 
-	if pm != nil {
-		pm.RegisterWakuProtocol(StoreID_v20beta4, StoreENRField)
-	}
 	return wakuStore
 }

--- a/waku/v2/protocol/store/waku_store_protocol.go
+++ b/waku/v2/protocol/store/waku_store_protocol.go
@@ -119,6 +119,10 @@ func (store *WakuStore) Start(ctx context.Context, sub *relay.Subscription) erro
 		return err
 	}
 
+	if store.pm != nil {
+		store.pm.RegisterWakuProtocol(StoreID_v20beta4, StoreENRField)
+	}
+
 	store.started = true
 	store.ctx, store.cancel = context.WithCancel(ctx)
 	store.MsgC = sub


### PR DESCRIPTION
# Description
Sets the behavior for store queries in REST to be similar to nwaku, in which if no peer is specified, and the wakunode is a store node, then it will query itself.
In addition to that, I noticed that the store protocol was registering itself to be used in the ENR when instantiating `WakuStore`, and this is wrong because instantiating a `WakuStore` does not mean that the node itself will be a store node (it can be only a client), so I moved that part of the code to the `Start` function.

## Issue

closes #1087 
