### PR TITLE
fix: flaky panic on relay unsubscribe

### DIFF
--- a/waku/v2/protocol/relay/waku_relay.go
+++ b/waku/v2/protocol/relay/waku_relay.go
@@ -459,37 +459,28 @@ func (w *WakuRelay) Unsubscribe(ctx context.Context, contentFilter waku_proto.Co
 	defer w.topicsMutex.Unlock()
 
 	for pubSubTopic, cTopics := range pubSubTopicMap {
-		cfTemp := waku_proto.NewContentFilter(pubSubTopic, cTopics...)
 		pubsubUnsubscribe := false
-		sub, ok := w.topics[pubSubTopic]
+		topicData, ok := w.topics[pubSubTopic]
 		if !ok {
 			w.log.Error("not subscribed to topic", zap.String("topic", pubSubTopic))
 			return errors.New("not subscribed to topic")
 		}
 
-		topicData, ok := w.topics[pubSubTopic]
-		if ok {
-			//Remove relevant subscription
-			for subID, sub := range topicData.contentSubs {
-				if sub.contentFilter.Equals(cfTemp) {
-					sub.Unsubscribe()
-					delete(topicData.contentSubs, subID)
-				}
+		cfTemp := waku_proto.NewContentFilter(pubSubTopic, cTopics...)
+		//Remove relevant subscription
+		for subID, sub := range topicData.contentSubs {
+			if sub.contentFilter.Equals(cfTemp) {
+				sub.Unsubscribe()
+				delete(topicData.contentSubs, subID)
 			}
+		}
 
-			if len(topicData.contentSubs) == 0 {
-				pubsubUnsubscribe = true
-			}
-		} else {
-			//Should not land here ideally
-			w.log.Error("pubsub subscriptions exists, but contentSubscription doesn't for contentFilter",
-				zap.String("pubsubTopic", pubSubTopic), zap.Strings("contentTopics", cTopics))
-
-			return errors.New("unexpected error in unsubscribe")
+		if len(topicData.contentSubs) == 0 {
+			pubsubUnsubscribe = true
 		}
 
 		if pubsubUnsubscribe {
-			err = w.unsubscribeFromPubsubTopic(sub)
+			err = w.unsubscribeFromPubsubTopic(topicData)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
# Description

This panic was randomly appearing in `TestPostToCommunityChat`:
```nim
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x11d7d31]

goroutine 1336997 [running]:
github.com/libp2p/go-libp2p-pubsub.(*Subscription).Topic(...)
	/home/jenkins/workspace/status-go/tests-nightly/vendor/github.com/libp2p/go-libp2p-pubsub/subscription.go:21
github.com/waku-org/go-waku/waku/v2/protocol/relay.(*WakuRelay).unsubscribeFromPubsubTopic(0xc049a84200, 0xc06af0f280)
	/home/jenkins/workspace/status-go/tests-nightly/vendor/github.com/waku-org/go-waku/waku/v2/protocol/relay/waku_relay.go:506 +0x31
github.com/waku-org/go-waku/waku/v2/protocol/relay.(*WakuRelay).Unsubscribe(0xc049a84200, {0xc02f751e50?, 0x2f9528a?}, {{0xc02b114060?, 0xc00402c600?}, 0xc04014a0f0?})
	/home/jenkins/workspace/status-go/tests-nightly/vendor/github.com/waku-org/go-waku/waku/v2/protocol/relay/waku_relay.go:492 +0x40a
github.com/status-im/status-go/wakuv2.(*Waku).subscribeToPubsubTopicWithWakuRelay.func1()
	/home/jenkins/workspace/status-go/tests-nightly/wakuv2/waku.go:652 +0x348
created by github.com/status-im/status-go/wakuv2.(*Waku).subscribeToPubsubTopicWithWakuRelay in goroutine 1331881
	/home/jenkins/workspace/status-go/tests-nightly/wakuv2/waku.go:647 +0x3d0
```

# Changes

Not sure if this fixes the bug, but this code was weird anyway
