### PR TITLE
fix: use total peers for pubsubTopic as out peers target

### DIFF
--- a/waku/v2/peermanager/peer_manager.go
+++ b/waku/v2/peermanager/peer_manager.go
@@ -313,8 +313,10 @@ func (pm *PeerManager) ensureMinRelayConnsPerTopic() {
 		// peers. This will ensure that the peers returned by this function
 		// match those peers that are currently connected
 
-		curPeerLen := pm.checkAndUpdateTopicHealth(topicInst)
-		if curPeerLen < pm.OutPeersTarget {
+		meshPeerLen := pm.checkAndUpdateTopicHealth(topicInst)
+		topicPeers := pm.host.Peerstore().(wps.WakuPeerstore).PeersByPubSubTopic(topicStr)
+		curPeerLen := topicPeers.Len()
+		if meshPeerLen < waku_proto.GossipSubDMin || curPeerLen < pm.OutPeersTarget {
 			pm.logger.Debug("subscribed topic has not reached target peers, initiating more connections to maintain healthy mesh",
 				zap.String("pubSubTopic", topicStr), zap.Int("connectedPeerCount", curPeerLen),
 				zap.Int("targetPeers", pm.OutPeersTarget))


### PR DESCRIPTION
While debugging connectivity issue, i had noticed that we are relying on only meshPeers and comparing it to relay out peers target in order to establish more connections. Since gossipSubMesh max would only be 8 and we would try to establish out connections always even if we reach relay outPeersTarget which is set to 80 for status.

Changing the logic to check with total pubsubTopic peerCounts and also the meshPeerCount.