### PR TITLE
feat: changes for optimizing filter ping

### DIFF
--- a/tests/utils.go
+++ b/tests/utils.go
@@ -9,7 +9,6 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"github.com/waku-org/go-waku/waku/v2/protocol"
 	"io"
 	"math"
 	"math/big"
@@ -21,6 +20,8 @@ import (
 	"testing"
 	"time"
 	"unicode/utf8"
+
+	"github.com/waku-org/go-waku/waku/v2/protocol"
 
 	gcrypto "github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/log"
@@ -46,6 +47,21 @@ type StringGenerator func(maxLength int) (string, error)
 // GetHostAddress returns the first listen address used by a host
 func GetHostAddress(ha host.Host) multiaddr.Multiaddr {
 	return ha.Addrs()[0]
+}
+
+// Returns a full multiaddr of host appended by peerID
+func GetAddr(h host.Host) multiaddr.Multiaddr {
+	id, _ := multiaddr.NewMultiaddr(fmt.Sprintf("/p2p/%s", h.ID().String()))
+	var selectedAddr multiaddr.Multiaddr
+	//For now skipping circuit relay addresses as libp2p seems to be returning empty p2p-circuit addresses.
+	for _, addr := range h.Network().ListenAddresses() {
+		if strings.Contains(addr.String(), "p2p-circuit") {
+			continue
+		}
+		selectedAddr = addr
+		break
+	}
+	return selectedAddr.Encapsulate(id)
 }
 
 // FindFreePort returns an available port number

--- a/waku/v2/api/filter.go
+++ b/waku/v2/api/filter.go
@@ -84,8 +84,8 @@ func (apiSub *Sub) closeAndResubscribe(subId string) {
 	apiSub.log.Debug("sub closeAndResubscribe", zap.String("subID", subId))
 
 	apiSub.subs[subId].Close()
-	apiSub.resubscribe()
 	delete(apiSub.subs, subId)
+	apiSub.resubscribe()
 }
 
 func (apiSub *Sub) cleanup() {
@@ -108,9 +108,9 @@ func (apiSub *Sub) cleanup() {
 // Attempts to resubscribe on topics that lack subscriptions
 func (apiSub *Sub) resubscribe() {
 	// Re-subscribe asynchronously
-	count := len(apiSub.subs) - 1
-	apiSub.log.Debug("subscribing again", zap.Stringer("contentFilter", apiSub.ContentFilter), zap.Int("numPeers", apiSub.Config.MaxPeers-count))
-	subs, err := apiSub.subscribe(apiSub.ContentFilter, apiSub.Config.MaxPeers-count)
+	existingSubCount := len(apiSub.subs)
+	apiSub.log.Debug("subscribing again", zap.Stringer("contentFilter", apiSub.ContentFilter), zap.Int("numPeers", apiSub.Config.MaxPeers-existingSubCount))
+	subs, err := apiSub.subscribe(apiSub.ContentFilter, apiSub.Config.MaxPeers-existingSubCount)
 	if err != nil {
 		return
 	} //Not handling scenario where all requested subs are not received as that will get handled in next cycle.

--- a/waku/v2/api/filter.go
+++ b/waku/v2/api/filter.go
@@ -69,7 +69,7 @@ func (apiSub *Sub) waitOnSubClose() {
 	for {
 		select {
 		case <-apiSub.ctx.Done():
-			apiSub.log.Debug("healthCheckLoop: Done()")
+			apiSub.log.Debug("apiSub context: Done()")
 			apiSub.cleanup()
 			return
 		case subId := <-apiSub.closing:

--- a/waku/v2/api/filter_test.go
+++ b/waku/v2/api/filter_test.go
@@ -36,12 +36,13 @@ func (s *FilterApiTestSuite) TestSubscribe() {
 	// We have one full node already created in SetupTest(),
 	// create another one
 	fullNodeData2 := s.GetWakuFilterFullNode(s.TestTopic, true)
-	s.ConnectHosts(s.LightNodeHost, fullNodeData2.FullNodeHost)
+	s.ConnectToFullNode(s.LightNode, fullNodeData2.FullNode)
+	//s.ConnectHosts(s.FullNodeHost, fullNodeData2.FullNodeHost)
 	peers := []peer.ID{s.FullNodeHost.ID(), fullNodeData2.FullNodeHost.ID()}
 	s.Log.Info("FullNodeHost IDs:", zap.Any("peers", peers))
 	// Make sure IDs are different
-	s.Require().True(peers[0] != peers[1])
-	apiConfig := FilterConfig{MaxPeers: 2, Peers: peers}
+	//s.Require().True(peers[0] != peers[1])
+	apiConfig := FilterConfig{MaxPeers: 2}
 
 	s.Require().Equal(apiConfig.MaxPeers, 2)
 	s.Require().Equal(contentFilter.PubsubTopic, s.TestTopic)
@@ -74,13 +75,19 @@ func (s *FilterApiTestSuite) TestSubscribe() {
 
 	s.Log.Info("stopping full node", zap.Stringer("id", fullNodeData2.FullNodeHost.ID()))
 	fullNodeData2.FullNode.Stop()
+	fullNodeData2.FullNodeHost.Close()
 	time.Sleep(1 * time.Second)
-	for sub := range apiSub.subs {
+	/* 	for sub := range apiSub.subs {
 		s.Log.Info("SubDetails:", zap.String("id", sub))
-	}
+	} */
 	s.Require().Equal(1, len(apiSub.subs))
 
-	time.Sleep(2 * time.Second)
+	/* 	fullNodeData3 := s.GetWakuFilterFullNode(s.TestTopic, true)
+	   	s.ConnectNodes(s.LightNode, fullNodeData3.FullNode)
+
+	   	time.Sleep(2 * time.Second)
+	   	s.Require().Equal(2, len(apiSub.subs))
+	*/
 	apiSub.Unsubscribe()
 	for range apiSub.DataCh {
 	}

--- a/waku/v2/api/filter_test.go
+++ b/waku/v2/api/filter_test.go
@@ -68,6 +68,19 @@ func (s *FilterApiTestSuite) TestSubscribe() {
 	}
 	s.Require().Equal(cnt, 1)
 
+	//Verify HealthCheck
+	isAlive := s.LightNode.IsSubscriptionAlive(context.Background(), apiSub.subs[subsArray[0]])
+	s.Require().True(isAlive)
+	isAlive = s.LightNode.IsSubscriptionAlive(context.Background(), apiSub.subs[subsArray[1]])
+	s.Require().True(isAlive)
+	s.Log.Info("stopping full node", zap.Stringer("id", fullNodeData2.FullNodeHost.ID()))
+	fullNodeData2.FullNode.Stop()
+	time.Sleep(1 * time.Second)
+	for sub := range apiSub.subs {
+		s.Log.Info("SubDetails:", zap.String("id", sub))
+	}
+	s.Require().Equal(1, len(apiSub.subs))
+
 	time.Sleep(2 * time.Second)
 	apiSub.Unsubscribe()
 	for range apiSub.DataCh {

--- a/waku/v2/api/filter_test.go
+++ b/waku/v2/api/filter_test.go
@@ -74,20 +74,15 @@ func (s *FilterApiTestSuite) TestSubscribe() {
 	s.Require().Equal(2, len(subs))
 
 	s.Log.Info("stopping full node", zap.Stringer("id", fullNodeData2.FullNodeHost.ID()))
+	fullNodeData3 := s.GetWakuFilterFullNode(s.TestTopic, true)
+
+	s.ConnectToFullNode(s.LightNode, fullNodeData3.FullNode)
+
 	fullNodeData2.FullNode.Stop()
 	fullNodeData2.FullNodeHost.Close()
-	time.Sleep(1 * time.Second)
-	/* 	for sub := range apiSub.subs {
-		s.Log.Info("SubDetails:", zap.String("id", sub))
-	} */
-	s.Require().Equal(1, len(apiSub.subs))
+	time.Sleep(2 * time.Second)
+	s.Require().Equal(2, len(apiSub.subs))
 
-	/* 	fullNodeData3 := s.GetWakuFilterFullNode(s.TestTopic, true)
-	   	s.ConnectNodes(s.LightNode, fullNodeData3.FullNode)
-
-	   	time.Sleep(2 * time.Second)
-	   	s.Require().Equal(2, len(apiSub.subs))
-	*/
 	apiSub.Unsubscribe()
 	for range apiSub.DataCh {
 	}

--- a/waku/v2/api/filter_test.go
+++ b/waku/v2/api/filter_test.go
@@ -69,10 +69,9 @@ func (s *FilterApiTestSuite) TestSubscribe() {
 	s.Require().Equal(cnt, 1)
 
 	//Verify HealthCheck
-	isAlive := s.LightNode.IsSubscriptionAlive(context.Background(), apiSub.subs[subsArray[0]])
-	s.Require().True(isAlive)
-	isAlive = s.LightNode.IsSubscriptionAlive(context.Background(), apiSub.subs[subsArray[1]])
-	s.Require().True(isAlive)
+	subs := s.LightNode.Subscriptions()
+	s.Require().Equal(2, len(subs))
+
 	s.Log.Info("stopping full node", zap.Stringer("id", fullNodeData2.FullNodeHost.ID()))
 	fullNodeData2.FullNode.Stop()
 	time.Sleep(1 * time.Second)

--- a/waku/v2/api/filter_test.go
+++ b/waku/v2/api/filter_test.go
@@ -81,10 +81,11 @@ func (s *FilterApiTestSuite) TestSubscribe() {
 	fullNodeData2.FullNode.Stop()
 	fullNodeData2.FullNodeHost.Close()
 	time.Sleep(2 * time.Second)
-	s.Require().Equal(2, len(apiSub.subs))
+	subs = s.LightNode.Subscriptions()
 
-	for subId := range apiSub.subs {
-		sub := apiSub.subs[subId]
+	s.Require().Equal(2, len(subs))
+
+	for _, sub := range subs {
 		s.Require().NotEqual(fullNodeData2.FullNodeHost.ID(), sub.PeerID)
 	}
 

--- a/waku/v2/api/filter_test.go
+++ b/waku/v2/api/filter_test.go
@@ -83,6 +83,11 @@ func (s *FilterApiTestSuite) TestSubscribe() {
 	time.Sleep(2 * time.Second)
 	s.Require().Equal(2, len(apiSub.subs))
 
+	for subId := range apiSub.subs {
+		sub := apiSub.subs[subId]
+		s.Require().NotEqual(fullNodeData2.FullNodeHost.ID(), sub.PeerID)
+	}
+
 	apiSub.Unsubscribe()
 	for range apiSub.DataCh {
 	}

--- a/waku/v2/peermanager/peer_manager.go
+++ b/waku/v2/peermanager/peer_manager.go
@@ -277,10 +277,10 @@ func (pm *PeerManager) getRelayPeers(specificPeers ...peer.ID) (inRelayPeers pee
 
 	//Need to filter peers to check if they support relay
 	if inPeers.Len() != 0 {
-		inRelayPeers, _ = pm.FilterPeersByProto(inPeers, relay.WakuRelayID_v200)
+		inRelayPeers, _ = pm.FilterPeersByProto(inPeers, nil, relay.WakuRelayID_v200)
 	}
 	if outPeers.Len() != 0 {
-		outRelayPeers, _ = pm.FilterPeersByProto(outPeers, relay.WakuRelayID_v200)
+		outRelayPeers, _ = pm.FilterPeersByProto(outPeers, nil, relay.WakuRelayID_v200)
 	}
 	return
 }

--- a/waku/v2/peermanager/peer_manager_test.go
+++ b/waku/v2/peermanager/peer_manager_test.go
@@ -3,8 +3,6 @@ package peermanager
 import (
 	"context"
 	"crypto/rand"
-	"fmt"
-	"strings"
 	"testing"
 	"time"
 
@@ -14,7 +12,6 @@ import (
 	"github.com/libp2p/go-libp2p/core/peer"
 	libp2pProtocol "github.com/libp2p/go-libp2p/core/protocol"
 	"github.com/libp2p/go-libp2p/p2p/host/peerstore/pstoremem"
-	"github.com/multiformats/go-multiaddr"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
 	"github.com/waku-org/go-waku/tests"
@@ -25,19 +22,6 @@ import (
 	"github.com/waku-org/go-waku/waku/v2/protocol/relay"
 	"github.com/waku-org/go-waku/waku/v2/utils"
 )
-
-func getAddr(h host.Host) multiaddr.Multiaddr {
-	id, _ := multiaddr.NewMultiaddr(fmt.Sprintf("/p2p/%s", h.ID().String()))
-	var selectedAddr multiaddr.Multiaddr
-	//For now skipping circuit relay addresses as libp2p seems to be returning empty p2p-circuit addresses.
-	for _, addr := range h.Network().ListenAddresses() {
-		if strings.Contains(addr.String(), "p2p-circuit") {
-			continue
-		}
-		selectedAddr = addr
-	}
-	return selectedAddr.Encapsulate(id)
-}
 
 func initTest(t *testing.T) (context.Context, *PeerManager, func()) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
@@ -72,7 +56,7 @@ func TestServiceSlots(t *testing.T) {
 
 	// add h2 peer to peer manager
 	t.Log(h2.ID())
-	_, err = pm.AddPeer(getAddr(h2), wps.Static, []string{""}, libp2pProtocol.ID(protocol))
+	_, err = pm.AddPeer(tests.GetAddr(h2), wps.Static, []string{""}, libp2pProtocol.ID(protocol))
 	require.NoError(t, err)
 
 	///////////////
@@ -86,7 +70,7 @@ func TestServiceSlots(t *testing.T) {
 	require.Equal(t, h2.ID(), peers[0])
 
 	// add h3 peer to peer manager
-	_, err = pm.AddPeer(getAddr(h3), wps.Static, []string{""}, libp2pProtocol.ID(protocol))
+	_, err = pm.AddPeer(tests.GetAddr(h3), wps.Static, []string{""}, libp2pProtocol.ID(protocol))
 	require.NoError(t, err)
 
 	// check that returned peer is h2 or h3 peer
@@ -111,7 +95,7 @@ func TestServiceSlots(t *testing.T) {
 	require.Error(t, err, ErrNoPeersAvailable)
 
 	// add h4 peer for protocol1
-	_, err = pm.AddPeer(getAddr(h4), wps.Static, []string{""}, libp2pProtocol.ID(protocol1))
+	_, err = pm.AddPeer(tests.GetAddr(h4), wps.Static, []string{""}, libp2pProtocol.ID(protocol1))
 	require.NoError(t, err)
 
 	//Test peer selection for protocol1
@@ -139,10 +123,10 @@ func TestPeerSelection(t *testing.T) {
 	defer h3.Close()
 
 	protocol := libp2pProtocol.ID("test/protocol")
-	_, err = pm.AddPeer(getAddr(h2), wps.Static, []string{"/waku/2/rs/2/1", "/waku/2/rs/2/2"}, libp2pProtocol.ID(protocol))
+	_, err = pm.AddPeer(tests.GetAddr(h2), wps.Static, []string{"/waku/2/rs/2/1", "/waku/2/rs/2/2"}, libp2pProtocol.ID(protocol))
 	require.NoError(t, err)
 
-	_, err = pm.AddPeer(getAddr(h3), wps.Static, []string{"/waku/2/rs/2/1"}, libp2pProtocol.ID(protocol))
+	_, err = pm.AddPeer(tests.GetAddr(h3), wps.Static, []string{"/waku/2/rs/2/1"}, libp2pProtocol.ID(protocol))
 	require.NoError(t, err)
 
 	_, err = pm.SelectPeers(PeerSelectionCriteria{SelectionType: Automatic, Proto: protocol})
@@ -173,7 +157,7 @@ func TestPeerSelection(t *testing.T) {
 	h4, err := tests.MakeHost(ctx, 0, rand.Reader)
 	require.NoError(t, err)
 	defer h4.Close()
-	_, err = pm.AddPeer(getAddr(h4), wps.Static, []string{"/waku/2/rs/2/1"}, libp2pProtocol.ID(protocol))
+	_, err = pm.AddPeer(tests.GetAddr(h4), wps.Static, []string{"/waku/2/rs/2/1"}, libp2pProtocol.ID(protocol))
 	require.NoError(t, err)
 
 	peerIDs, err = pm.SelectPeers(PeerSelectionCriteria{SelectionType: Automatic, Proto: protocol, PubsubTopics: []string{"/waku/2/rs/2/1"}, MaxPeers: 3})
@@ -200,7 +184,7 @@ func TestDefaultProtocol(t *testing.T) {
 	defer h5.Close()
 
 	//Test peer selection for relay protocol from peer store
-	_, err = pm.AddPeer(getAddr(h5), wps.Static, []string{""}, relay.WakuRelayID_v200)
+	_, err = pm.AddPeer(tests.GetAddr(h5), wps.Static, []string{""}, relay.WakuRelayID_v200)
 	require.NoError(t, err)
 
 	// since we are not passing peerList, selectPeer fn using filterByProto checks in PeerStore for peers with same protocol.
@@ -221,7 +205,7 @@ func TestAdditionAndRemovalOfPeer(t *testing.T) {
 	require.NoError(t, err)
 	defer h6.Close()
 
-	_, err = pm.AddPeer(getAddr(h6), wps.Static, []string{""}, protocol2)
+	_, err = pm.AddPeer(tests.GetAddr(h6), wps.Static, []string{""}, protocol2)
 	require.NoError(t, err)
 
 	peers, err := pm.SelectPeers(PeerSelectionCriteria{SelectionType: Automatic, Proto: protocol2})

--- a/waku/v2/peermanager/peer_selection.go
+++ b/waku/v2/peermanager/peer_selection.go
@@ -2,6 +2,7 @@ package peermanager
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 
 	"github.com/libp2p/go-libp2p/core/peer"
@@ -12,7 +13,16 @@ import (
 	"golang.org/x/exp/maps"
 )
 
-type peerSet map[peer.ID]struct{}
+type PeerSet map[peer.ID]struct{}
+
+func PeerInSet(peers PeerSet, peer peer.ID) bool {
+	if len(peers) > 0 {
+		if _, ok := peers[peer]; ok {
+			return true
+		}
+	}
+	return false
+}
 
 // SelectPeerByContentTopic is used to return a random peer that supports a given protocol for given contentTopic.
 // If a list of specific peers is passed, the peer will be chosen from that list assuming
@@ -54,17 +64,19 @@ func (pm *PeerManager) SelectRandom(criteria PeerSelectionCriteria) (peer.IDSlic
 			zap.Strings("pubsubTopics", criteria.PubsubTopics), zap.Error(err))
 		return nil, err
 	} else if len(peerIDs) == 0 {
-		peerIDs = make(peerSet)
+		peerIDs = make(PeerSet)
 	}
 	// if not found in serviceSlots or proto == WakuRelayIDv200
-	filteredPeers, err := pm.FilterPeersByProto(criteria.SpecificPeers, criteria.Proto)
+	pm.logger.Debug("looking for peers in peerStore", zap.String("proto", string(criteria.Proto)))
+	filteredPeers, err := pm.FilterPeersByProto(criteria.SpecificPeers, criteria.ExcludePeers, criteria.Proto)
 	if err != nil {
 		return nil, err
 	}
 	if len(criteria.PubsubTopics) > 0 {
 		filteredPeers = pm.host.Peerstore().(wps.WakuPeerstore).PeersByPubSubTopics(criteria.PubsubTopics, filteredPeers...)
 	}
-	randomPeers, err := selectRandomPeers(filteredPeers, criteria.MaxPeers-len(peerIDs))
+	//Not passing excludePeers as filterPeers are already considering excluded ones.
+	randomPeers, err := selectRandomPeers(filteredPeers, nil, criteria.MaxPeers-len(peerIDs))
 	if err != nil && len(peerIDs) == 0 {
 		return nil, err
 	}
@@ -75,10 +87,13 @@ func (pm *PeerManager) SelectRandom(criteria PeerSelectionCriteria) (peer.IDSlic
 	return maps.Keys(peerIDs), nil
 }
 
-func getRandom(filter peerSet, count int) (peerSet, error) {
+func getRandom(filter PeerSet, count int, excludePeers PeerSet) (PeerSet, error) {
 	i := 0
-	selectedPeers := make(peerSet)
+	selectedPeers := make(PeerSet)
 	for pID := range filter {
+		if PeerInSet(excludePeers, pID) {
+			continue
+		}
 		//Map's iterator in golang works using randomness and hence not random function is being used.
 		selectedPeers[pID] = struct{}{}
 		i++
@@ -93,34 +108,37 @@ func getRandom(filter peerSet, count int) (peerSet, error) {
 }
 
 // selects count random peers from list of peers
-func selectRandomPeers(peers peer.IDSlice, count int) (peerSet, error) {
-	filteredPeerMap := peerSliceToMap(peers)
-	return getRandom(filteredPeerMap, count)
+func selectRandomPeers(peers peer.IDSlice, excludePeers PeerSet, count int) (PeerSet, error) {
+	filteredPeerMap := PeerSliceToMap(peers)
+	return getRandom(filteredPeerMap, count, excludePeers)
 }
 
-func peerSliceToMap(peers peer.IDSlice) peerSet {
-	peerSet := make(peerSet, peers.Len())
+func PeerSliceToMap(peers peer.IDSlice) PeerSet {
+	peerSet := make(PeerSet, peers.Len())
 	for _, peer := range peers {
 		peerSet[peer] = struct{}{}
 	}
 	return peerSet
 }
 
-func (pm *PeerManager) selectServicePeer(criteria PeerSelectionCriteria) (peerSet, error) {
-	peers := make(peerSet)
+func (pm *PeerManager) selectServicePeer(criteria PeerSelectionCriteria) (PeerSet, error) {
+	peers := make(PeerSet)
 	var err error
 	for retryCnt := 0; retryCnt < 1; retryCnt++ {
 		//Try to fetch from serviceSlot
 		if slot := pm.serviceSlots.getPeers(criteria.Proto); slot != nil {
 			if len(criteria.PubsubTopics) == 0 || (len(criteria.PubsubTopics) == 1 && criteria.PubsubTopics[0] == "") {
-				return slot.getRandom(criteria.MaxPeers)
+				return slot.getRandom(criteria.MaxPeers, criteria.ExcludePeers)
 			} else { //PubsubTopic based selection
 				keys := make([]peer.ID, 0, len(slot.m))
 				for i := range slot.m {
+					if PeerInSet(criteria.ExcludePeers, i) {
+						continue
+					}
 					keys = append(keys, i)
 				}
 				selectedPeers := pm.host.Peerstore().(wps.WakuPeerstore).PeersByPubSubTopics(criteria.PubsubTopics, keys...)
-				tmpPeers, err := selectRandomPeers(selectedPeers, criteria.MaxPeers)
+				tmpPeers, err := selectRandomPeers(selectedPeers, criteria.ExcludePeers, criteria.MaxPeers)
 				for tmpPeer := range tmpPeers {
 					peers[tmpPeer] = struct{}{}
 				}
@@ -145,12 +163,21 @@ func (pm *PeerManager) selectServicePeer(criteria PeerSelectionCriteria) (peerSe
 
 // PeerSelectionCriteria is the selection Criteria that is used by PeerManager to select peers.
 type PeerSelectionCriteria struct {
-	SelectionType PeerSelection
-	Proto         protocol.ID
-	PubsubTopics  []string
-	SpecificPeers peer.IDSlice
-	MaxPeers      int
-	Ctx           context.Context
+	SelectionType PeerSelection   `json:"selectionType"`
+	Proto         protocol.ID     `json:"protocolId"`
+	PubsubTopics  []string        `json:"pubsubTopics"`
+	SpecificPeers peer.IDSlice    `json:"specificPeers"`
+	MaxPeers      int             `json:"maxPeerCount"`
+	Ctx           context.Context `json:"-"`
+	ExcludePeers  PeerSet         `json:"excludePeers"`
+}
+
+func (psc PeerSelectionCriteria) String() string {
+	pscJson, err := json.Marshal(psc)
+	if err != nil {
+		return ""
+	}
+	return string(pscJson)
 }
 
 // SelectPeers selects a peer based on selectionType specified.
@@ -159,6 +186,12 @@ func (pm *PeerManager) SelectPeers(criteria PeerSelectionCriteria) (peer.IDSlice
 	if criteria.MaxPeers == 0 {
 		criteria.MaxPeers = 1
 	}
+	excPeers := maps.Keys(criteria.ExcludePeers)
+	var excPeer peer.ID
+	if len(excPeers) > 0 {
+		excPeer = excPeers[0]
+	}
+	pm.logger.Debug("Select Peers", zap.Stringer("selectionCriteria", criteria), zap.Stringer("excludedPeers", excPeer))
 	switch criteria.SelectionType {
 	case Automatic:
 		return pm.SelectRandom(criteria)
@@ -191,7 +224,7 @@ func (pm *PeerManager) SelectPeerWithLowestRTT(criteria PeerSelectionCriteria) (
 		peers = pm.host.Peerstore().(wps.WakuPeerstore).PeersByPubSubTopics(criteria.PubsubTopics, criteria.SpecificPeers...)
 	}
 
-	peers, err = pm.FilterPeersByProto(peers, criteria.Proto)
+	peers, err = pm.FilterPeersByProto(peers, criteria.ExcludePeers, criteria.Proto)
 	if err != nil {
 		return "", err
 	}
@@ -201,22 +234,25 @@ func (pm *PeerManager) SelectPeerWithLowestRTT(criteria PeerSelectionCriteria) (
 
 // FilterPeersByProto filters list of peers that support specified protocols.
 // If specificPeers is nil, all peers in the host's peerStore are considered for filtering.
-func (pm *PeerManager) FilterPeersByProto(specificPeers peer.IDSlice, proto ...protocol.ID) (peer.IDSlice, error) {
+func (pm *PeerManager) FilterPeersByProto(specificPeers peer.IDSlice, excludePeers PeerSet, proto ...protocol.ID) (peer.IDSlice, error) {
 	peerSet := specificPeers
 	if len(peerSet) == 0 {
 		peerSet = pm.host.Peerstore().Peers()
 	}
-
 	var peers peer.IDSlice
 	for _, peer := range peerSet {
 		protocols, err := pm.host.Peerstore().SupportsProtocols(peer, proto...)
 		if err != nil {
 			return nil, err
 		}
-
 		if len(protocols) > 0 {
+			//Maybe we can optimize below set of statements a better way??
+			if PeerInSet(excludePeers, peer) {
+				continue
+			}
 			peers = append(peers, peer)
 		}
 	}
+	pm.logger.Debug("peers selected", zap.Int("peerCnt", len(peers)))
 	return peers, nil
 }

--- a/waku/v2/peermanager/service_slot.go
+++ b/waku/v2/peermanager/service_slot.go
@@ -19,10 +19,10 @@ func newPeerMap() *peerMap {
 	}
 }
 
-func (pm *peerMap) getRandom(count int) (peerSet, error) {
+func (pm *peerMap) getRandom(count int, excludePeers PeerSet) (PeerSet, error) {
 	pm.mu.RLock()
 	defer pm.mu.RUnlock()
-	return getRandom(pm.m, count)
+	return getRandom(pm.m, count, excludePeers)
 }
 
 func (pm *peerMap) remove(pID peer.ID) {

--- a/waku/v2/peermanager/service_slot_test.go
+++ b/waku/v2/peermanager/service_slot_test.go
@@ -1,11 +1,12 @@
 package peermanager
 
 import (
+	"testing"
+
 	"github.com/libp2p/go-libp2p/core/peer"
 	libp2pProtocol "github.com/libp2p/go-libp2p/core/protocol"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/exp/maps"
-	"testing"
 )
 
 func TestServiceSlot(t *testing.T) {
@@ -18,13 +19,13 @@ func TestServiceSlot(t *testing.T) {
 	//
 	slots.getPeers(protocol).add(peerID)
 	//
-	fetchedPeers, err := slots.getPeers(protocol).getRandom(1)
+	fetchedPeers, err := slots.getPeers(protocol).getRandom(1, nil)
 	require.NoError(t, err)
 	require.Equal(t, peerID, maps.Keys(fetchedPeers)[0])
 	//
 	slots.getPeers(protocol).remove(peerID)
 	//
-	_, err = slots.getPeers(protocol).getRandom(1)
+	_, err = slots.getPeers(protocol).getRandom(1, nil)
 	require.Equal(t, err, ErrNoPeersAvailable)
 
 	// Test with more peers
@@ -36,7 +37,7 @@ func TestServiceSlot(t *testing.T) {
 	slots.getPeers(protocol).add(peerID3)
 	//
 
-	fetchedPeers, err = slots.getPeers(protocol).getRandom(2)
+	fetchedPeers, err = slots.getPeers(protocol).getRandom(2, nil)
 	require.NoError(t, err)
 	require.Equal(t, 2, len(maps.Keys(fetchedPeers)))
 
@@ -47,7 +48,7 @@ func TestServiceSlot(t *testing.T) {
 
 	slots.getPeers(protocol).remove(peerID2)
 
-	fetchedPeers, err = slots.getPeers(protocol).getRandom(10)
+	fetchedPeers, err = slots.getPeers(protocol).getRandom(10, nil)
 	require.NoError(t, err)
 	require.Equal(t, peerID3, maps.Keys(fetchedPeers)[0])
 
@@ -65,15 +66,15 @@ func TestServiceSlotRemovePeerFromAll(t *testing.T) {
 	slots.getPeers(protocol).add(peerID)
 	slots.getPeers(protocol1).add(peerID)
 	//
-	fetchedPeers, err := slots.getPeers(protocol1).getRandom(1)
+	fetchedPeers, err := slots.getPeers(protocol1).getRandom(1, nil)
 	require.NoError(t, err)
 	require.Equal(t, peerID, maps.Keys(fetchedPeers)[0])
 
 	//
 	slots.removePeer(peerID)
 	//
-	_, err = slots.getPeers(protocol).getRandom(1)
+	_, err = slots.getPeers(protocol).getRandom(1, nil)
 	require.Equal(t, err, ErrNoPeersAvailable)
-	_, err = slots.getPeers(protocol1).getRandom(1)
+	_, err = slots.getPeers(protocol1).getRandom(1, nil)
 	require.Equal(t, err, ErrNoPeersAvailable)
 }

--- a/waku/v2/protocol/filter/client.go
+++ b/waku/v2/protocol/filter/client.go
@@ -92,6 +92,10 @@ func NewWakuFilterLightNode(broadcaster relay.Broadcaster, pm *peermanager.PeerM
 	return wf
 }
 
+func (wf *WakuFilterLightNode) setPeerPingInterval(duration time.Duration) {
+	wf.peerPingInterval = duration
+}
+
 // Sets the host to be able to mount or consume a protocol
 func (wf *WakuFilterLightNode) SetHost(h host.Host) {
 	wf.h = h
@@ -397,6 +401,7 @@ func (wf *WakuFilterLightNode) Subscribe(ctx context.Context, contentFilter prot
 				failedContentTopics = append(failedContentTopics, cTopics...)
 				continue
 			}
+			wf.log.Debug("subscription successful", zap.String("pubSubTopic", pubSubTopic), zap.Strings("contentTopics", cTopics), zap.Stringer("peer", peer))
 			subscriptions = append(subscriptions, wf.subscriptions.NewSubscription(peer, cFilter))
 		}
 	}

--- a/waku/v2/protocol/filter/client.go
+++ b/waku/v2/protocol/filter/client.go
@@ -466,7 +466,7 @@ func (wf *WakuFilterLightNode) IsSubscriptionAlive(ctx context.Context, subscrip
 		return false
 	}
 	//Don't ping, rather check status of last ping and return status?? or something else.
-	return subscription.Closed
+	return !subscription.Closed
 }
 
 // Unsubscribe is used to stop receiving messages from specified peers for the content filter

--- a/waku/v2/protocol/filter/client.go
+++ b/waku/v2/protocol/filter/client.go
@@ -88,6 +88,7 @@ func NewWakuFilterLightNode(broadcaster relay.Broadcaster, pm *peermanager.PeerM
 	wf.pm = pm
 	wf.CommonService = service.NewCommonService()
 	wf.metrics = newMetrics(reg)
+	wf.peerPingInterval = 5 * time.Second
 	return wf
 }
 
@@ -458,14 +459,14 @@ func (wf *WakuFilterLightNode) Ping(ctx context.Context, peerID peer.ID, opts ..
 		peerID)
 }
 
-func (wf *WakuFilterLightNode) IsSubscriptionAlive(ctx context.Context, subscription *subscription.SubscriptionDetails) error {
+func (wf *WakuFilterLightNode) IsSubscriptionAlive(ctx context.Context, subscription *subscription.SubscriptionDetails) bool {
 	wf.RLock()
 	defer wf.RUnlock()
 	if err := wf.ErrOnNotRunning(); err != nil {
-		return err
+		return false
 	}
-	//TODO: Don't ping, rather check status of last ping and return status?? or something else.
-	return wf.Ping(ctx, subscription.PeerID)
+	//Don't ping, rather check status of last ping and return status?? or something else.
+	return subscription.Closed
 }
 
 // Unsubscribe is used to stop receiving messages from specified peers for the content filter

--- a/waku/v2/protocol/filter/filter_health_check.go
+++ b/waku/v2/protocol/filter/filter_health_check.go
@@ -1,0 +1,32 @@
+package filter
+
+import (
+	"context"
+	"time"
+)
+
+func (wf *WakuFilterLightNode) PingPeers() {
+	//Send a ping to all the peers and report their status to corresponding subscriptions
+	// Alive or not or set state of subcription??
+	for _, peer := range wf.subscriptions.GetSubscribedPeers() {
+		err := wf.Ping(context.TODO(), peer)
+		if err != nil {
+			subscriptions := wf.subscriptions.GetAllSubscriptionsForPeer(peer)
+			for _, subscription := range subscriptions {
+				//Indicating that subscription is closing
+				//This feels like a hack, but taking this approach for now so as to avoid refactoring.
+				subscription.Closing <- true
+			}
+		}
+	}
+}
+
+func (wf *WakuFilterLightNode) FilterHealthCheckLoop() {
+	wf.CommonService.WaitGroup().Add(1)
+	defer wf.WaitGroup().Done()
+	for {
+		//TODO: Do we have to wait for wf.ctx context completion and exit as well?
+		time.Sleep(wf.peerPingInterval)
+		wf.PingPeers()
+	}
+}

--- a/waku/v2/protocol/filter/filter_health_check.go
+++ b/waku/v2/protocol/filter/filter_health_check.go
@@ -24,9 +24,14 @@ func (wf *WakuFilterLightNode) PingPeers() {
 func (wf *WakuFilterLightNode) FilterHealthCheckLoop() {
 	wf.CommonService.WaitGroup().Add(1)
 	defer wf.WaitGroup().Done()
+	ticker := time.NewTicker(wf.peerPingInterval)
+	defer ticker.Stop()
 	for {
-		//TODO: Do we have to wait for wf.ctx context completion and exit as well?
-		time.Sleep(wf.peerPingInterval)
-		wf.PingPeers()
+		select {
+		case <-ticker.C:
+			wf.PingPeers()
+		case <-wf.CommonService.Context().Done():
+			return
+		}
 	}
 }

--- a/waku/v2/protocol/filter/filter_health_check.go
+++ b/waku/v2/protocol/filter/filter_health_check.go
@@ -3,6 +3,8 @@ package filter
 import (
 	"context"
 	"time"
+
+	"go.uber.org/zap"
 )
 
 func (wf *WakuFilterLightNode) PingPeers() {
@@ -11,8 +13,12 @@ func (wf *WakuFilterLightNode) PingPeers() {
 	for _, peer := range wf.subscriptions.GetSubscribedPeers() {
 		err := wf.Ping(context.TODO(), peer)
 		if err != nil {
+			wf.log.Info("Filter ping failed towards peer", zap.Stringer("peer", peer))
+
 			subscriptions := wf.subscriptions.GetAllSubscriptionsForPeer(peer)
 			for _, subscription := range subscriptions {
+				wf.log.Debug("Notifying sub closing", zap.String("subID", subscription.ID))
+
 				//Indicating that subscription is closing
 				//This feels like a hack, but taking this approach for now so as to avoid refactoring.
 				subscription.Closing <- true

--- a/waku/v2/protocol/filter/filter_health_check.go
+++ b/waku/v2/protocol/filter/filter_health_check.go
@@ -21,7 +21,7 @@ func (wf *WakuFilterLightNode) PingPeer(peer peer.ID) {
 	defer cancel()
 	err := wf.Ping(ctxWithTimeout, peer)
 	if err != nil {
-		wf.log.Info("Filter ping failed towards peer", zap.Stringer("peer", peer), zap.Error(err))
+		wf.log.Warn("Filter ping failed towards peer", zap.Stringer("peer", peer), zap.Error(err))
 
 		subscriptions := wf.subscriptions.GetAllSubscriptionsForPeer(peer)
 		for _, subscription := range subscriptions {

--- a/waku/v2/protocol/filter/filter_health_check.go
+++ b/waku/v2/protocol/filter/filter_health_check.go
@@ -28,7 +28,6 @@ func (wf *WakuFilterLightNode) PingPeer(peer peer.ID) {
 			wf.log.Debug("Notifying sub closing", zap.String("subID", subscription.ID))
 
 			//Indicating that subscription is closing,
-			//Can this cause race condition with subscription close?
 			close(subscription.Closing)
 		}
 	}

--- a/waku/v2/protocol/filter/filter_subscribe_test.go
+++ b/waku/v2/protocol/filter/filter_subscribe_test.go
@@ -364,19 +364,8 @@ func (s *FilterTestSuite) TestIsSubscriptionAlive() {
 	s.subscribe(messages[0].PubSubTopic, messages[0].ContentTopic, s.FullNodeHost.ID())
 
 	// IsSubscriptionAlive returns no error for the first message
-	err := s.LightNode.IsSubscriptionAlive(s.ctx, s.subDetails[0])
-	s.Require().NoError(err)
-
-	// Create new host/peer - not related to any node
-	host, err := tests.MakeHost(context.Background(), 54321, rand.Reader)
-	s.Require().NoError(err)
-
-	// Alter the existing peer ID in sub details
-	s.subDetails[0].PeerID = host.ID()
-
-	// IsSubscriptionAlive returns error for the second message, peer ID doesn't match
-	err = s.LightNode.IsSubscriptionAlive(s.ctx, s.subDetails[0])
-	s.Require().Error(err)
+	isAlive := s.LightNode.IsSubscriptionAlive(s.ctx, s.subDetails[0])
+	s.Require().Equal(true, isAlive)
 
 }
 

--- a/waku/v2/protocol/filter/filter_subscribe_test.go
+++ b/waku/v2/protocol/filter/filter_subscribe_test.go
@@ -357,18 +357,6 @@ func (s *FilterTestSuite) TestSubscribeFullNode2FullNode() {
 
 }
 
-func (s *FilterTestSuite) TestIsSubscriptionAlive() {
-	messages := s.prepareData(2, false, true, false, nil)
-
-	// Subscribe with the first message only
-	s.subscribe(messages[0].PubSubTopic, messages[0].ContentTopic, s.FullNodeHost.ID())
-
-	// IsSubscriptionAlive returns no error for the first message
-	isAlive := s.LightNode.IsSubscriptionAlive(s.ctx, s.subDetails[0])
-	s.Require().Equal(true, isAlive)
-
-}
-
 func (s *FilterTestSuite) TestFilterSubscription() {
 	contentFilter := protocol.ContentFilter{PubsubTopic: s.TestTopic, ContentTopics: protocol.NewContentTopicSet(s.TestContentTopic)}
 

--- a/waku/v2/protocol/filter/filter_subscribe_test.go
+++ b/waku/v2/protocol/filter/filter_subscribe_test.go
@@ -324,7 +324,7 @@ func (s *FilterTestSuite) TestSubscribeFullNode2FullNode() {
 	s.ctx, s.ctxCancel = context.WithTimeout(context.Background(), 10*time.Second)
 
 	nodeData := s.GetWakuFilterFullNode(testTopic, false)
-	fullNode2 := nodeData.fullNode
+	fullNode2 := nodeData.FullNode
 
 	// Connect nodes
 	fullNode2.h.Peerstore().AddAddr(s.FullNodeHost.ID(), tests.GetHostAddress(s.FullNodeHost), peerstore.PermanentAddrTTL)

--- a/waku/v2/protocol/filter/filter_test.go
+++ b/waku/v2/protocol/filter/filter_test.go
@@ -7,9 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/libp2p/go-libp2p/core/peerstore"
 	"github.com/stretchr/testify/suite"
-	"github.com/waku-org/go-waku/tests"
 	"github.com/waku-org/go-waku/waku/v2/protocol"
 	"github.com/waku-org/go-waku/waku/v2/service"
 	"github.com/waku-org/go-waku/waku/v2/utils"
@@ -46,6 +44,7 @@ func (s *FilterTestSuite) TestFireAndForgetAndCustomWg() {
 	s.Require().NoError(err)
 
 	result, err := s.LightNode.Unsubscribe(s.ctx, contentFilter, DontWait())
+
 	s.Require().NoError(err)
 	s.Require().Equal(0, len(result.Errors()))
 
@@ -109,10 +108,7 @@ func (s *FilterTestSuite) TestAutoShard() {
 	s.MakeWakuFilterLightNode()
 	s.StartLightNode()
 	s.MakeWakuFilterFullNode(pubSubTopic.String(), false)
-
-	s.LightNodeHost.Peerstore().AddAddr(s.FullNodeHost.ID(), tests.GetHostAddress(s.FullNodeHost), peerstore.PermanentAddrTTL)
-	err = s.LightNodeHost.Peerstore().AddProtocols(s.FullNodeHost.ID(), FilterSubscribeID_v20beta1)
-	s.Require().NoError(err)
+	s.ConnectToFullNode(s.LightNode, s.FullNode)
 
 	s.Log.Info("Testing Autoshard:CreateSubscription")
 	s.subscribe("", s.TestContentTopic, s.FullNodeHost.ID())
@@ -210,7 +206,7 @@ func (s *FilterTestSuite) TestStaticSharding() {
 	s.MakeWakuFilterFullNode(s.TestTopic, false)
 
 	// Connect nodes
-	s.ConnectHosts(s.LightNodeHost, s.FullNodeHost)
+	s.ConnectToFullNode(s.LightNode, s.FullNode)
 
 	s.subscribe(s.TestTopic, s.TestContentTopic, s.FullNodeHost.ID())
 

--- a/waku/v2/protocol/filter/filter_test.go
+++ b/waku/v2/protocol/filter/filter_test.go
@@ -92,7 +92,7 @@ func (s *FilterTestSuite) TestAutoShard() {
 
 	//Workaround as could not find a way to reuse setup test with params
 	// Stop what is run in setup
-	s.fullNode.Stop()
+	s.FullNode.Stop()
 	s.LightNode.Stop()
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second) // Test can't exceed 10 seconds
 	s.ctx = ctx

--- a/waku/v2/protocol/filter/filter_unsubscribe_test.go
+++ b/waku/v2/protocol/filter/filter_unsubscribe_test.go
@@ -80,7 +80,7 @@ func (s *FilterTestSuite) TestUnsubscribeMultiPubSubMultiContentTopic() {
 	s.MakeWakuFilterFullNode(s.TestTopic, true)
 
 	// Connect nodes
-	s.LightNodeHost.Peerstore().AddAddr(s.FullNodeHost.ID(), tests.GetHostAddress(s.fullNode.h), peerstore.PermanentAddrTTL)
+	s.LightNodeHost.Peerstore().AddAddr(s.FullNodeHost.ID(), tests.GetHostAddress(s.FullNode.h), peerstore.PermanentAddrTTL)
 	err := s.LightNodeHost.Peerstore().AddProtocols(s.FullNodeHost.ID(), FilterSubscribeID_v20beta1)
 	s.Require().NoError(err)
 
@@ -211,7 +211,7 @@ func (s *FilterTestSuite) TestUnsubscribeAllDiffPubSubContentTopics() {
 	s.MakeWakuFilterFullNode(s.TestTopic, true)
 
 	// Connect nodes
-	s.LightNodeHost.Peerstore().AddAddr(s.FullNodeHost.ID(), tests.GetHostAddress(s.fullNode.h), peerstore.PermanentAddrTTL)
+	s.LightNodeHost.Peerstore().AddAddr(s.FullNodeHost.ID(), tests.GetHostAddress(s.FullNode.h), peerstore.PermanentAddrTTL)
 	err := s.LightNodeHost.Peerstore().AddProtocols(s.FullNodeHost.ID(), FilterSubscribeID_v20beta1)
 	s.Require().NoError(err)
 

--- a/waku/v2/protocol/filter/options.go
+++ b/waku/v2/protocol/filter/options.go
@@ -39,6 +39,7 @@ type (
 		peerAddr          multiaddr.Multiaddr
 		peerSelectionType peermanager.PeerSelection
 		preferredPeers    peer.IDSlice
+		peersToExclude    peermanager.PeerSet
 		maxPeers          int
 		requestID         []byte
 		log               *zap.Logger
@@ -101,6 +102,14 @@ func WithMaxPeersPerContentFilter(numPeers int) FilterSubscribeOption {
 	}
 }
 
+// WithPeersToExclude option excludes the peers that are specified from selection
+func WithPeersToExclude(peers ...peer.ID) FilterSubscribeOption {
+	return func(params *FilterSubscribeParameters) error {
+		params.peersToExclude = peermanager.PeerSliceToMap(peers)
+		return nil
+	}
+}
+
 // WithAutomaticPeerSelection is an option used to randomly select a peer from the peer store.
 // If a list of specific peers is passed, the peer will be chosen from that list assuming it
 // supports the chosen protocol, otherwise it will chose a peer from the node peerstore
@@ -145,6 +154,7 @@ func DefaultSubscriptionOptions() []FilterSubscribeOption {
 	return []FilterSubscribeOption{
 		WithAutomaticPeerSelection(),
 		WithAutomaticRequestID(),
+		WithMaxPeersPerContentFilter(1),
 	}
 }
 

--- a/waku/v2/protocol/filter/test_utils.go
+++ b/waku/v2/protocol/filter/test_utils.go
@@ -32,7 +32,7 @@ type FullNodeData struct {
 	RelaySub     *relay.Subscription
 	FullNodeHost host.Host
 	Broadcaster  relay.Broadcaster
-	fullNode     *WakuFilterFullNode
+	FullNode     *WakuFilterFullNode
 }
 
 type FilterTestSuite struct {
@@ -78,6 +78,7 @@ func (s *FilterTestSuite) SetupTest() {
 	s.TestContentTopic = DefaultTestContentTopic
 
 	s.MakeWakuFilterLightNode()
+	s.LightNode.setPeerPingInterval(1 * time.Second)
 	s.StartLightNode()
 
 	//TODO: Add tests to verify broadcaster.
@@ -89,7 +90,7 @@ func (s *FilterTestSuite) SetupTest() {
 }
 
 func (s *FilterTestSuite) TearDownTest() {
-	s.fullNode.Stop()
+	s.FullNode.Stop()
 	s.LightNode.Stop()
 	s.RelaySub.Unsubscribe()
 	s.LightNode.Stop()
@@ -142,7 +143,7 @@ func (s *FilterTestSuite) GetWakuFilterFullNode(topic string, withRegisterAll bo
 	err := node2Filter.Start(s.ctx, sub)
 	s.Require().NoError(err)
 
-	nodeData.fullNode = node2Filter
+	nodeData.FullNode = node2Filter
 
 	return nodeData
 }

--- a/waku/v2/protocol/filter/test_utils.go
+++ b/waku/v2/protocol/filter/test_utils.go
@@ -78,7 +78,7 @@ func (s *FilterTestSuite) SetupTest() {
 	s.TestContentTopic = DefaultTestContentTopic
 
 	s.MakeWakuFilterLightNode()
-	s.LightNode.setPeerPingInterval(1 * time.Second)
+	s.LightNode.peerPingInterval = 1 * time.Second
 	s.StartLightNode()
 
 	//TODO: Add tests to verify broadcaster.

--- a/waku/v2/protocol/filter/test_utils.go
+++ b/waku/v2/protocol/filter/test_utils.go
@@ -101,8 +101,6 @@ func (s *FilterTestSuite) TearDownTest() {
 func (s *FilterTestSuite) ConnectToFullNode(h1 *WakuFilterLightNode, h2 *WakuFilterFullNode) {
 	mAddr := tests.GetAddr(h2.h)
 	_, err := h1.pm.AddPeer(mAddr, wps.Static, []string{s.TestTopic}, FilterSubscribeID_v20beta1)
-	//h1.Peerstore().AddAddr(h2.ID(), tests.GetHostAddress(h2), peerstore.PermanentAddrTTL)
-	//err := h1.Peerstore().AddProtocols(h2.ID())
 	s.Log.Info("add peer", zap.Stringer("mAddr", mAddr))
 	s.Require().NoError(err)
 }

--- a/waku/v2/protocol/subscription/subscription_details.go
+++ b/waku/v2/protocol/subscription/subscription_details.go
@@ -25,10 +25,11 @@ type PeerContentFilter struct {
 type SubscriptionDetails struct {
 	sync.RWMutex
 
-	ID     string `json:"subscriptionID"`
-	mapRef *SubscriptionsMap
-	Closed bool `json:"-"`
-	once   sync.Once
+	ID      string `json:"subscriptionID"`
+	mapRef  *SubscriptionsMap
+	Closed  bool `json:"-"`
+	once    sync.Once
+	Closing chan bool
 
 	PeerID        peer.ID                 `json:"peerID"`
 	ContentFilter protocol.ContentFilter  `json:"contentFilters"`
@@ -96,7 +97,7 @@ func (s *SubscriptionDetails) CloseC() {
 	s.once.Do(func() {
 		s.Lock()
 		defer s.Unlock()
-
+		close(s.Closing)
 		s.Closed = true
 		close(s.C)
 	})

--- a/waku/v2/protocol/subscription/subscription_details.go
+++ b/waku/v2/protocol/subscription/subscription_details.go
@@ -29,7 +29,7 @@ type SubscriptionDetails struct {
 	mapRef  *SubscriptionsMap
 	Closed  bool `json:"-"`
 	once    sync.Once
-	Closing chan bool
+	Closing chan struct{}
 
 	PeerID        peer.ID                 `json:"peerID"`
 	ContentFilter protocol.ContentFilter  `json:"contentFilters"`
@@ -97,7 +97,7 @@ func (s *SubscriptionDetails) CloseC() {
 	s.once.Do(func() {
 		s.Lock()
 		defer s.Unlock()
-		close(s.Closing)
+		close(s.Closing) //Can this cause race condition with healthcheck??
 		s.Closed = true
 		close(s.C)
 	})

--- a/waku/v2/protocol/subscription/subscription_details.go
+++ b/waku/v2/protocol/subscription/subscription_details.go
@@ -97,7 +97,6 @@ func (s *SubscriptionDetails) CloseC() {
 	s.once.Do(func() {
 		s.Lock()
 		defer s.Unlock()
-		close(s.Closing) //Can this cause race condition with healthcheck??
 		s.Closed = true
 		close(s.C)
 	})

--- a/waku/v2/protocol/subscription/subscriptions_map.go
+++ b/waku/v2/protocol/subscription/subscriptions_map.go
@@ -75,6 +75,7 @@ func (sub *SubscriptionsMap) NewSubscription(peerID peer.ID, cf protocol.Content
 		PeerID:        peerID,
 		C:             make(chan *protocol.Envelope, 1024),
 		ContentFilter: protocol.ContentFilter{PubsubTopic: cf.PubsubTopic, ContentTopics: maps.Clone(cf.ContentTopics)},
+		Closing:       make(chan bool),
 	}
 
 	// Increase the number of subscriptions for this (pubsubTopic, contentTopic) pair
@@ -216,6 +217,30 @@ func (m *SubscriptionsMap) GetSubscriptionsForPeer(peerID peer.ID, contentFilter
 		}
 	}
 	return output
+}
+
+func (m *SubscriptionsMap) GetAllSubscriptionsForPeer(peerID peer.ID) []*SubscriptionDetails {
+	m.RLock()
+	defer m.RUnlock()
+
+	var output []*SubscriptionDetails
+	for _, peerSubs := range m.items {
+		if peerSubs.PeerID == peerID {
+			for _, subs := range peerSubs.SubsPerPubsubTopic {
+				for _, subscriptionDetail := range subs {
+					output = append(output, subscriptionDetail)
+				}
+			}
+			break
+		}
+	}
+	return output
+}
+
+func (m *SubscriptionsMap) GetSubscribedPeers() peer.IDSlice {
+	m.RLock()
+	defer m.RUnlock()
+	return maps.Keys(m.items)
 }
 
 func (m *SubscriptionsMap) GetAllSubscriptions() []*SubscriptionDetails {

--- a/waku/v2/protocol/subscription/subscriptions_map.go
+++ b/waku/v2/protocol/subscription/subscriptions_map.go
@@ -75,7 +75,7 @@ func (sub *SubscriptionsMap) NewSubscription(peerID peer.ID, cf protocol.Content
 		PeerID:        peerID,
 		C:             make(chan *protocol.Envelope, 1024),
 		ContentFilter: protocol.ContentFilter{PubsubTopic: cf.PubsubTopic, ContentTopics: maps.Clone(cf.ContentTopics)},
-		Closing:       make(chan bool),
+		Closing:       make(chan struct{}),
 	}
 
 	// Increase the number of subscriptions for this (pubsubTopic, contentTopic) pair


### PR DESCRIPTION
# Description
Implementing #1099 , realized that there are some issues wrt approach taken in https://github.com/waku-org/go-waku/pull/1048

Following are the issues being addressed/to be addressed:
1. For each subscription towards same peer, pings are sent which is unnecessary traffic periodically
2. There is no check that if a Filter ping fails , a susbcribe is done what if it already chooses another peer for which we have subscription against? (tracked https://github.com/waku-org/go-waku/issues/1104)


Taking an approach to not send an actual ping via Filter Subscription Ping API, rather check status of last ping. And trying to no refactor code much, so that we can check results faster. 

Note: Tests are still pending.

Approach/Impementation Details:
- Have a separate go-routine that collates unique peers from all subscriptions and sends a ping once in 5 seconds to each peer
- If the ping fails, the same is notified in the subscription Closing channel(indicating that this subscription is closing..could use better wording i guess)
- Filter API layer would then use this indication to take further actions such as resubscribing to another peer (Note that there is still a possible issue indicate in point-2 above that needs to be fixed)
- Going forward, this same indication can be used to take actions such as initiate storev3 queries for this subscription based and compare with local message cache and fetch any missed messages from store node.

Pending Items:

- [x] Unit tests to validate new logic
- [x] https://github.com/waku-org/go-waku/issues/1104
- [x] Update Filter API test to subscribe to a new peer