### PR TITLE
fix: record connection failures when stream opening fails for any protocol

### DIFF
--- a/waku/v2/protocol/filter/server.go
+++ b/waku/v2/protocol/filter/server.go
@@ -14,6 +14,7 @@ import (
 	"github.com/libp2p/go-msgio/pbio"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/waku-org/go-waku/logging"
+	"github.com/waku-org/go-waku/waku/v2/peerstore"
 	"github.com/waku-org/go-waku/waku/v2/protocol"
 	"github.com/waku-org/go-waku/waku/v2/protocol/filter/pb"
 	"github.com/waku-org/go-waku/waku/v2/protocol/relay"
@@ -273,6 +274,9 @@ func (wf *WakuFilterFullNode) pushMessage(ctx context.Context, logger *zap.Logge
 			wf.metrics.RecordError(pushTimeoutFailure)
 		} else {
 			wf.metrics.RecordError(dialFailure)
+			if ps, ok := wf.h.Peerstore().(peerstore.WakuPeerstore); ok {
+				ps.AddConnFailure(peer.AddrInfo{ID: peerID})
+			}
 		}
 		logger.Error("opening peer stream", zap.Error(err))
 		return err

--- a/waku/v2/protocol/legacy_store/waku_store_client.go
+++ b/waku/v2/protocol/legacy_store/waku_store_client.go
@@ -207,6 +207,9 @@ func (store *WakuStore) queryFrom(ctx context.Context, historyRequest *pb.Histor
 	if err != nil {
 		logger.Error("creating stream to peer", zap.Error(err))
 		store.metrics.RecordError(dialFailure)
+		if ps, ok := store.h.Peerstore().(peerstore.WakuPeerstore); ok {
+			ps.AddConnFailure(peer.AddrInfo{ID: selectedPeer})
+		}
 		return nil, err
 	}
 

--- a/waku/v2/protocol/metadata/waku_metadata.go
+++ b/waku/v2/protocol/metadata/waku_metadata.go
@@ -15,6 +15,7 @@ import (
 	"github.com/libp2p/go-msgio/pbio"
 	"github.com/multiformats/go-multiaddr"
 	"github.com/waku-org/go-waku/logging"
+	"github.com/waku-org/go-waku/waku/v2/peerstore"
 	"github.com/waku-org/go-waku/waku/v2/protocol"
 	"github.com/waku-org/go-waku/waku/v2/protocol/enr"
 	"github.com/waku-org/go-waku/waku/v2/protocol/metadata/pb"
@@ -103,6 +104,9 @@ func (wakuM *WakuMetadata) Request(ctx context.Context, peerID peer.ID) (*pb.Wak
 	stream, err := wakuM.h.NewStream(ctx, peerID, MetadataID_v1)
 	if err != nil {
 		logger.Error("creating stream to peer", zap.Error(err))
+		if ps, ok := wakuM.h.Peerstore().(peerstore.WakuPeerstore); ok {
+			ps.AddConnFailure(peer.AddrInfo{ID: peerID})
+		}
 		return nil, err
 	}
 

--- a/waku/v2/protocol/peer_exchange/client.go
+++ b/waku/v2/protocol/peer_exchange/client.go
@@ -76,6 +76,9 @@ func (wakuPX *WakuPeerExchange) Request(ctx context.Context, numPeers int, opts 
 
 	stream, err := wakuPX.h.NewStream(ctx, params.selectedPeer, PeerExchangeID_v20alpha1)
 	if err != nil {
+		if ps, ok := wakuPX.h.Peerstore().(peerstore.WakuPeerstore); ok {
+			ps.AddConnFailure(peer.AddrInfo{ID: params.selectedPeer})
+		}
 		return err
 	}
 

--- a/waku/v2/protocol/store/client.go
+++ b/waku/v2/protocol/store/client.go
@@ -253,6 +253,9 @@ func (s *WakuStore) queryFrom(ctx context.Context, storeRequest *pb.StoreQueryRe
 	stream, err := s.h.NewStream(ctx, selectedPeer, StoreQueryID_v300)
 	if err != nil {
 		logger.Error("creating stream to peer", zap.Error(err))
+		if ps, ok := s.h.Peerstore().(peerstore.WakuPeerstore); ok {
+			ps.AddConnFailure(peer.AddrInfo{ID: selectedPeer})
+		}
 		return nil, err
 	}
 


### PR DESCRIPTION
# Description
Connection failures  are recorded only when attempted from peerManager or by invoking connect call. But all the req/resp protocols open streams which internally does a dial if there is no existing connection to the peer. If this dial fails, it is not recorded as a connection error.

Since connection errors recorded in peerStore are being used to report to telemetry, these would also have to be recorded as connection errors.

cc @adklempner 