### PR TITLE
fix: filter out peers to be considered for circuit-relay 

### DIFF
--- a/waku/v2/node/wakunode2.go
+++ b/waku/v2/node/wakunode2.go
@@ -893,13 +893,26 @@ func (w *WakuNode) findRelayNodes(ctx context.Context) {
 		rand.Shuffle(len(peers), func(i, j int) { peers[i], peers[j] = peers[j], peers[i] })
 
 		for _, p := range peers {
+			pENR, err := w.Host().Peerstore().(wps.WakuPeerstore).ENR(p.ID)
+			if err != nil {
+				w.log.Error("could not get ENR for the peer, skipping for circuit-relay", zap.Stringer("peer", p.ID), zap.Error(err))
+				continue
+			}
+			rs, err := enr.RelayShardList(pENR.Record())
+			if err != nil {
+				w.log.Error("could not get shard info for the peer from ENR, skipping for circuit-relay", zap.Stringer("peer", p.ID), zap.Error(err))
+				continue
+			}
+			if rs.ClusterID != w.ClusterID() {
+				w.log.Debug("clusterID mismatch for the peer, skipping for circuit-relay", zap.Stringer("peer", p.ID), zap.Error(err))
+				continue
+			}
 			info := w.Host().Peerstore().PeerInfo(p.ID)
 			supportedProtocols, err := w.Host().Peerstore().SupportsProtocols(p.ID, proto.ProtoIDv2Hop)
 			if err != nil {
 				w.log.Error("could not check supported protocols", zap.Error(err))
 				continue
 			}
-
 			if len(supportedProtocols) == 0 {
 				continue
 			}


### PR DESCRIPTION
While debugging conenctivity issues with peer-exchange, i had noticed that many peers have p2p circuit relay addresses formed with nodes that are not in the status fleet and probably part of TWN. As peers returned from the fleet using discv5 also include ones that are not part of cluster 16, this could be side-effect of that.
Connecting via such peers is causing failure, probably because metadata disconnects when we try to connect to them and hence circuit relay connection towards the final peer also fails. 

Hence adding a filter to the peers that are considered for circuit-relay so that peers from a different cluster are not considered as valid circuit-relay peers.

# Changes

<!-- List of detailed changes -->

- [ ] Circuit relay peers selection includes filtering of peers by ENR and those that have same clusterID as localnode.

