### PR TITLE
Update link from unofficial nixos wiki to official one

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ make
 ./build/waku --help
 ```
 #### Nix
-You can build Waku v2 node using [Nix](https://nixos.org/) [Flakes](https://nixos.wiki/wiki/Flakes):
+You can build Waku v2 node using [Nix](https://nixos.org/) [Flakes](https://wiki.nixos.org/wiki/Flakes):
 ```sh
 nix build github:waku-org/go-waku
 ```


### PR DESCRIPTION
The README references the old, unofficial NixOS wiki. This PR updates the links to point to the new official NixOS wiki source, which will be more properly maintained in the future. It's very much a Fandom wiki situation.