### PR TITLE
chore: use decred secp256k1 directly

### DIFF
--- a/waku/v2/utils/crypto.go
+++ b/waku/v2/utils/crypto.go
@@ -3,21 +3,21 @@ package utils
 import (
 	"crypto/ecdsa"
 
-	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/decred/dcrd/dcrec/secp256k1/v4"
 	"github.com/libp2p/go-libp2p/core/crypto"
 )
 
 // EcdsaPubKeyToSecp256k1PublicKey converts an `ecdsa.PublicKey` into a libp2p `crypto.Secp256k1PublicKey“
 func EcdsaPubKeyToSecp256k1PublicKey(pubKey *ecdsa.PublicKey) *crypto.Secp256k1PublicKey {
-	xFieldVal := &btcec.FieldVal{}
-	yFieldVal := &btcec.FieldVal{}
+	xFieldVal := &secp256k1.FieldVal{}
+	yFieldVal := &secp256k1.FieldVal{}
 	xFieldVal.SetByteSlice(pubKey.X.Bytes())
 	yFieldVal.SetByteSlice(pubKey.Y.Bytes())
-	return (*crypto.Secp256k1PublicKey)(btcec.NewPublicKey(xFieldVal, yFieldVal))
+	return (*crypto.Secp256k1PublicKey)(secp256k1.NewPublicKey(xFieldVal, yFieldVal))
 }
 
 // EcdsaPrivKeyToSecp256k1PrivKey converts an `ecdsa.PrivateKey` into a libp2p `crypto.Secp256k1PrivateKey“
 func EcdsaPrivKeyToSecp256k1PrivKey(privKey *ecdsa.PrivateKey) *crypto.Secp256k1PrivateKey {
-	privK, _ := btcec.PrivKeyFromBytes(privKey.D.Bytes())
+	privK := secp256k1.PrivKeyFromBytes(privKey.D.Bytes())
 	return (*crypto.Secp256k1PrivateKey)(privK)
 }


### PR DESCRIPTION
Use `github.com/decred/dcrd/dcrec/secp256k1/v4` directly rather than `github.com/btcsuite/btcd/btcec/v2` which is just a wrapper around the underlying decred library. Inspired by ethereum/go-ethereum#30595

`github.com/btcsuite/btcd/btcec/v2` has a very annoying breaking change when upgrading from v2.3.3 to v2.3.4. The easiest way to work around this is to remove the wrapper.