### PR TITLE
chore: bump Go to 1.21 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # BUILD IMAGE --------------------------------------------------------
-FROM golang:1.20 as builder
+FROM golang:1.21 as builder
 
 WORKDIR /app
 COPY . .


### PR DESCRIPTION
# Description
Changing build image to golang:1.21 to get in sync with go.mod.