### PR TITLE
fix: use correct ticker for all peers ping

### DIFF
--- a/waku/v2/node/keepalive.go
+++ b/waku/v2/node/keepalive.go
@@ -59,7 +59,7 @@ func (w *WakuNode) startKeepAlive(ctx context.Context, randomPeersPingDuration t
 	if allPeersPingDuration != 0 {
 		allPeersTicker := time.NewTicker(allPeersPingDuration)
 		defer allPeersTicker.Stop()
-		randomPeersTickerC = allPeersTicker.C
+		allPeersTickerC = allPeersTicker.C
 	}
 
 	lastTimeExecuted := w.timesource.Now()


### PR DESCRIPTION
https://github.com/waku-org/go-waku/pull/1214 for 2.30.x branch