### PR TITLE
feat: modify peer-manager to consider relay target peers 

### DIFF
--- a/logging/logging.go
+++ b/logging/logging.go
@@ -8,6 +8,7 @@ package logging
 
 import (
 	"encoding/hex"
+	"fmt"
 	"net"
 	"time"
 
@@ -146,4 +147,9 @@ func TCPAddr(key string, ip net.IP, port int) zap.Field {
 // UDPAddr creates a field for UDP v4/v6 address and port
 func UDPAddr(key string, ip net.IP, port int) zap.Field {
 	return zap.Stringer(key, &net.UDPAddr{IP: ip, Port: port})
+}
+
+func Uint64(key string, value uint64) zap.Field {
+	valueStr := fmt.Sprintf("%v", value)
+	return zap.String(key, valueStr)
 }

--- a/waku/v2/node/wakunode2.go
+++ b/waku/v2/node/wakunode2.go
@@ -256,7 +256,7 @@ func New(opts ...WakuNodeOption) (*WakuNode, error) {
 	w.metadata = metadata
 
 	//Initialize peer manager.
-	w.peermanager = peermanager.NewPeerManager(w.opts.maxPeerConnections, w.opts.peerStoreCapacity, metadata, w.log)
+	w.peermanager = peermanager.NewPeerManager(w.opts.maxPeerConnections, w.opts.peerStoreCapacity, metadata, params.enableRelay, w.log)
 
 	w.peerConnector, err = peermanager.NewPeerConnectionStrategy(w.peermanager, discoveryConnectTimeout, w.log)
 	if err != nil {

--- a/waku/v2/node/wakunode2.go
+++ b/waku/v2/node/wakunode2.go
@@ -554,9 +554,9 @@ func (w *WakuNode) watchENRChanges(ctx context.Context) {
 				currNodeVal := w.localNode.Node().String()
 				if prevNodeVal != currNodeVal {
 					if prevNodeVal == "" {
-						w.log.Info("enr record", logging.ENode("enr", w.localNode.Node()))
+						w.log.Info("local node enr record", logging.ENode("enr", w.localNode.Node()))
 					} else {
-						w.log.Info("new enr record", logging.ENode("enr", w.localNode.Node()))
+						w.log.Info("local node new enr record", logging.ENode("enr", w.localNode.Node()))
 					}
 					prevNodeVal = currNodeVal
 				}

--- a/waku/v2/node/wakuoptions.go
+++ b/waku/v2/node/wakuoptions.go
@@ -44,6 +44,8 @@ const UserAgent string = "go-waku"
 const defaultMinRelayPeersToPublish = 0
 
 const DefaultMaxConnectionsPerIP = 5
+const DefaultMaxConnections = 300
+const DefaultMaxPeerStoreCapacity = 300
 
 type WakuNodeParameters struct {
 	hostAddr            *net.TCPAddr
@@ -124,9 +126,10 @@ type WakuNodeOption func(*WakuNodeParameters) error
 // Default options used in the libp2p node
 var DefaultWakuNodeOptions = []WakuNodeOption{
 	WithPrometheusRegisterer(prometheus.NewRegistry()),
-	WithMaxPeerConnections(50),
+	WithMaxPeerConnections(DefaultMaxConnections),
 	WithMaxConnectionsPerIP(DefaultMaxConnectionsPerIP),
 	WithCircuitRelayParams(2*time.Second, 3*time.Minute),
+	WithPeerStoreCapacity(DefaultMaxPeerStoreCapacity),
 }
 
 // MultiAddresses return the list of multiaddresses configured in the node

--- a/waku/v2/peermanager/peer_connector.go
+++ b/waku/v2/peermanager/peer_connector.go
@@ -17,7 +17,6 @@ import (
 	"github.com/libp2p/go-libp2p/p2p/discovery/backoff"
 	"github.com/waku-org/go-waku/logging"
 	wps "github.com/waku-org/go-waku/waku/v2/peerstore"
-	waku_proto "github.com/waku-org/go-waku/waku/v2/protocol"
 	"github.com/waku-org/go-waku/waku/v2/service"
 
 	"go.uber.org/zap"
@@ -127,7 +126,7 @@ func (c *PeerConnectionStrategy) consumeSubscription(s subscription) {
 				triggerImmediateConnection := false
 				//Not connecting to peer as soon as it is discovered,
 				// rather expecting this to be pushed from PeerManager based on the need.
-				if len(c.host.Network().Peers()) < waku_proto.GossipSubDMin {
+				if len(c.host.Network().Peers()) < c.pm.OutPeersTarget {
 					triggerImmediateConnection = true
 				}
 				c.logger.Debug("adding discovered peer", logging.HostID("peerID", p.AddrInfo.ID))
@@ -227,7 +226,7 @@ func (c *PeerConnectionStrategy) addConnectionBackoff(peerID peer.ID) {
 func (c *PeerConnectionStrategy) dialPeers() {
 	defer c.WaitGroup().Done()
 
-	maxGoRoutines := c.pm.OutRelayPeersTarget
+	maxGoRoutines := c.pm.OutPeersTarget
 	if maxGoRoutines > maxActiveDials {
 		maxGoRoutines = maxActiveDials
 	}

--- a/waku/v2/peermanager/peer_connector.go
+++ b/waku/v2/peermanager/peer_connector.go
@@ -129,7 +129,6 @@ func (c *PeerConnectionStrategy) consumeSubscription(s subscription) {
 				if len(c.host.Network().Peers()) < c.pm.OutPeersTarget {
 					triggerImmediateConnection = true
 				}
-				c.logger.Debug("adding discovered peer", logging.HostID("peerID", p.AddrInfo.ID))
 				c.pm.AddDiscoveredPeer(p, triggerImmediateConnection)
 
 			case <-time.After(1 * time.Second):

--- a/waku/v2/peermanager/peer_discovery.go
+++ b/waku/v2/peermanager/peer_discovery.go
@@ -55,7 +55,7 @@ func (pm *PeerManager) discoverOnDemand(cluster uint16,
 
 	wakuProtoInfo, ok := pm.wakuprotoToENRFieldMap[wakuProtocol]
 	if !ok {
-		pm.logger.Error("cannot do on demand discovery for non-waku protocol", zap.String("protocol", string(wakuProtocol)))
+		pm.logger.Info("cannot do on demand discovery for non-waku protocol", zap.String("protocol", string(wakuProtocol)))
 		return nil, errors.New("cannot do on demand discovery for non-waku protocol")
 	}
 	iterator, err := pm.discoveryService.PeerIterator(

--- a/waku/v2/peermanager/peer_discovery.go
+++ b/waku/v2/peermanager/peer_discovery.go
@@ -55,7 +55,7 @@ func (pm *PeerManager) discoverOnDemand(cluster uint16,
 
 	wakuProtoInfo, ok := pm.wakuprotoToENRFieldMap[wakuProtocol]
 	if !ok {
-		pm.logger.Info("cannot do on demand discovery for non-waku protocol", zap.String("protocol", string(wakuProtocol)))
+		pm.logger.Warn("cannot do on demand discovery for non-waku protocol", zap.String("protocol", string(wakuProtocol)))
 		return nil, errors.New("cannot do on demand discovery for non-waku protocol")
 	}
 	iterator, err := pm.discoveryService.PeerIterator(

--- a/waku/v2/peermanager/peer_manager_test.go
+++ b/waku/v2/peermanager/peer_manager_test.go
@@ -30,7 +30,7 @@ func initTest(t *testing.T) (context.Context, *PeerManager, func()) {
 	require.NoError(t, err)
 
 	// host 1 is used by peer manager
-	pm := NewPeerManager(10, 20, nil, utils.Logger())
+	pm := NewPeerManager(10, 20, nil, true, utils.Logger())
 	pm.SetHost(h1)
 
 	return ctx, pm, func() {
@@ -228,7 +228,7 @@ func TestConnectToRelayPeers(t *testing.T) {
 
 	defer deferFn()
 
-	pm.connectToRelayPeers()
+	pm.connectToPeers()
 
 }
 
@@ -252,7 +252,7 @@ func createHostWithDiscv5AndPM(t *testing.T, hostName string, topic string, enrF
 
 	err = wenr.Update(utils.Logger(), localNode, wenr.WithWakuRelaySharding(rs[0]))
 	require.NoError(t, err)
-	pm := NewPeerManager(10, 20, nil, logger)
+	pm := NewPeerManager(10, 20, nil, true, logger)
 	pm.SetHost(host)
 	peerconn, err := NewPeerConnectionStrategy(pm, 30*time.Second, logger)
 	require.NoError(t, err)

--- a/waku/v2/peermanager/topic_event_handler.go
+++ b/waku/v2/peermanager/topic_event_handler.go
@@ -48,7 +48,9 @@ func (pm *PeerManager) handleNewRelayTopicSubscription(pubsubTopic string, topic
 
 	pm.checkAndUpdateTopicHealth(pm.subRelayTopics[pubsubTopic])
 
-	if connectedPeers >= waku_proto.GossipSubDMin { //TODO: Use a config rather than hard-coding.
+	//Leaving this logic based on gossipSubDMin as this is a good start for a subscribed topic.
+	// subsequent connectivity loop iteration would initiate more connections which should take it towards a healthy mesh.
+	if connectedPeers >= waku_proto.GossipSubDMin {
 		// Should we use optimal number or define some sort of a config for the node to choose from?
 		// A desktop node may choose this to be 4-6, whereas a service node may choose this to be 8-12 based on resources it has
 		// or bandwidth it can support.
@@ -70,7 +72,7 @@ func (pm *PeerManager) handleNewRelayTopicSubscription(pubsubTopic string, topic
 		}
 		//For now all peers are being given same priority,
 		// Later we may want to choose peers that have more shards in common over others.
-		pm.connectToPeers(notConnectedPeers[0:numPeersToConnect])
+		pm.connectToSpecifiedPeers(notConnectedPeers[0:numPeersToConnect])
 	} else {
 		triggerDiscovery = true
 	}

--- a/waku/v2/peermanager/topic_event_handler_test.go
+++ b/waku/v2/peermanager/topic_event_handler_test.go
@@ -3,6 +3,9 @@ package peermanager
 import (
 	"context"
 	"crypto/rand"
+	"testing"
+	"time"
+
 	"github.com/libp2p/go-libp2p/core/event"
 	"github.com/libp2p/go-libp2p/core/host"
 	"github.com/libp2p/go-libp2p/core/network"
@@ -17,8 +20,6 @@ import (
 	"github.com/waku-org/go-waku/waku/v2/timesource"
 	"github.com/waku-org/go-waku/waku/v2/utils"
 	"go.uber.org/zap"
-	"testing"
-	"time"
 )
 
 func makeWakuRelay(t *testing.T, log *zap.Logger) (*relay.WakuRelay, host.Host, relay.Broadcaster) {
@@ -44,7 +45,7 @@ func makeWakuRelay(t *testing.T, log *zap.Logger) (*relay.WakuRelay, host.Host, 
 
 func makePeerManagerWithEventBus(t *testing.T, r *relay.WakuRelay, h *host.Host) (*PeerManager, event.Bus) {
 	// Host 1 used by peer manager
-	pm := NewPeerManager(10, 20, nil, utils.Logger())
+	pm := NewPeerManager(10, 20, nil, true, utils.Logger())
 	pm.SetHost(*h)
 
 	// Create a new relay event bus
@@ -77,7 +78,7 @@ func TestSubscribeToRelayEvtBus(t *testing.T) {
 	r, h1, _ := makeWakuRelay(t, log)
 
 	// Host 1 used by peer manager
-	pm := NewPeerManager(10, 20, nil, utils.Logger())
+	pm := NewPeerManager(10, 20, nil, true, utils.Logger())
 	pm.SetHost(h1)
 
 	// Create a new relay event bus

--- a/waku/v2/protocol/filter/test_utils.go
+++ b/waku/v2/protocol/filter/test_utils.go
@@ -164,7 +164,7 @@ func (s *FilterTestSuite) GetWakuFilterLightNode() LightNodeData {
 	s.Require().NoError(err)
 	b := relay.NewBroadcaster(10)
 	s.Require().NoError(b.Start(context.Background()))
-	pm := peermanager.NewPeerManager(5, 5, nil, s.Log)
+	pm := peermanager.NewPeerManager(5, 5, nil, true, s.Log)
 	filterPush := NewWakuFilterLightNode(b, pm, timesource.NewDefaultClock(), prometheus.DefaultRegisterer, s.Log)
 	filterPush.SetHost(host)
 	pm.SetHost(host)

--- a/waku/v2/protocol/legacy_store/waku_store_client_test.go
+++ b/waku/v2/protocol/legacy_store/waku_store_client_test.go
@@ -36,7 +36,7 @@ func TestQueryOptions(t *testing.T) {
 	require.NoError(t, err)
 
 	// Let peer manager reside at host
-	pm := peermanager.NewPeerManager(5, 5, nil, utils.Logger())
+	pm := peermanager.NewPeerManager(5, 5, nil, true, utils.Logger())
 	pm.SetHost(host)
 
 	// Add host2 to peerstore

--- a/waku/v2/protocol/lightpush/waku_lightpush_test.go
+++ b/waku/v2/protocol/lightpush/waku_lightpush_test.go
@@ -237,7 +237,7 @@ func TestWakuLightPushCornerCases(t *testing.T) {
 	testContentTopic := "/test/10/my-lp-app/proto"
 
 	// Prepare peer manager instance to include in test
-	pm := peermanager.NewPeerManager(10, 10, nil, utils.Logger())
+	pm := peermanager.NewPeerManager(10, 10, nil, true, utils.Logger())
 
 	node1, sub1, host1 := makeWakuRelay(t, testTopic)
 	defer node1.Stop()

--- a/waku/v2/protocol/peer_exchange/waku_peer_exchange_test.go
+++ b/waku/v2/protocol/peer_exchange/waku_peer_exchange_test.go
@@ -291,7 +291,7 @@ func TestRetrieveProvidePeerExchangeWithPMAndPeerAddr(t *testing.T) {
 	require.NoError(t, err)
 
 	// Prepare peer manager for host3
-	pm3 := peermanager.NewPeerManager(10, 20, nil, log)
+	pm3 := peermanager.NewPeerManager(10, 20, nil, true, log)
 	pm3.SetHost(host3)
 	pxPeerConn3, err := peermanager.NewPeerConnectionStrategy(pm3, 30*time.Second, utils.Logger())
 	require.NoError(t, err)
@@ -366,7 +366,7 @@ func TestRetrieveProvidePeerExchangeWithPMOnly(t *testing.T) {
 	require.NoError(t, err)
 
 	// Prepare peer manager for host3
-	pm3 := peermanager.NewPeerManager(10, 20, nil, log)
+	pm3 := peermanager.NewPeerManager(10, 20, nil, true, log)
 	pm3.SetHost(host3)
 	pxPeerConn3, err := peermanager.NewPeerConnectionStrategy(pm3, 30*time.Second, utils.Logger())
 	require.NoError(t, err)

--- a/waku/v2/protocol/store/client_test.go
+++ b/waku/v2/protocol/store/client_test.go
@@ -43,7 +43,7 @@ func TestStoreClient(t *testing.T) {
 	err = wakuRelay.Start(context.Background())
 	require.NoError(t, err)
 
-	pm := peermanager.NewPeerManager(5, 5, nil, utils.Logger())
+	pm := peermanager.NewPeerManager(5, 5, nil, true, utils.Logger())
 	pm.SetHost(host)
 	err = pm.SubscribeToRelayEvtBus(wakuRelay.Events())
 	require.NoError(t, err)


### PR DESCRIPTION
Also start refactor to work with lightMode.
Complete refactor will happen in separate PR to avoid blocking the changes for relay.

# Description
Addresses https://github.com/waku-org/go-waku/issues/1132
