### PR TITLE
fix: crash noticed while adding existing peer that doesn't have an ENR

### DIFF
--- a/cmd/waku/node.go
+++ b/cmd/waku/node.go
@@ -331,7 +331,7 @@ func Execute(options NodeOptions) error {
 	}
 
 	for _, d := range discoveredNodes {
-		wakuNode.AddDiscoveredPeer(d.PeerID, d.PeerInfo.Addrs, wakupeerstore.DNSDiscovery, nil, true)
+		wakuNode.AddDiscoveredPeer(d.PeerID, d.PeerInfo.Addrs, wakupeerstore.DNSDiscovery, nil, d.ENR, true)
 	}
 
 	//For now assuming that static peers added support/listen on all topics specified via commandLine.

--- a/waku/v2/node/connectedness_test.go
+++ b/waku/v2/node/connectedness_test.go
@@ -74,7 +74,7 @@ func TestConnectionStatusChanges(t *testing.T) {
 
 	goCheckConnectedness(t, &wg, topicHealthStatusChan, peermanager.MinimallyHealthy)
 
-	node1.AddDiscoveredPeer(node2.host.ID(), node2.ListenAddresses(), peerstore.Static, []string{pubsubTopic}, true)
+	node1.AddDiscoveredPeer(node2.host.ID(), node2.ListenAddresses(), peerstore.Static, []string{pubsubTopic}, nil, true)
 
 	wg.Wait()
 

--- a/waku/v2/node/wakunode2.go
+++ b/waku/v2/node/wakunode2.go
@@ -698,7 +698,7 @@ func (w *WakuNode) AddPeer(address ma.Multiaddr, origin wps.Origin, pubSubTopics
 }
 
 // AddDiscoveredPeer to add a discovered peer to the node peerStore
-func (w *WakuNode) AddDiscoveredPeer(ID peer.ID, addrs []ma.Multiaddr, origin wps.Origin, pubsubTopics []string, connectNow bool) {
+func (w *WakuNode) AddDiscoveredPeer(ID peer.ID, addrs []ma.Multiaddr, origin wps.Origin, pubsubTopics []string, enr *enode.Node, connectNow bool) {
 	p := service.PeerData{
 		Origin: origin,
 		AddrInfo: peer.AddrInfo{
@@ -706,6 +706,7 @@ func (w *WakuNode) AddDiscoveredPeer(ID peer.ID, addrs []ma.Multiaddr, origin wp
 			Addrs: addrs,
 		},
 		PubsubTopics: pubsubTopics,
+		ENR:          enr,
 	}
 	w.peermanager.AddDiscoveredPeer(p, connectNow)
 }

--- a/waku/v2/peermanager/peer_manager.go
+++ b/waku/v2/peermanager/peer_manager.go
@@ -431,17 +431,17 @@ func (pm *PeerManager) AddDiscoveredPeer(p service.PeerData, connectNow bool) {
 	if err == nil {
 		enr, err := pm.host.Peerstore().(wps.WakuPeerstore).ENR(p.AddrInfo.ID)
 		// Verifying if the enr record is more recent (DiscV5 and peer exchange can return peers already seen)
-		if err == nil && enr.Record().Seq() >= p.ENR.Seq() {
-			return
-		}
-		if err != nil {
-			//Peer is already in peer-store but it doesn't have an enr, but discovered peer has ENR
-			pm.logger.Info("peer already found in peerstore, but doesn't have an ENR record, re-adding",
-				logging.HostID("peer", p.AddrInfo.ID), zap.Uint64("newENRSeq", p.ENR.Seq()))
-		} else {
+		if err == nil {
+			if enr.Record().Seq() >= p.ENR.Seq() {
+				return
+			}
 			//Peer is already in peer-store but stored ENR is older than discovered one.
 			pm.logger.Info("peer already found in peerstore, but re-adding it as ENR sequence is higher than locally stored",
 				logging.HostID("peer", p.AddrInfo.ID), zap.Uint64("newENRSeq", p.ENR.Seq()), zap.Uint64("storedENRSeq", enr.Record().Seq()))
+		} else {
+			//Peer is in peer-store but it doesn't have an enr
+			pm.logger.Info("peer already found in peerstore, but doesn't have an ENR record, re-adding",
+				logging.HostID("peer", p.AddrInfo.ID))
 		}
 	}
 

--- a/waku/v2/peermanager/peer_manager.go
+++ b/waku/v2/peermanager/peer_manager.go
@@ -432,12 +432,16 @@ func (pm *PeerManager) AddDiscoveredPeer(p service.PeerData, connectNow bool) {
 		enr, err := pm.host.Peerstore().(wps.WakuPeerstore).ENR(p.AddrInfo.ID)
 		// Verifying if the enr record is more recent (DiscV5 and peer exchange can return peers already seen)
 		if err == nil {
-			if enr.Record().Seq() >= p.ENR.Seq() {
-				return
+			if p.ENR != nil {
+				if enr.Record().Seq() >= p.ENR.Seq() {
+					return
+				}
+				//Peer is already in peer-store but stored ENR is older than discovered one.
+				pm.logger.Info("peer already found in peerstore, but re-adding it as ENR sequence is higher than locally stored",
+					logging.HostID("peer", p.AddrInfo.ID), zap.Uint64("newENRSeq", p.ENR.Seq()), zap.Uint64("storedENRSeq", enr.Record().Seq()))
+			} else {
+				pm.logger.Info("peer already found in peerstore, but no new ENR", logging.HostID("peer", p.AddrInfo.ID))
 			}
-			//Peer is already in peer-store but stored ENR is older than discovered one.
-			pm.logger.Info("peer already found in peerstore, but re-adding it as ENR sequence is higher than locally stored",
-				logging.HostID("peer", p.AddrInfo.ID), zap.Uint64("newENRSeq", p.ENR.Seq()), zap.Uint64("storedENRSeq", enr.Record().Seq()))
 		} else {
 			//Peer is in peer-store but it doesn't have an enr
 			pm.logger.Info("peer already found in peerstore, but doesn't have an ENR record, re-adding",

--- a/waku/v2/peermanager/peer_selection.go
+++ b/waku/v2/peermanager/peer_selection.go
@@ -67,7 +67,6 @@ func (pm *PeerManager) SelectRandom(criteria PeerSelectionCriteria) (peer.IDSlic
 		peerIDs = make(PeerSet)
 	}
 	// if not found in serviceSlots or proto == WakuRelayIDv200
-	pm.logger.Debug("looking for peers in peerStore", zap.String("proto", string(criteria.Proto)))
 	filteredPeers, err := pm.FilterPeersByProto(criteria.SpecificPeers, criteria.ExcludePeers, criteria.Proto)
 	if err != nil {
 		return nil, err
@@ -253,6 +252,5 @@ func (pm *PeerManager) FilterPeersByProto(specificPeers peer.IDSlice, excludePee
 			peers = append(peers, peer)
 		}
 	}
-	pm.logger.Debug("peers selected", zap.Int("peerCnt", len(peers)))
 	return peers, nil
 }


### PR DESCRIPTION
# Description
When rebasing from develop onto https://github.com/status-im/status-go/pull/4665 , had noticed that when i run Filter test in status-go, there is a crash due to hitting a scenario where peer is already in peerStore and again being added via discovery but doesn't have ENR. 

The log statement is causing a crash.

following is the backtrace

```
signal SIGSEGV: segmentation violation code=0x2 addr=0x0 pc=0x1013cb770]

goroutine 391 [running]:
github.com/ethereum/go-ethereum/p2p/enode.(*Node).Seq(0x14000923230?)
	/Users/prem/Code/bkp/status-go/vendor/github.com/ethereum/go-ethereum/p2p/enode/node.go:89
github.com/waku-org/go-waku/waku/v2/peermanager.(*PeerManager).AddDiscoveredPeer(0x140000da210, {0x4, {{0x14000923230, 0x27}, {0x140002cb780, 0x3, 0x4}}, 0x0, {0x140008d2c40, 0x1, ...}}, ...)
	/Users/prem/Code/bkp/status-go/vendor/github.com/waku-org/go-waku/waku/v2/peermanager/peer_manager.go:440 +0x1f4
github.com/waku-org/go-waku/waku/v2/node.(*WakuNode).AddDiscoveredPeer(...)
	/Users/prem/Code/bkp/status-go/vendor/github.com/waku-org/go-waku/waku/v2/node/wakunode2.go:710
github.com/status-im/status-go/wakuv2.(*Waku).connect(0x140004fa000, {{0x14000923230, 0x27}, {0x140002cb780, 0x3, 0x4}}, 0x4)
	/Users/prem/Code/bkp/status-go/wakuv2/waku.go:452 +0x124
created by github.com/status-im/status-go/wakuv2.(*Waku).runPeerExchangeLoop
	/Users/prem/Code/bkp/status-go/wakuv2/waku.go:523 +0x570
exit status 2
FAIL	github.com/status-im/status-go/wakuv2	6.591s

```

# Changes


- [x] Fixes this case which was not handled in AddDiscoveredPeer
- [x] Removed some debug logs in peer selection that may cause flooding.
- [x] Update AddDiscoveredPeer API in wakuNode to take in an optional ENR
