### PR TITLE
feat: add option to specify preferred peers for filter

### DIFF
--- a/waku/v2/api/filter/filter_test.go
+++ b/waku/v2/api/filter/filter_test.go
@@ -54,7 +54,7 @@ func (s *FilterApiTestSuite) TestSubscribe() {
 	s.Require().Equal(contentFilter.PubsubTopic, s.TestTopic)
 	ctx, cancel := context.WithCancel(context.Background())
 	s.Log.Info("About to perform API Subscribe()")
-	params := subscribeParameters{300 * time.Second, 1024}
+	params := subscribeParameters{300 * time.Second, 1024, nil}
 	apiSub, err := Subscribe(ctx, s.LightNode, contentFilter, apiConfig, s.Log, &params)
 	s.Require().NoError(err)
 	s.Require().Equal(apiSub.ContentFilter, contentFilter)


### PR DESCRIPTION
# Description
Added functionality to specify preferred-peers for filter. One of the peers used for filter subscription out of n will be randomly chosen from list of preferred peers. 

In case of status this is meant to increase filter subscription success-rate as fleet nodes will be specified as filter-peers.

once this is dogfooded, lightpush can also be modified to use same logic.

status-go pr including these changes https://github.com/status-im/status-go/pull/5964