### PR TITLE
fix: prevent panics in peermanager and WakuRelay

### DIFF
--- a/waku/v2/peermanager/peer_manager.go
+++ b/waku/v2/peermanager/peer_manager.go
@@ -125,6 +125,10 @@ func inAndOutRelayPeers(relayPeers int) (int, int) {
 // checkAndUpdateTopicHealth finds health of specified topic and updates and notifies of the same.
 // Also returns the healthyPeerCount
 func (pm *PeerManager) checkAndUpdateTopicHealth(topic *NodeTopicDetails) int {
+	if topic == nil {
+		return 0
+	}
+
 	healthyPeerCount := 0
 
 	for _, p := range pm.relay.PubSub().MeshPeers(topic.topic.String()) {

--- a/waku/v2/protocol/relay/waku_relay.go
+++ b/waku/v2/protocol/relay/waku_relay.go
@@ -493,6 +493,9 @@ func (w *WakuRelay) Unsubscribe(ctx context.Context, contentFilter waku_proto.Co
 // unsubscribeFromPubsubTopic unsubscribes subscription from underlying pubsub.
 // Note: caller has to acquire topicsMutex in order to avoid race conditions
 func (w *WakuRelay) unsubscribeFromPubsubTopic(topicData *pubsubTopicSubscriptionDetails) error {
+	if topicData.subscription == nil {
+		return nil
+	}
 
 	pubSubTopic := topicData.subscription.Topic()
 	w.log.Info("unsubscribing from pubsubTopic", zap.String("topic", pubSubTopic))


### PR DESCRIPTION
# Description

Fixes https://github.com/status-im/status-go/issues/5759
More details in the issue comments.

It's possible that those functions are called with such parameters that causes panics.
While we should probably find the root cause and fix it, I'd like to prevent panics in the first place.