### PR TITLE
feat: emit an event in EventBus upon dial error

### DIFF
--- a/waku/v2/node/wakunode2.go
+++ b/waku/v2/node/wakunode2.go
@@ -751,10 +751,7 @@ func (w *WakuNode) DialPeerWithInfo(ctx context.Context, peerInfo peer.AddrInfo)
 
 func (w *WakuNode) connect(ctx context.Context, info peer.AddrInfo) error {
 	err := w.host.Connect(ctx, info)
-	if err != nil {
-		w.host.Peerstore().(wps.WakuPeerstore).AddConnFailure(info.ID)
-		return err
-	}
+	w.peerConnector.HandleDialError(err, info.ID)
 
 	for _, addr := range info.Addrs {
 		// TODO: this is a temporary fix

--- a/waku/v2/node/wakunode2.go
+++ b/waku/v2/node/wakunode2.go
@@ -751,7 +751,12 @@ func (w *WakuNode) DialPeerWithInfo(ctx context.Context, peerInfo peer.AddrInfo)
 
 func (w *WakuNode) connect(ctx context.Context, info peer.AddrInfo) error {
 	err := w.host.Connect(ctx, info)
-	w.peerConnector.HandleDialError(err, info.ID)
+	if err != nil {
+		if w.peermanager != nil {
+			w.peermanager.HandleDialError(err, info.ID)
+		}
+		return err
+	}
 
 	for _, addr := range info.Addrs {
 		// TODO: this is a temporary fix

--- a/waku/v2/peermanager/peer_connector.go
+++ b/waku/v2/peermanager/peer_connector.go
@@ -4,7 +4,6 @@ package peermanager
 
 import (
 	"context"
-	"errors"
 	"math/rand"
 	"sync"
 	"sync/atomic"
@@ -19,9 +18,7 @@ import (
 	"github.com/waku-org/go-waku/waku/v2/onlinechecker"
 	wps "github.com/waku-org/go-waku/waku/v2/peerstore"
 	"github.com/waku-org/go-waku/waku/v2/service"
-	"github.com/waku-org/go-waku/waku/v2/utils"
 
-	"github.com/libp2p/go-libp2p/core/event"
 	"go.uber.org/zap"
 
 	lru "github.com/hashicorp/golang-lru"
@@ -41,9 +38,8 @@ type PeerConnectionStrategy struct {
 	*service.CommonDiscoveryService
 	subscriptions []subscription
 
-	backoff      backoff.BackoffFactory
-	logger       *zap.Logger
-	evtDialError event.Emitter
+	backoff backoff.BackoffFactory
+	logger  *zap.Logger
 }
 
 type subscription struct {
@@ -159,11 +155,6 @@ func (c *PeerConnectionStrategy) SetHost(h host.Host) {
 // Start attempts to connect to the peers passed in by peerCh.
 // Will not connect to peers if they are within the backoff period.
 func (c *PeerConnectionStrategy) Start(ctx context.Context) error {
-	var err error
-	c.evtDialError, err = c.host.EventBus().Emitter(new(utils.DialError))
-	if err != nil {
-		return err
-	}
 	return c.CommonDiscoveryService.Start(ctx, c.start)
 
 }
@@ -179,9 +170,7 @@ func (c *PeerConnectionStrategy) start() error {
 
 // Stop terminates the peer-connector
 func (c *PeerConnectionStrategy) Stop() {
-	c.CommonDiscoveryService.Stop(func() {
-		c.evtDialError.Close()
-	})
+	c.CommonDiscoveryService.Stop(func() {})
 }
 
 func (c *PeerConnectionStrategy) isPaused() bool {
@@ -287,19 +276,10 @@ func (c *PeerConnectionStrategy) dialPeer(pi peer.AddrInfo, sem chan struct{}) {
 	ctx, cancel := context.WithTimeout(c.Context(), c.dialTimeout)
 	defer cancel()
 	err := c.host.Connect(ctx, pi)
-	c.HandleDialError(err, pi.ID)
-	c.host.Peerstore().(wps.WakuPeerstore).ResetConnFailures(pi.ID)
-	<-sem
-}
-
-func (c *PeerConnectionStrategy) HandleDialError(err error, peerID peer.ID) {
-	if err != nil && !errors.Is(err, context.Canceled) {
-		c.addConnectionBackoff(peerID)
-		c.host.Peerstore().(wps.WakuPeerstore).AddConnFailure(peerID)
-		c.logger.Warn("connecting to peer", logging.HostID("peerID", peerID), zap.Error(err))
-		emitterErr := c.evtDialError.Emit(utils.DialError{Err: err, PeerID: peerID})
-		if emitterErr != nil {
-			c.logger.Error("failed to emit DialError", zap.Error(emitterErr))
-		}
+	if err != nil {
+		c.pm.HandleDialError(err, pi.ID)
+	} else {
+		c.host.Peerstore().(wps.WakuPeerstore).ResetConnFailures(pi.ID)
 	}
+	<-sem
 }

--- a/waku/v2/peermanager/peer_manager_test.go
+++ b/waku/v2/peermanager/peer_manager_test.go
@@ -223,6 +223,7 @@ func TestConnectToRelayPeers(t *testing.T) {
 	ctx, pm, deferFn := initTest(t)
 	pc, err := NewPeerConnectionStrategy(pm, onlinechecker.NewDefaultOnlineChecker(true), 120*time.Second, pm.logger)
 	require.NoError(t, err)
+	pc.SetHost(pm.host)
 	err = pc.Start(ctx)
 	require.NoError(t, err)
 	pm.Start(ctx)

--- a/waku/v2/protocol/filter/client.go
+++ b/waku/v2/protocol/filter/client.go
@@ -245,8 +245,8 @@ func (wf *WakuFilterLightNode) request(ctx context.Context, requestID []byte,
 	stream, err := wf.h.NewStream(ctx, peerID, FilterSubscribeID_v20beta1)
 	if err != nil {
 		wf.metrics.RecordError(dialFailure)
-		if ps, ok := wf.h.Peerstore().(peerstore.WakuPeerstore); ok {
-			ps.AddConnFailure(peerID)
+		if wf.pm != nil {
+			wf.pm.HandleDialError(err, peerID)
 		}
 		return err
 	}

--- a/waku/v2/protocol/legacy_store/waku_store_client.go
+++ b/waku/v2/protocol/legacy_store/waku_store_client.go
@@ -205,10 +205,9 @@ func (store *WakuStore) queryFrom(ctx context.Context, historyRequest *pb.Histor
 
 	stream, err := store.h.NewStream(ctx, selectedPeer, StoreID_v20beta4)
 	if err != nil {
-		logger.Error("creating stream to peer", zap.Error(err))
 		store.metrics.RecordError(dialFailure)
-		if ps, ok := store.h.Peerstore().(peerstore.WakuPeerstore); ok {
-			ps.AddConnFailure(selectedPeer)
+		if store.pm != nil {
+			store.pm.HandleDialError(err, selectedPeer)
 		}
 		return nil, err
 	}

--- a/waku/v2/protocol/lightpush/waku_lightpush.go
+++ b/waku/v2/protocol/lightpush/waku_lightpush.go
@@ -195,10 +195,9 @@ func (wakuLP *WakuLightPush) request(ctx context.Context, req *pb.PushRequest, p
 
 	stream, err := wakuLP.h.NewStream(ctx, peerID, LightPushID_v20beta1)
 	if err != nil {
-		logger.Error("creating stream to peer", zap.Error(err))
 		wakuLP.metrics.RecordError(dialFailure)
-		if ps, ok := wakuLP.h.Peerstore().(peerstore.WakuPeerstore); ok {
-			ps.AddConnFailure(peerID)
+		if wakuLP.pm != nil {
+			wakuLP.pm.HandleDialError(err, peerID)
 		}
 		return nil, err
 	}

--- a/waku/v2/protocol/peer_exchange/client.go
+++ b/waku/v2/protocol/peer_exchange/client.go
@@ -76,8 +76,8 @@ func (wakuPX *WakuPeerExchange) Request(ctx context.Context, numPeers int, opts 
 
 	stream, err := wakuPX.h.NewStream(ctx, params.selectedPeer, PeerExchangeID_v20alpha1)
 	if err != nil {
-		if ps, ok := wakuPX.h.Peerstore().(peerstore.WakuPeerstore); ok {
-			ps.AddConnFailure(params.selectedPeer)
+		if wakuPX.pm != nil {
+			wakuPX.pm.HandleDialError(err, params.selectedPeer)
 		}
 		return err
 	}

--- a/waku/v2/protocol/store/client.go
+++ b/waku/v2/protocol/store/client.go
@@ -281,9 +281,8 @@ func (s *WakuStore) queryFrom(ctx context.Context, storeRequest *pb.StoreQueryRe
 
 	stream, err := s.h.NewStream(ctx, params.selectedPeer, StoreQueryID_v300)
 	if err != nil {
-		logger.Error("creating stream to peer", zap.Error(err))
-		if ps, ok := s.h.Peerstore().(peerstore.WakuPeerstore); ok {
-			ps.AddConnFailure(params.selectedPeer)
+		if s.pm != nil {
+			s.pm.HandleDialError(err, params.selectedPeer)
 		}
 		return nil, err
 	}

--- a/waku/v2/utils/peer.go
+++ b/waku/v2/utils/peer.go
@@ -5,6 +5,11 @@ import (
 	"github.com/multiformats/go-multiaddr"
 )
 
+type DialError struct {
+	Err    error
+	PeerID peer.ID
+}
+
 // GetPeerID is used to extract the peerID from a multiaddress
 func GetPeerID(m multiaddr.Multiaddr) (peer.ID, error) {
 	peerIDStr, err := m.ValueForProtocol(multiaddr.P_P2P)


### PR DESCRIPTION
# Description
<!--- Describe your changes to provide context for reviewrs -->

Upon error dialing in `PeerConnectionStrategy.dialPeer` or `WakuNode.connect`, emit a `DialError` event. This allows consumers of `go-waku` to subscribe to a channel which outputs the dial errors as they occur.

# Changes

<!-- List of detailed changes -->

- Create `DialError` interface in utils
- Add an event emitter for `DialError` events to `PeerConnectionStrategy` (created in `Start()`, closed in `Stop()`)
- Add a function `HandleDialError` to `PeerConnectionStrategy` that:
  - runs existing logic on dial failure (add backoff, add to connection failures in waku peer store)
  - emit a `DialError` event using the ID of the peer and the returned error message from `c.host.Connect(ctx, pi)`
- use above function in `PeerConnectionStrategy.dialPeer` and `WakuNode.connect` when an error is returned by `host.Connect`

# Tests

<!-- List down any tests that were executed specifically for this pull-request -->



<!--
## How to test

1.
1.
1.

-->


<!--
## Issue

closes #
-->
