### PR TITLE
chore: use utc time in logs to avoid user location getting disclosed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,10 @@ examples/basic-relay/build/basic-relay
 examples/filter2/build/filter2
 examples/noise/build/
 examples/noise/noise
+examples/basic-light-client/basic2
+examples/basic-relay/basic2
+examples/filter2/filter2
+examples/rln/rln
 
 # Test binary, built with `go test -c`
 *.test

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -157,3 +157,7 @@ func Uint64(key string, value uint64) zap.Field {
 	valueStr := fmt.Sprintf("%v", value)
 	return zap.String(key, valueStr)
 }
+
+func UTCTime(key string, t time.Time) zap.Field {
+	return zap.Time(key, t.UTC())
+}

--- a/waku/v2/peermanager/peer_connector.go
+++ b/waku/v2/peermanager/peer_connector.go
@@ -207,11 +207,11 @@ func (c *PeerConnectionStrategy) canDialPeer(pi peer.AddrInfo) bool {
 		now := time.Now()
 		if now.Before(tv.nextTry) {
 			c.logger.Debug("Skipping connecting to peer due to backoff strategy",
-				zap.Time("currentTime", now), zap.Time("until", tv.nextTry))
+				logging.UTCTime("currentTime", now), logging.UTCTime("until", tv.nextTry))
 			return false
 		}
 		c.logger.Debug("Proceeding with connecting to peer",
-			zap.Time("currentTime", now), zap.Time("nextTry", tv.nextTry))
+			logging.UTCTime("currentTime", now), logging.UTCTime("nextTry", tv.nextTry))
 	}
 	return true
 }
@@ -228,7 +228,7 @@ func (c *PeerConnectionStrategy) addConnectionBackoff(peerID peer.ID) {
 		cachedPeer = &connCacheData{strat: c.backoff()}
 		cachedPeer.nextTry = time.Now().Add(cachedPeer.strat.Delay())
 		c.logger.Debug("Initializing connectionCache for peer ",
-			logging.HostID("peerID", peerID), zap.Time("until", cachedPeer.nextTry))
+			logging.HostID("peerID", peerID), logging.UTCTime("until", cachedPeer.nextTry))
 		c.cache.Add(peerID, cachedPeer)
 	}
 }


### PR DESCRIPTION
# Description
fixes #1191 

# Changes

<!-- List of detailed changes -->

- [x] changed default source to return time in UTC . @richard-ramos i have noticed NTP is not being used in status, but if NTP is used would the timesource provide time in UTC or local tz?
- [x] changed other places where time is logged to use UTC






<!--
## How to test

1.
1.
1.

-->


<!--
## Issue

closes #
-->
