### PR TITLE
fix: dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,6 +2,5 @@ README.md
 Dockerfile
 .*ignore
 LICENSE*
-tests
 examples
 *.db

--- a/flake.nix
+++ b/flake.nix
@@ -29,7 +29,7 @@
           ];
           doCheck = false;
           # FIXME: This needs to be manually changed when updating modules.
-          vendorSha256 = "sha256-sl46fu5IGxjGNERJxRFb1ujdRvPf9AZlwKR2z/F5/lI=";
+          vendorSha256 = "sha256-FNG4fq7B2/86Mhk1vgFTcsgQ6Xg1A6W0PrmY82iUTro=";
           # Fix for 'nix run' trying to execute 'go-waku'.
           meta = { mainProgram = "waku"; };
         };


### PR DESCRIPTION
Fixes this error:
```
22:55:49   > [builder 4/4] RUN make -j$(nproc) build:
22:55:49  2.885 go: downloading github.com/syndtr/goleveldb v1.0.1-0.20220614013038-64ee5596c38a
22:55:49  2.897 go: downloading github.com/quic-go/qtls-go1-20 v0.3.4
22:55:49  2.900 go: downloading github.com/shirou/gopsutil v3.21.4-0.20210419000835-c7a38de76ee5+incompatible
22:55:49  2.907 go: downloading github.com/btcsuite/btcutil v0.0.0-20190425235716-9e5f4b9a998d
22:55:49  2.931 go: downloading github.com/golang/snappy v0.0.4
22:55:49  2.962 go: downloading github.com/tklauser/go-sysconf v0.3.5
22:55:49  2.991 go: downloading github.com/tklauser/numcpus v0.2.2
22:55:49  6.162 waku/v2/protocol/filter/test_utils.go:16:2: no required module provides package github.com/waku-org/go-waku/tests; to add it:
22:55:49  6.162     go get github.com/waku-org/go-waku/tests
22:55:49  6.167 make: *** [Makefile:57: build] Error 1
22:55:49  ------
22:55:49  Dockerfile:8
22:55:49  --------------------
22:55:49     6 |     
22:55:49     7 |     # Build the final node binary
22:55:49     8 | >>> RUN make -j$(nproc) build
22:55:49     9 |     
22:55:49    10 |     # ACTUAL IMAGE -------------------------------------------------------
22:55:49  --------------------
22:55:49  ERROR: failed to solve: process "/bin/sh -c make -j$(nproc) build" did not complete successfully: exit code: 2
```