### PR TITLE
refactor: extract ping interface

### DIFF
--- a/waku/v2/api/common/pinger.go
+++ b/waku/v2/api/common/pinger.go
@@ -1,0 +1,37 @@
+package common
+
+import (
+	"context"
+	"time"
+
+	"github.com/libp2p/go-libp2p/core/host"
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/libp2p/go-libp2p/p2p/protocol/ping"
+)
+
+type Pinger interface {
+	PingPeer(ctx context.Context, peerID peer.ID) (time.Duration, error)
+}
+
+type defaultPingImpl struct {
+	host host.Host
+}
+
+func NewDefaultPinger(host host.Host) Pinger {
+	return &defaultPingImpl{
+		host: host,
+	}
+}
+
+func (d *defaultPingImpl) PingPeer(ctx context.Context, peerID peer.ID) (time.Duration, error) {
+	pingResultCh := ping.Ping(ctx, d.host, peerID)
+	select {
+	case <-ctx.Done():
+		return 0, ctx.Err()
+	case r := <-pingResultCh:
+		if r.Error != nil {
+			return 0, r.Error
+		}
+		return r.RTT, nil
+	}
+}


### PR DESCRIPTION
This would allow replacing the Ping function by a nim-libp2p implementation in status-go + nwaku.
A default implementation is also provided to be used in status-go + gowaku

cc: @gabrielmer  @Ivansete-status 