### PR TITLE
fix: use IP addresses instead of dns to store multiaddresses

### DIFF
--- a/waku/v2/node/address_test.go
+++ b/waku/v2/node/address_test.go
@@ -1,6 +1,7 @@
 package node
 
 import (
+	"context"
 	"net"
 	"testing"
 
@@ -9,23 +10,23 @@ import (
 )
 
 func TestExternalAddressSelection(t *testing.T) {
-	a1, _ := ma.NewMultiaddr("/ip4/192.168.0.106/tcp/60000/p2p/16Uiu2HAmUVVrJo1KMw4QwUANYF7Ws4mfcRqf9xHaaGP87GbMuY2f")                                                                                                                // Valid
-	a2, _ := ma.NewMultiaddr("/ip4/127.0.0.1/tcp/60000/p2p/16Uiu2HAmUVVrJo1KMw4QwUANYF7Ws4mfcRqf9xHaaGP87GbMuY2f")                                                                                                                    // Valid but should not be prefered
-	a3, _ := ma.NewMultiaddr("/ip4/192.168.1.20/tcp/19710/p2p/16Uiu2HAmUVVrJo1KMw4QwUANYF7Ws4mfcRqf9xHaaGP87GbMuY2f")                                                                                                                 // Valid
-	a4, _ := ma.NewMultiaddr("/dns4/www.status.im/tcp/2012/ws/p2p/16Uiu2HAmUVVrJo1KMw4QwUANYF7Ws4mfcRqf9xHaaGP87GbMuY2f")                                                                                                             // Invalid (it's useless)
-	a5, _ := ma.NewMultiaddr("/dns4/www.status.im/tcp/443/wss/p2p/16Uiu2HAmUVVrJo1KMw4QwUANYF7Ws4mfcRqf9xHaaGP87GbMuY2f")                                                                                                             // Valid
-	a6, _ := ma.NewMultiaddr("/ip4/192.168.1.20/tcp/19710/wss/p2p/16Uiu2HAmUVVrJo1KMw4QwUANYF7Ws4mfcRqf9xHaaGP87GbMuY2f")                                                                                                             // Invalid (local + wss)
-	a7, _ := ma.NewMultiaddr("/ip4/192.168.1.20/tcp/19710/ws/p2p/16Uiu2HAmUVVrJo1KMw4QwUANYF7Ws4mfcRqf9xHaaGP87GbMuY2f")                                                                                                              // Invalid  (it's useless)
-	a8, _ := ma.NewMultiaddr("/dns4/node-02.gc-us-central1-a.status.prod.statusim.net/tcp/30303/p2p/16Uiu2HAmDQugwDHM3YeUp86iGjrUvbdw3JPRgikC7YoGBsT2ymMg/p2p-circuit/p2p/16Uiu2HAmUVVrJo1KMw4QwUANYF7Ws4mfcRqf9xHaaGP87GbMuY2f")     // VALID
-	a9, _ := ma.NewMultiaddr("/dns4/node-02.gc-us-central1-a.status.prod.statusim.net/tcp/443/wss/p2p/16Uiu2HAmDQugwDHM3YeUp86iGjrUvbdw3JPRgikC7YoGBsT2ymMg/p2p-circuit/p2p/16Uiu2HAmUVVrJo1KMw4QwUANYF7Ws4mfcRqf9xHaaGP87GbMuY2f")   // VALID
+	a1, _ := ma.NewMultiaddr("/ip4/192.168.0.106/tcp/60000/p2p/16Uiu2HAmUVVrJo1KMw4QwUANYF7Ws4mfcRqf9xHaaGP87GbMuY2f")                                                                                                              // Valid
+	a2, _ := ma.NewMultiaddr("/ip4/127.0.0.1/tcp/60000/p2p/16Uiu2HAmUVVrJo1KMw4QwUANYF7Ws4mfcRqf9xHaaGP87GbMuY2f")                                                                                                                  // Valid but should not be prefered
+	a3, _ := ma.NewMultiaddr("/ip4/192.168.1.20/tcp/19710/p2p/16Uiu2HAmUVVrJo1KMw4QwUANYF7Ws4mfcRqf9xHaaGP87GbMuY2f")                                                                                                               // Valid
+	a4, _ := ma.NewMultiaddr("/dns4/www.status.im/tcp/2012/ws/p2p/16Uiu2HAmUVVrJo1KMw4QwUANYF7Ws4mfcRqf9xHaaGP87GbMuY2f")                                                                                                           // Invalid (it's useless)
+	a5, _ := ma.NewMultiaddr("/dns4/www.status.im/tcp/443/wss/p2p/16Uiu2HAmUVVrJo1KMw4QwUANYF7Ws4mfcRqf9xHaaGP87GbMuY2f")                                                                                                           // Valid
+	a6, _ := ma.NewMultiaddr("/ip4/192.168.1.20/tcp/19710/wss/p2p/16Uiu2HAmUVVrJo1KMw4QwUANYF7Ws4mfcRqf9xHaaGP87GbMuY2f")                                                                                                           // Invalid (local + wss)
+	a7, _ := ma.NewMultiaddr("/ip4/192.168.1.20/tcp/19710/ws/p2p/16Uiu2HAmUVVrJo1KMw4QwUANYF7Ws4mfcRqf9xHaaGP87GbMuY2f")                                                                                                            // Invalid  (it's useless)
+	a8, _ := ma.NewMultiaddr("/dns4/node-02.gc-us-central1-a.status.prod.statusim.net/tcp/30303/p2p/16Uiu2HAmDQugwDHM3YeUp86iGjrUvbdw3JPRgikC7YoGBsT2ymMg/p2p-circuit/p2p/16Uiu2HAmUVVrJo1KMw4QwUANYF7Ws4mfcRqf9xHaaGP87GbMuY2f")   // VALID
+	a9, _ := ma.NewMultiaddr("/dns4/node-02.gc-us-central1-a.status.prod.statusim.net/tcp/443/wss/p2p/16Uiu2HAmDQugwDHM3YeUp86iGjrUvbdw3JPRgikC7YoGBsT2ymMg/p2p-circuit/p2p/16Uiu2HAmUVVrJo1KMw4QwUANYF7Ws4mfcRqf9xHaaGP87GbMuY2f") // VALID
 	a10, _ := ma.NewMultiaddr("/dns4/node-01.gc-us-central1-a.waku.test.statusim.net/tcp/8000/wss/p2p/16Uiu2HAmDCp8XJ9z1ev18zuv8NHekAsjNyezAvmMfFEJkiharitG/p2p-circuit/p2p/16Uiu2HAmUVVrJo1KMw4QwUANYF7Ws4mfcRqf9xHaaGP87GbMuY2f") // VALID
 	a11, _ := ma.NewMultiaddr("/dns4/node-01.gc-us-central1-a.waku.test.statusim.net/tcp/30303/p2p/16Uiu2HAmDCp8XJ9z1ev18zuv8NHekAsjNyezAvmMfFEJkiharitG/p2p-circuit/p2p/16Uiu2HAmUVVrJo1KMw4QwUANYF7Ws4mfcRqf9xHaaGP87GbMuY2f")    // VALID
-	a12, _ := ma.NewMultiaddr("/ip4/188.23.1.8/tcp/30303/p2p/16Uiu2HAmUVVrJo1KMw4QwUANYF7Ws4mfcRqf9xHaaGP87GbMuY2f")                                                                                                                  // VALID
+	a12, _ := ma.NewMultiaddr("/ip4/188.23.1.8/tcp/30303/p2p/16Uiu2HAmUVVrJo1KMw4QwUANYF7Ws4mfcRqf9xHaaGP87GbMuY2f")                                                                                                                // VALID
 
 	addrs := []ma.Multiaddr{a1, a2, a3, a4, a5, a6, a7}
 
 	w := &WakuNode{}
-	extAddr, multiaddr, err := w.getENRAddresses([]ma.Multiaddr{a1, a2, a3, a4, a5, a6, a7})
+	extAddr, multiaddr, err := w.getENRAddresses(context.Background(), []ma.Multiaddr{a1, a2, a3, a4, a5, a6, a7})
 	a4NoP2P, _ := decapsulateP2P(a4)
 	require.NoError(t, err)
 	require.Equal(t, extAddr.IP, net.IPv4(192, 168, 0, 106))
@@ -34,13 +35,13 @@ func TestExternalAddressSelection(t *testing.T) {
 	require.Len(t, multiaddr, 4)
 
 	addrs = append(addrs, a8, a9, a10, a11, a12)
-	extAddr, _, err = w.getENRAddresses(addrs)
+	extAddr, _, err = w.getENRAddresses(context.Background(), addrs)
 	require.NoError(t, err)
 	require.Equal(t, extAddr.IP, net.IPv4(188, 23, 1, 8))
 	require.Equal(t, extAddr.Port, 30303)
 
-	a8RelayNode, _ := decapsulateCircuitRelayAddr(a8)
-	_, multiaddr, err = w.getENRAddresses([]ma.Multiaddr{a1, a8})
+	a8RelayNode, _ := decapsulateCircuitRelayAddr(context.Background(), a8)
+	_, multiaddr, err = w.getENRAddresses(context.Background(), []ma.Multiaddr{a1, a8})
 	require.NoError(t, err)
 	require.Len(t, multiaddr, 1)
 	require.Equal(t, multiaddr[0].String(), a8RelayNode.String()) // Should have included circuit-relay addr

--- a/waku/v2/protocol/enr/localnode.go
+++ b/waku/v2/protocol/enr/localnode.go
@@ -120,9 +120,7 @@ func writeMultiaddressField(localnode *enode.LocalNode, addrAggr []multiaddr.Mul
 		fieldRaw = append(fieldRaw, maRaw...)
 	}
 
-	if len(fieldRaw) != 0 && len(fieldRaw) <= 100 { // Max length for multiaddr field before triggering the 300 bytes limit
-		localnode.Set(enr.WithEntry(MultiaddrENRField, fieldRaw))
-	}
+	localnode.Set(enr.WithEntry(MultiaddrENRField, fieldRaw))
 
 	// This is to trigger the signing record err due to exceeding 300bytes limit
 	_ = localnode.Node()


### PR DESCRIPTION
This is so the circuit relay `multiaddrs` only use IP and not the long URLs like those used on the fleet.
This has the drawback that if the domain name is updated to point to a different IP, the IP address stored in the `multiaddr` field will no longer be valid, but I think this is okay, since ENRs are not the ideal place for storing circuit relay addresses (we should use rendezvous instead), and it's done only in an attempt to provide a way for peers to announce themselves.