### PR TITLE
fix: filter ping timeout and retry in case of failure

### DIFF
--- a/waku/v2/api/filter.go
+++ b/waku/v2/api/filter.go
@@ -14,7 +14,6 @@ import (
 	"go.uber.org/zap"
 )
 
-const FilterPingTimeout = 5 * time.Second
 const MultiplexChannelBuffer = 100
 
 type FilterConfig struct {


### PR DESCRIPTION
# Description
While going through filter ping code, had noticed that 
- ping timeout was set to PingInterval which is 1 minute and is too large to identify failures in case peer is down or network disconnected etc. So, reducing it to 5 seconds to catch errors faster
-  aligning with rfc https://github.com/waku-org/specs/blob/master/standards/application/req-res-reliability.md#regular-pings 
> -  added a second ping in case of failure before we give-up and move subscriptions to another peer. 
> This is as per  , and this has been implemented in js-waku as well.
> - Perform filter pings only when we are online