### PR TITLE
fix: remove stale entry in subscription map and update filter ping interval

### DIFF
--- a/waku/v2/protocol/filter/client.go
+++ b/waku/v2/protocol/filter/client.go
@@ -88,7 +88,7 @@ func NewWakuFilterLightNode(broadcaster relay.Broadcaster, pm *peermanager.PeerM
 	wf.pm = pm
 	wf.CommonService = service.NewCommonService()
 	wf.metrics = newMetrics(reg)
-	wf.peerPingInterval = 5 * time.Second
+	wf.peerPingInterval = 1 * time.Minute
 	return wf
 }
 

--- a/waku/v2/protocol/subscription/subscriptions_map.go
+++ b/waku/v2/protocol/subscription/subscriptions_map.go
@@ -147,6 +147,11 @@ func (sub *SubscriptionsMap) Delete(subscription *SubscriptionDetails) error {
 		sub.decreaseSubFor(contentFilter.PubsubTopic, contentTopic)
 	}
 
+	if len(peerSubscription.SubsPerPubsubTopic) == 0 {
+		sub.logger.Debug("no more subs for peer", zap.Stringer("id", subscription.PeerID))
+		delete(sub.items, subscription.PeerID)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
While dogfooding filter, noticed that there is a stale entry left in subscriptions map if all subscriptions to a peer are unsubscribed. This was leading to sending un-necessary pings leading to 404 error. 

Added logic to remove from the map.

Also, realized the fliter ping interval is too aggresive i.e 5 seconds and increased it to 1 minute. 