### PR TITLE
refactor: use protobuffer for API storenode queries

### DIFF
--- a/waku/v2/api/common/storenode_requestor.go
+++ b/waku/v2/api/common/storenode_requestor.go
@@ -1,0 +1,12 @@
+package common
+
+import (
+	"context"
+
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/waku-org/go-waku/waku/v2/protocol/store/pb"
+)
+
+type StorenodeRequestor interface {
+	Query(ctx context.Context, peerID peer.ID, query *pb.StoreQueryRequest) (StoreRequestResult, error)
+}

--- a/waku/v2/api/history/cycle.go
+++ b/waku/v2/api/history/cycle.go
@@ -393,14 +393,10 @@ func (m *StorenodeCycle) SetStorenodeConfigProvider(provider StorenodeConfigProv
 	m.storenodeConfigProvider = provider
 }
 
-func (m *StorenodeCycle) WaitForAvailableStoreNode(ctx context.Context, timeout time.Duration) bool {
-	// Add 1 second to timeout, because the storenode cycle has 1 second ticker, which doesn't tick on start.
+func (m *StorenodeCycle) WaitForAvailableStoreNode(ctx context.Context) bool {
+	// Note: Add 1 second to timeout, because the storenode cycle has 1 second ticker, which doesn't tick on start.
 	// This can be improved after merging https://github.com/status-im/status-go/pull/4380.
 	// NOTE: https://stackoverflow.com/questions/32705582/how-to-get-time-tick-to-tick-immediately
-	timeout += time.Second
-
-	ctx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
 
 	wg := sync.WaitGroup{}
 	wg.Add(1)
@@ -410,7 +406,18 @@ func (m *StorenodeCycle) WaitForAvailableStoreNode(ctx context.Context, timeout 
 			select {
 			case <-m.StorenodeAvailableOneshotEmitter.Subscribe():
 			case <-ctx.Done():
+				if errors.Is(ctx.Err(), context.Canceled) {
+					return
+				}
+
+				// Wait for an additional second, but handle cancellation
+				select {
+				case <-time.After(1 * time.Second):
+				case <-ctx.Done(): // context was cancelled
+				}
+
 				return
+
 			}
 		}
 	}()
@@ -418,6 +425,11 @@ func (m *StorenodeCycle) WaitForAvailableStoreNode(ctx context.Context, timeout 
 	select {
 	case <-waitForWaitGroup(&wg):
 	case <-ctx.Done():
+		// Wait for an additional second, but handle cancellation
+		select {
+		case <-time.After(1 * time.Second):
+		case <-ctx.Done(): // context was cancelled o
+		}
 	}
 
 	return m.IsStorenodeAvailable(m.activeStorenode)

--- a/waku/v2/api/missing/default_requestor.go
+++ b/waku/v2/api/missing/default_requestor.go
@@ -5,12 +5,12 @@ import (
 
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/waku-org/go-waku/waku/v2/api/common"
-	"github.com/waku-org/go-waku/waku/v2/protocol"
 	"github.com/waku-org/go-waku/waku/v2/protocol/pb"
 	"github.com/waku-org/go-waku/waku/v2/protocol/store"
+	storepb "github.com/waku-org/go-waku/waku/v2/protocol/store/pb"
 )
 
-func NewDefaultStorenodeRequestor(store *store.WakuStore) StorenodeRequestor {
+func NewDefaultStorenodeRequestor(store *store.WakuStore) common.StorenodeRequestor {
 	return &defaultStorenodeRequestor{
 		store: store,
 	}
@@ -24,10 +24,6 @@ func (d *defaultStorenodeRequestor) GetMessagesByHash(ctx context.Context, peerI
 	return d.store.QueryByHash(ctx, messageHashes, store.WithPeer(peerID), store.WithPaging(false, pageSize))
 }
 
-func (d *defaultStorenodeRequestor) QueryWithCriteria(ctx context.Context, peerID peer.ID, pageSize uint64, pubsubTopic string, contentTopics []string, from *int64, to *int64) (common.StoreRequestResult, error) {
-	return d.store.Query(ctx, store.FilterCriteria{
-		ContentFilter: protocol.NewContentFilter(pubsubTopic, contentTopics...),
-		TimeStart:     from,
-		TimeEnd:       to,
-	}, store.WithPeer(peerID), store.WithPaging(false, pageSize), store.IncludeData(false))
+func (d *defaultStorenodeRequestor) Query(ctx context.Context, peerID peer.ID, storeQueryRequest *storepb.StoreQueryRequest) (common.StoreRequestResult, error) {
+	return d.store.RequestRaw(ctx, peerID, storeQueryRequest)
 }


### PR DESCRIPTION
To allow more flexibility at the moment of doing queries, instead of having custom functions that receive N different combination of parameters to do a store query, we use instead a single function which receives instead a StoreQueryRequest protobuffer

The json representation of the StoreQueryRequest matches what is used in libwaku, and since protobuffers in nwaku and go-waku are the same (and are supposed to be backward compatible), we can safely use them. It has the side effect of making the API simpler too

cc: @gabrielmer, @Ivansete-status 