### PR TITLE
fix: allow peer-selection without pubsubTopics

### DIFF
--- a/waku/v2/peermanager/peer_connector.go
+++ b/waku/v2/peermanager/peer_connector.go
@@ -130,7 +130,7 @@ func (c *PeerConnectionStrategy) consumeSubscription(s subscription) {
 				if len(c.host.Network().Peers()) < waku_proto.GossipSubDMin {
 					triggerImmediateConnection = true
 				}
-				c.logger.Debug("adding discovered peer", logging.HostID("peerID", p.AddrInfo.ID))
+				c.logger.Debug("adding discovered peer", logging.HostID("peerID", p.AddrInfo.ID), zap.Int64("origin", int64(p.Origin)))
 				c.pm.AddDiscoveredPeer(p, triggerImmediateConnection)
 
 			case <-time.After(1 * time.Second):


### PR DESCRIPTION
# Description
Noticed that peer-selection always assumes supported pubsubTopics are known for a peer. 
Added a functionality to not use pubsubTopic filter as selection if it is not passed in selectionCriteria. 
But not sure if this is a valid peer selection mechanism.

Considering peers that are discovered in status-go seemed to get added without pubsubTopic list.

Note: I am not 100% sure if this is required. Will keep this in draft until i get clarity.
