### PR TITLE
fix: add peer addresses on expiry if peer is discovered again

### DIFF
--- a/waku/v2/protocol/relay/waku_relay.go
+++ b/waku/v2/protocol/relay/waku_relay.go
@@ -513,7 +513,7 @@ func (w *WakuRelay) unsubscribeFromPubsubTopic(topicData *pubsubTopicSubscriptio
 
 	err := topicData.topic.Close()
 	if err != nil {
-		w.log.Error("failed to close the pubsubTopic", zap.String("topic", pubSubTopic))
+		w.log.Error("failed to close the pubsubTopic", zap.String("topic", pubSubTopic), zap.Error(err))
 		return err
 	}
 
@@ -521,7 +521,7 @@ func (w *WakuRelay) unsubscribeFromPubsubTopic(topicData *pubsubTopicSubscriptio
 
 	err = w.pubsub.UnregisterTopicValidator(pubSubTopic)
 	if err != nil {
-		w.log.Error("failed to unregister topic validator", zap.String("topic", pubSubTopic))
+		w.log.Error("failed to unregister topic validator", zap.String("topic", pubSubTopic), zap.Error(err))
 		return err
 	}
 


### PR DESCRIPTION
# Description
While testing https://github.com/status-im/status-go/pull/5350 after enabling peerExchangeClient, had noticed a good number of peer connection failures happen because of peer addresses expiring. 
If a peer is discovered dynamically, its address TTL i set to default value which is 1 hour. 
Eventhough the peer is discovered again later, only the ENR is updated in case of a change. This results in addresses being expired and hence failing to connect to these peers with error "no addresses".

`ERROR[06-14|15:41:07.989|github.com/waku-org/go-waku/waku/v2/protocol/filter/client.go:405]                          Failed to subscribe                      pubSubTopic=/waku/2/rs/16/32 contentTopics=[/waku/1/0x7135123e/rfc26] error="failed to dial: failed to dial 16Uiu2HAkuanZeK281yniUVD9pUMWoBe2MjSknjy5gLB5LuhJj1Bk: no addresses"`

# Changes

<!-- List of detailed changes -->

- [ ] Whenever AdddiscoveredPeer is invoked, check if addresses have expired and add them again.
