### PR TITLE
chore: allow setting enr shards for lightclient

### DIFF
--- a/waku/v2/node/localnode.go
+++ b/waku/v2/node/localnode.go
@@ -338,6 +338,14 @@ func (w *WakuNode) setupENR(ctx context.Context, addrs []ma.Multiaddr) error {
 
 }
 
+func (w *WakuNode) SetRelayShards(rs protocol.RelayShards) error {
+	err := wenr.Update(w.log, w.localNode, wenr.WithWakuRelaySharding(rs))
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
 func (w *WakuNode) watchTopicShards(ctx context.Context) error {
 	evtRelaySubscribed, err := w.Relay().Events().Subscribe(new(relay.EvtRelaySubscribed))
 	if err != nil {

--- a/waku/v2/node/wakunode2.go
+++ b/waku/v2/node/wakunode2.go
@@ -457,16 +457,25 @@ func (w *WakuNode) Start(ctx context.Context) error {
 	}
 
 	w.filterLightNode.SetHost(host)
+
+	err = w.setupENR(ctx, w.ListenAddresses())
+	if err != nil {
+		return err
+	}
+
 	if w.opts.enableFilterLightNode {
 		err := w.filterLightNode.Start(ctx)
 		if err != nil {
 			return err
 		}
-	}
-
-	err = w.setupENR(ctx, w.ListenAddresses())
-	if err != nil {
-		return err
+		//TODO: setting this up temporarily to improve connectivity success for lightNode in status.
+		//This will have to be removed or changed with community sharding will be implemented.
+		if w.opts.shards != nil {
+			err = w.SetRelayShards(*w.opts.shards)
+			if err != nil {
+				return err
+			}
+		}
 	}
 
 	w.peerExchange.SetHost(host)

--- a/waku/v2/protocol/lightpush/waku_lightpush.go
+++ b/waku/v2/protocol/lightpush/waku_lightpush.go
@@ -328,9 +328,9 @@ func (wakuLP *WakuLightPush) Publish(ctx context.Context, message *wpb.WakuMessa
 	req.Message = message
 	req.PubsubTopic = params.pubsubTopic
 
-	logger := message.Logger(wakuLP.log, params.pubsubTopic).With(zap.Stringers("peerIDs", params.selectedPeers))
+	logger := message.Logger(wakuLP.log, params.pubsubTopic)
 
-	logger.Debug("publishing message")
+	logger.Debug("publishing message", zap.Stringers("peers", params.selectedPeers))
 	var wg sync.WaitGroup
 	var responses []*pb.PushResponse
 	for _, peerID := range params.selectedPeers {


### PR DESCRIPTION
# Description
go-waku has the issue of disconnecting lightClients that don't provide shard info in metadata. This has been fixed in https://github.com/waku-org/go-waku/pull/1154 , but since it would take time for this change to propagate into the network of status desktop instances already running it is causing issues for lightClients to connect to existing nodes. 
e.g as explained here https://discord.com/channels/1110799176264056863/1261332218991738941

In order to mitigate this issue, this Pr would allow lightClients to set shards in their ENR which would in-turn be used in metadata exchange. Note that these changes are to be reverted once community sharding is implemented in status.
