### PR TITLE
ci: use GIT_REF for building docker image when set

### DIFF
--- a/ci/Jenkinsfile.docker
+++ b/ci/Jenkinsfile.docker
@@ -43,9 +43,10 @@ pipeline {
   stages {
     stage('Build') {
       steps { script {
+        def commitOrRef = params.GIT_REF ? params.GIT_REF.take(8) : GIT_COMMIT.take(8)
         image = docker.build(
-          "${params.IMAGE_NAME}:${params.IMAGE_TAG ?: GIT_COMMIT.take(8)}",
-          "--build-arg='GIT_COMMIT=${GIT_COMMIT.take(8)}' ."
+          "${params.IMAGE_NAME}:${params.IMAGE_TAG ?: commitOrRef}",
+          "--build-arg='GIT_COMMIT=${commitOrRef}' ."
         )
       } }
     }


### PR DESCRIPTION
# Description
This PR updates the build stage which builds the Docker Image to use `GIT_REF` when its set.
This ensures that when we perform a parameterised build from Jenkins we actually get a docker image from the branch or commit we set in `GIT_REF`