### PR TITLE
fix: set default store hash query timeout to 30s

### DIFF
--- a/waku/v2/api/common/utils.go
+++ b/waku/v2/api/common/utils.go
@@ -1,0 +1,5 @@
+package common
+
+import "time"
+
+const DefaultStoreQueryTimeout = 30 * time.Second

--- a/waku/v2/api/missing/missing_messages.go
+++ b/waku/v2/api/missing/missing_messages.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/waku-org/go-waku/logging"
-	"github.com/waku-org/go-waku/waku/v2/api/common"
 	"github.com/waku-org/go-waku/waku/v2/protocol"
 	"github.com/waku-org/go-waku/waku/v2/protocol/pb"
 	"github.com/waku-org/go-waku/waku/v2/protocol/store"
@@ -262,7 +261,7 @@ func (m *MissingMessageVerifier) fetchMessagesBatch(c chan<- *protocol.Envelope,
 			defer wg.Wait()
 
 			result, err := m.storeQueryWithRetry(interest.ctx, func(ctx context.Context) (*store.Result, error) {
-				queryCtx, cancel := context.WithTimeout(ctx, common.DefaultStoreQueryTimeout)
+				queryCtx, cancel := context.WithTimeout(ctx, m.params.storeQueryTimeout)
 				defer cancel()
 				return m.store.QueryByHash(queryCtx, messageHashes, store.WithPeer(interest.peerID), store.WithPaging(false, maxMsgHashesPerRequest))
 			}, logger, "retrieving missing messages")

--- a/waku/v2/api/missing/options.go
+++ b/waku/v2/api/missing/options.go
@@ -1,11 +1,16 @@
 package missing
 
-import "time"
+import (
+	"time"
+
+	"github.com/waku-org/go-waku/waku/v2/api/common"
+)
 
 type missingMessageVerifierParams struct {
 	delay                        time.Duration
 	interval                     time.Duration
 	maxAttemptsToRetrieveHistory int
+	storeQueryTimeout            time.Duration
 }
 
 // MissingMessageVerifierOption is an option that can be used to customize the MissingMessageVerifier behavior
@@ -32,8 +37,16 @@ func WithMaxRetryAttempts(max int) MissingMessageVerifierOption {
 	}
 }
 
+// WithStoreQueryTimeout sets the timeout for store query
+func WithStoreQueryTimeout(timeout time.Duration) MissingMessageVerifierOption {
+	return func(params *missingMessageVerifierParams) {
+		params.storeQueryTimeout = timeout
+	}
+}
+
 var defaultMissingMessagesVerifierOptions = []MissingMessageVerifierOption{
 	WithVerificationInterval(time.Minute),
 	WithDelay(20 * time.Second),
 	WithMaxRetryAttempts(3),
+	WithStoreQueryTimeout(common.DefaultStoreQueryTimeout),
 }

--- a/waku/v2/api/publish/message_check.go
+++ b/waku/v2/api/publish/message_check.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/libp2p/go-libp2p/core/peer"
+	apicommon "github.com/waku-org/go-waku/waku/v2/api/common"
 	"github.com/waku-org/go-waku/waku/v2/protocol"
 	"github.com/waku-org/go-waku/waku/v2/protocol/pb"
 	"github.com/waku-org/go-waku/waku/v2/protocol/store"
@@ -218,7 +219,9 @@ func (m *MessageSentCheck) messageHashBasedQuery(ctx context.Context, hashes []c
 
 	m.logger.Debug("store.queryByHash request", zap.String("requestID", hexutil.Encode(requestID)), zap.Stringer("peerID", selectedPeer), zap.Stringers("messageHashes", messageHashes))
 
-	result, err := m.store.QueryByHash(ctx, messageHashes, opts...)
+	queryCtx, cancel := context.WithTimeout(ctx, apicommon.DefaultStoreQueryTimeout)
+	defer cancel()
+	result, err := m.store.QueryByHash(queryCtx, messageHashes, opts...)
 	if err != nil {
 		m.logger.Error("store.queryByHash failed", zap.String("requestID", hexutil.Encode(requestID)), zap.Stringer("peerID", selectedPeer), zap.Error(err))
 		return []common.Hash{}


### PR DESCRIPTION
# Description

Hash query may take too long, set the timeout to 30s to raise alert for any longer queries.

closes https://github.com/waku-org/go-waku/issues/1189

