### PR TITLE
fix(lightpush): return non-empty reqId and add LP opts to builder

### DIFF
--- a/waku/v2/node/wakunode2.go
+++ b/waku/v2/node/wakunode2.go
@@ -291,7 +291,7 @@ func New(opts ...WakuNodeOption) (*WakuNode, error) {
 
 	w.filterFullNode = filter.NewWakuFilterFullNode(w.timesource, w.opts.prometheusReg, w.log, w.opts.filterOpts...)
 	w.filterLightNode = filter.NewWakuFilterLightNode(w.bcaster, w.peermanager, w.timesource, w.opts.prometheusReg, w.log)
-	w.lightPush = lightpush.NewWakuLightPush(w.Relay(), w.peermanager, w.opts.prometheusReg, w.log)
+	w.lightPush = lightpush.NewWakuLightPush(w.Relay(), w.peermanager, w.opts.prometheusReg, w.log, w.opts.lightpushOpts...)
 
 	w.store = store.NewWakuStore(w.peermanager, w.timesource, w.log)
 

--- a/waku/v2/node/wakuoptions.go
+++ b/waku/v2/node/wakuoptions.go
@@ -28,6 +28,7 @@ import (
 	"github.com/waku-org/go-waku/waku/v2/peermanager"
 	"github.com/waku-org/go-waku/waku/v2/protocol/filter"
 	"github.com/waku-org/go-waku/waku/v2/protocol/legacy_store"
+	"github.com/waku-org/go-waku/waku/v2/protocol/lightpush"
 	"github.com/waku-org/go-waku/waku/v2/protocol/pb"
 	"github.com/waku-org/go-waku/waku/v2/rendezvous"
 	"github.com/waku-org/go-waku/waku/v2/timesource"
@@ -77,6 +78,7 @@ type WakuNodeParameters struct {
 	enableFilterFullNode  bool
 	filterOpts            []filter.Option
 	pubsubOpts            []pubsub.Option
+	lightpushOpts         []lightpush.Option
 
 	minRelayPeersToPublish int
 	maxMsgSizeBytes        int
@@ -458,9 +460,10 @@ func WithMessageProvider(s legacy_store.MessageProvider) WakuNodeOption {
 }
 
 // WithLightPush is a WakuNodeOption that enables the lightpush protocol
-func WithLightPush() WakuNodeOption {
+func WithLightPush(lightpushOpts ...lightpush.Option) WakuNodeOption {
 	return func(params *WakuNodeParameters) error {
 		params.enableLightPush = true
+		params.lightpushOpts = lightpushOpts
 		return nil
 	}
 }

--- a/waku/v2/protocol/lightpush/pb/validation.go
+++ b/waku/v2/protocol/lightpush/pb/validation.go
@@ -2,6 +2,10 @@ package pb
 
 import "errors"
 
+// This special value for requestId indicates that the message was rate limited
+// and we did not retreive the requestId to avoid a potential attack vector.
+const REQUESTID_RATE_LIMITED = "N/A"
+
 var (
 	errMissingRequestID   = errors.New("missing RequestId field")
 	errMissingQuery       = errors.New("missing Query field")
@@ -32,6 +36,9 @@ func (x *PushRpc) ValidateRequest() error {
 }
 
 func (x *PushRpc) ValidateResponse(requestID string) error {
+	if x.RequestId == REQUESTID_RATE_LIMITED {
+		return nil
+	}
 	if x.RequestId == "" {
 		return errMissingRequestID
 	}

--- a/waku/v2/protocol/lightpush/waku_lightpush.go
+++ b/waku/v2/protocol/lightpush/waku_lightpush.go
@@ -108,6 +108,7 @@ func (wakuLP *WakuLightPush) onRequest(ctx context.Context) func(network.Stream)
 			wakuLP.metrics.RecordError(rateLimitFailure)
 			responseMsg := "exceeds the rate limit"
 			responsePushRPC.Response.Info = &responseMsg
+			responsePushRPC.RequestId = pb.REQUESTID_RATE_LIMITED
 			wakuLP.reply(stream, responsePushRPC, logger)
 			return
 		}


### PR DESCRIPTION
# Description
This PR adds missing Lightpush options to `withLightpush()` builder function. It also fixes a missing `requestId` issue which resulted in rate limitting errors showing up as `missing RequestId field` error.

It also enhances `fitler2` example to setup lightpush on the full node with rate limit to allow for some basic experimentation.

# Changes

<!-- List of detailed changes -->

- [x] New constant `REQUESTID_RATE_LIMITED` is defined to indicate the request was rate limited
- [x] `ValidateResponse` now returns without error when the above constant is `requestId` value
- [x] Lightpush server sets the above constant as a `requestId` when the rate limit is hit
- [x] `withLightpush()` now accepts `lightpush.Option` (i.e. `rate.Limiter` at the moment)

# Tests

<!-- List down any tests that were executed specifically for this pull-request -->



<!--
## How to test

1. `make` the `fitler2` example 
1. Run it and see no errors
1. Change the sleep value in `writeLightpushLoop` to `500ms`
1. See every other Lightpush request fail with rate limit exceeded error

-->


<!--
## Issue

closes #
-->
