### PR TITLE
fix: filter batch duration opt was not propagated correctly

### DIFF
--- a/waku/v2/api/filter/filter_test.go
+++ b/waku/v2/api/filter/filter_test.go
@@ -54,7 +54,8 @@ func (s *FilterApiTestSuite) TestSubscribe() {
 	s.Require().Equal(contentFilter.PubsubTopic, s.TestTopic)
 	ctx, cancel := context.WithCancel(context.Background())
 	s.Log.Info("About to perform API Subscribe()")
-	apiSub, err := Subscribe(ctx, s.LightNode, contentFilter, apiConfig, s.Log)
+	params := subscribeParameters{300 * time.Second, 1024}
+	apiSub, err := Subscribe(ctx, s.LightNode, contentFilter, apiConfig, s.Log, &params)
 	s.Require().NoError(err)
 	s.Require().Equal(apiSub.ContentFilter, contentFilter)
 	s.Log.Info("Subscribed")


### PR DESCRIPTION
# Description
The fix made in release branch to update filter batch duration ticker to 300ms was not propagated correctly in the code that is moved to go-waku. 
this PR addresses the gaps in the fix propagation.

# Changes

<!-- List of detailed changes -->

- [x] option of batch duration passed to FilterManager is not applied correctly in filter manager causing batch loop to run once every 5 seconds.
- [x] some movement of options from Subscribe to FilterManager constructor.

