### PR TITLE
feat: increase outbound q size for pubsub

### DIFF
--- a/waku/v2/protocol/relay/config.go
+++ b/waku/v2/protocol/relay/config.go
@@ -13,6 +13,10 @@ import (
 
 var DefaultRelaySubscriptionBufferSize int = 1024
 
+// trying to match value here https://github.com/vacp2p/nim-libp2p/pull/1077
+// note that nim-libp2p has 2 peer queues 1 for priority and other non-priority, whereas go-libp2p seems to have single peer-queue
+var DefaultPeerOutboundQSize int = 1024
+
 type RelaySubscribeParameters struct {
 	dontConsume bool
 	cacheSize   uint
@@ -109,6 +113,7 @@ func (w *WakuRelay) defaultPubsubOptions() []pubsub.Option {
 		pubsub.WithSeenMessagesTTL(2 * time.Minute),
 		pubsub.WithPeerScore(w.peerScoreParams, w.peerScoreThresholds),
 		pubsub.WithPeerScoreInspect(w.peerScoreInspector, 6*time.Second),
+		pubsub.WithPeerOutboundQueueSize(DefaultPeerOutboundQSize),
 	}
 }
 


### PR DESCRIPTION
# Description
while going through logs in status-desktop relay mode, i had noticed following log occuring quite consistently.

`DEBUG[09-05|06:35:08.182|go.uber.org/zap/sugar.go:198]                                                               dropping message to peer 16Uiu2HAmGAA54bBTE78MYidSy3P7Q9yAWFNTAEReJYD69VRvtL5r: queue full `

On quick analysis, noticed that this is happening towards almost all peers. 

In a span of ~24 hours i could see logs towards almost 200 peers which shows that we need to increase queue-size that might be causing this. 

```

grep "dropping message to peer" geth* | awk '{print $6}' | sort | uniq  | wc -l
     202

```

# Changes

<!-- List of detailed changes -->

- [ ] increased default outbound queue size towards peers from 32 to 1024 (in alignment with nwaku https://github.com/vacp2p/nim-libp2p/pull/1077)


# Tests

dogfooding in progress, will update with results