### PR TITLE
fix: keep channels open

### DIFF
--- a/waku/v2/api/publish/message_queue.go
+++ b/waku/v2/api/publish/message_queue.go
@@ -103,12 +103,6 @@ func (m *MessageQueue) Start(ctx context.Context) {
 			m.envelopeAvailableOnPriorityQueueSignal <- struct{}{}
 
 		case <-ctx.Done():
-			if m.usePriorityQueue {
-				close(m.throttledPrioritySendQueue)
-				close(m.envelopeAvailableOnPriorityQueueSignal)
-			} else {
-				close(m.toSendChan)
-			}
 			return
 		}
 	}
@@ -116,24 +110,36 @@ func (m *MessageQueue) Start(ctx context.Context) {
 
 // Push an envelope into the message queue. The priority is optional, and will be ignored
 // if the message queue does not use a priority queue
-func (m *MessageQueue) Push(envelope *protocol.Envelope, priority ...MessagePriority) {
+func (m *MessageQueue) Push(ctx context.Context, envelope *protocol.Envelope, priority ...MessagePriority) {
 	if m.usePriorityQueue {
 		msgPriority := NormalPriority
 		if len(priority) != 0 {
 			msgPriority = priority[0]
 		}
 
-		m.throttledPrioritySendQueue <- &envelopePriority{
+		pEnvelope := &envelopePriority{
 			envelope: envelope,
 			priority: msgPriority,
 		}
+
+		select {
+		case m.throttledPrioritySendQueue <- pEnvelope:
+			// Do nothing
+		case <-ctx.Done():
+			return
+		}
 	} else {
-		m.toSendChan <- envelope
+		select {
+		case m.toSendChan <- envelope:
+			// Do nothing
+		case <-ctx.Done():
+			return
+		}
 	}
 }
 
 // Pop will return a channel on which a message can be retrieved from the message queue
-func (m *MessageQueue) Pop() <-chan *protocol.Envelope {
+func (m *MessageQueue) Pop(ctx context.Context) <-chan *protocol.Envelope {
 	ch := make(chan *protocol.Envelope)
 
 	go func() {
@@ -147,6 +153,9 @@ func (m *MessageQueue) Pop() <-chan *protocol.Envelope {
 			if ok {
 				ch <- envelope
 			}
+
+		case <-ctx.Done():
+
 		}
 
 		close(ch)

--- a/waku/v2/api/publish/message_queue_test.go
+++ b/waku/v2/api/publish/message_queue_test.go
@@ -17,9 +17,14 @@ func TestFifoQueue(t *testing.T) {
 	queue := NewMessageQueue(10, false)
 	go queue.Start(ctx)
 
-	queue.Push(ctx, protocol.NewEnvelope(&pb.WakuMessage{}, 0, "A"))
-	queue.Push(ctx, protocol.NewEnvelope(&pb.WakuMessage{}, 0, "B"))
-	queue.Push(ctx, protocol.NewEnvelope(&pb.WakuMessage{}, 0, "C"))
+	err := queue.Push(ctx, protocol.NewEnvelope(&pb.WakuMessage{}, 0, "A"))
+	require.NoError(t, err)
+
+	err = queue.Push(ctx, protocol.NewEnvelope(&pb.WakuMessage{}, 0, "B"))
+	require.NoError(t, err)
+
+	err = queue.Push(ctx, protocol.NewEnvelope(&pb.WakuMessage{}, 0, "C"))
+	require.NoError(t, err)
 
 	envelope, ok := <-queue.Pop(ctx)
 	require.True(t, ok)
@@ -45,13 +50,26 @@ func TestPriorityQueue(t *testing.T) {
 	queue := NewMessageQueue(10, true)
 	go queue.Start(ctx)
 
-	queue.Push(ctx, protocol.NewEnvelope(&pb.WakuMessage{Timestamp: proto.Int64(0)}, 0, "A"), LowPriority)
-	queue.Push(ctx, protocol.NewEnvelope(&pb.WakuMessage{Timestamp: proto.Int64(1)}, 0, "B"), LowPriority)
-	queue.Push(ctx, protocol.NewEnvelope(&pb.WakuMessage{Timestamp: proto.Int64(2)}, 0, "C"), HighPriority)
-	queue.Push(ctx, protocol.NewEnvelope(&pb.WakuMessage{Timestamp: proto.Int64(3)}, 0, "D"), NormalPriority)
-	queue.Push(ctx, protocol.NewEnvelope(&pb.WakuMessage{Timestamp: proto.Int64(4)}, 0, "E"), HighPriority)
-	queue.Push(ctx, protocol.NewEnvelope(&pb.WakuMessage{Timestamp: proto.Int64(5)}, 0, "F"), LowPriority)
-	queue.Push(ctx, protocol.NewEnvelope(&pb.WakuMessage{Timestamp: proto.Int64(6)}, 0, "G"), NormalPriority)
+	err := queue.Push(ctx, protocol.NewEnvelope(&pb.WakuMessage{Timestamp: proto.Int64(0)}, 0, "A"), LowPriority)
+	require.NoError(t, err)
+
+	err = queue.Push(ctx, protocol.NewEnvelope(&pb.WakuMessage{Timestamp: proto.Int64(1)}, 0, "B"), LowPriority)
+	require.NoError(t, err)
+
+	err = queue.Push(ctx, protocol.NewEnvelope(&pb.WakuMessage{Timestamp: proto.Int64(2)}, 0, "C"), HighPriority)
+	require.NoError(t, err)
+
+	err = queue.Push(ctx, protocol.NewEnvelope(&pb.WakuMessage{Timestamp: proto.Int64(3)}, 0, "D"), NormalPriority)
+	require.NoError(t, err)
+
+	err = queue.Push(ctx, protocol.NewEnvelope(&pb.WakuMessage{Timestamp: proto.Int64(4)}, 0, "E"), HighPriority)
+	require.NoError(t, err)
+
+	err = queue.Push(ctx, protocol.NewEnvelope(&pb.WakuMessage{Timestamp: proto.Int64(5)}, 0, "F"), LowPriority)
+	require.NoError(t, err)
+
+	err = queue.Push(ctx, protocol.NewEnvelope(&pb.WakuMessage{Timestamp: proto.Int64(6)}, 0, "G"), NormalPriority)
+	require.NoError(t, err)
 
 	time.Sleep(2 * time.Second)
 

--- a/waku/v2/api/publish/message_queue_test.go
+++ b/waku/v2/api/publish/message_queue_test.go
@@ -17,25 +17,25 @@ func TestFifoQueue(t *testing.T) {
 	queue := NewMessageQueue(10, false)
 	go queue.Start(ctx)
 
-	queue.Push(protocol.NewEnvelope(&pb.WakuMessage{}, 0, "A"))
-	queue.Push(protocol.NewEnvelope(&pb.WakuMessage{}, 0, "B"))
-	queue.Push(protocol.NewEnvelope(&pb.WakuMessage{}, 0, "C"))
+	queue.Push(ctx, protocol.NewEnvelope(&pb.WakuMessage{}, 0, "A"))
+	queue.Push(ctx, protocol.NewEnvelope(&pb.WakuMessage{}, 0, "B"))
+	queue.Push(ctx, protocol.NewEnvelope(&pb.WakuMessage{}, 0, "C"))
 
-	envelope, ok := <-queue.Pop()
+	envelope, ok := <-queue.Pop(ctx)
 	require.True(t, ok)
 	require.Equal(t, "A", envelope.PubsubTopic())
 
-	envelope, ok = <-queue.Pop()
+	envelope, ok = <-queue.Pop(ctx)
 	require.True(t, ok)
 	require.Equal(t, "B", envelope.PubsubTopic())
 
-	envelope, ok = <-queue.Pop()
+	envelope, ok = <-queue.Pop(ctx)
 	require.True(t, ok)
 	require.Equal(t, "C", envelope.PubsubTopic())
 
 	cancel()
 
-	_, ok = <-queue.Pop()
+	_, ok = <-queue.Pop(ctx)
 	require.False(t, ok)
 }
 
@@ -45,47 +45,47 @@ func TestPriorityQueue(t *testing.T) {
 	queue := NewMessageQueue(10, true)
 	go queue.Start(ctx)
 
-	queue.Push(protocol.NewEnvelope(&pb.WakuMessage{Timestamp: proto.Int64(0)}, 0, "A"), LowPriority)
-	queue.Push(protocol.NewEnvelope(&pb.WakuMessage{Timestamp: proto.Int64(1)}, 0, "B"), LowPriority)
-	queue.Push(protocol.NewEnvelope(&pb.WakuMessage{Timestamp: proto.Int64(2)}, 0, "C"), HighPriority)
-	queue.Push(protocol.NewEnvelope(&pb.WakuMessage{Timestamp: proto.Int64(3)}, 0, "D"), NormalPriority)
-	queue.Push(protocol.NewEnvelope(&pb.WakuMessage{Timestamp: proto.Int64(4)}, 0, "E"), HighPriority)
-	queue.Push(protocol.NewEnvelope(&pb.WakuMessage{Timestamp: proto.Int64(5)}, 0, "F"), LowPriority)
-	queue.Push(protocol.NewEnvelope(&pb.WakuMessage{Timestamp: proto.Int64(6)}, 0, "G"), NormalPriority)
+	queue.Push(ctx, protocol.NewEnvelope(&pb.WakuMessage{Timestamp: proto.Int64(0)}, 0, "A"), LowPriority)
+	queue.Push(ctx, protocol.NewEnvelope(&pb.WakuMessage{Timestamp: proto.Int64(1)}, 0, "B"), LowPriority)
+	queue.Push(ctx, protocol.NewEnvelope(&pb.WakuMessage{Timestamp: proto.Int64(2)}, 0, "C"), HighPriority)
+	queue.Push(ctx, protocol.NewEnvelope(&pb.WakuMessage{Timestamp: proto.Int64(3)}, 0, "D"), NormalPriority)
+	queue.Push(ctx, protocol.NewEnvelope(&pb.WakuMessage{Timestamp: proto.Int64(4)}, 0, "E"), HighPriority)
+	queue.Push(ctx, protocol.NewEnvelope(&pb.WakuMessage{Timestamp: proto.Int64(5)}, 0, "F"), LowPriority)
+	queue.Push(ctx, protocol.NewEnvelope(&pb.WakuMessage{Timestamp: proto.Int64(6)}, 0, "G"), NormalPriority)
 
 	time.Sleep(2 * time.Second)
 
-	envelope, ok := <-queue.Pop()
+	envelope, ok := <-queue.Pop(ctx)
 	require.True(t, ok)
 	require.Equal(t, "C", envelope.PubsubTopic())
 
-	envelope, ok = <-queue.Pop()
+	envelope, ok = <-queue.Pop(ctx)
 	require.True(t, ok)
 	require.Equal(t, "E", envelope.PubsubTopic())
 
-	envelope, ok = <-queue.Pop()
+	envelope, ok = <-queue.Pop(ctx)
 	require.True(t, ok)
 	require.Equal(t, "D", envelope.PubsubTopic())
 
-	envelope, ok = <-queue.Pop()
+	envelope, ok = <-queue.Pop(ctx)
 	require.True(t, ok)
 	require.Equal(t, "G", envelope.PubsubTopic())
 
-	envelope, ok = <-queue.Pop()
+	envelope, ok = <-queue.Pop(ctx)
 	require.True(t, ok)
 	require.Equal(t, "A", envelope.PubsubTopic())
 
-	envelope, ok = <-queue.Pop()
+	envelope, ok = <-queue.Pop(ctx)
 	require.True(t, ok)
 	require.Equal(t, "B", envelope.PubsubTopic())
 
-	envelope, ok = <-queue.Pop()
+	envelope, ok = <-queue.Pop(ctx)
 	require.True(t, ok)
 	require.Equal(t, "F", envelope.PubsubTopic())
 
 	cancel()
 
-	_, ok = <-queue.Pop()
+	_, ok = <-queue.Pop(ctx)
 	require.False(t, ok)
 
 }


### PR DESCRIPTION
@igor-sirotin reported the following error:

panic: send on closed channel
```
goroutine 228896 [running]:
github.com/waku-org/go-waku/waku/v2/api/publish.(*MessageQueue).Push(...)
        /Users/igorsirotin/Repositories/Status/status-go/vendor/github.com/waku-org/go-waku/waku/v2/api/publish/message_queue.go:131
github.com/status-im/status-go/wakuv2.(*Waku).Send(0x14002e9cf00, {0x14000bb8400?, 0xa?}, 0x1400347a000?, 0x107a22d50)
        /Users/igorsirotin/Repositories/Status/status-go/wakuv2/message_publishing.go:56 +0x140
github.com/status-im/status-go/wakuv2.(*PublicWakuAPI).Post(0x14006e4a3f0, {0x14001258f00?, 0x84?}, {{0x14001259100, 0x40}, {0x0, 0x0, 0x0}, {0x14001258f00, 0x40}, ...})
        /Users/igorsirotin/Repositories/Status/status-go/wakuv2/api.go:259 +0x568
```

Since this is happening because the channel is closed when the context is done, and the publish function is still being executed, attempting to add a message to the queue. To avoid this error, i just remove the need to close this channel, since it will be garbage collected eventually, since it will determine the channel to be unreachable will have its resources reclaimed whether or not it is closed, and also made Push and Pop functions cancelable by passing a context

Required to fix https://github.com/status-im/status-go/issues/5661
