### PR TITLE
fix: ignore ws from circuit relay addresses, and allow non multiaddresses in `multiaddrs` ENR key

### DIFF
--- a/waku/v2/node/localnode.go
+++ b/waku/v2/node/localnode.go
@@ -234,17 +234,24 @@ func selectWSListenAddresses(addresses []ma.Multiaddr) ([]ma.Multiaddr, error) {
 
 func selectCircuitRelayListenAddresses(ctx context.Context, addresses []ma.Multiaddr) ([]ma.Multiaddr, error) {
 	var result []ma.Multiaddr
+
 	for _, addr := range addresses {
 		addr, err := decapsulateCircuitRelayAddr(ctx, addr)
 		if err != nil {
 			continue
 		}
+
+		_, noWS := addr.ValueForProtocol(ma.P_WSS)
+		_, noWSS := addr.ValueForProtocol(ma.P_WS)
+		if noWS == nil || noWSS == nil { // WS or WSS found
+			continue
+		}
+
 		result = append(result, addr)
 	}
 
 	return result, nil
 }
-
 
 func filter0Port(addresses []ma.Multiaddr) ([]ma.Multiaddr, error) {
 	var result []ma.Multiaddr

--- a/waku/v2/protocol/enr/enr.go
+++ b/waku/v2/protocol/enr/enr.go
@@ -120,7 +120,8 @@ func Multiaddress(node *enode.Node) (peer.ID, []multiaddr.Multiaddr, error) {
 		maRaw := multiaddrRaw[offset+2 : offset+2+int(maSize)]
 		addr, err := multiaddr.NewMultiaddrBytes(maRaw)
 		if err != nil {
-			return "", nil, fmt.Errorf("invalid multiaddress field length")
+			// The value is not a multiaddress. Ignoring...
+			continue
 		}
 
 		hostInfoStr := fmt.Sprintf("/p2p/%s", peerID.String())


### PR DESCRIPTION
- WS / WSS addresses are not taken into account for circuit relay
- Allows storing arbitrary data in the `multiaddrs` ENR key. If a value is not recognized, it's ignored