### PR TITLE
Correct Grammar, Capitalization, and Terminology

### DIFF
--- a/docs/api/dnsdisc.md
+++ b/docs/api/dnsdisc.md
@@ -4,17 +4,17 @@ DNS Discovery enables anyone to register an ENR tree in the TXT field of a domai
 
 ENR is the format used to store node connection details (ip, port, multiaddr, etc).
 
-This enables a separation of software development and operations as dApp developers can include one or several domain names to use for DNS discovery, while operators can handle the update of the dns record.
+This enables a separation of software development and operations as dApp developers can include one or several domain names to use for DNS discovery, while operators can handle the update of the DNS record.
 
 It also enables more decentralized bootstrapping as anyone can register a domain name and publish it for others to use.
 
 **Pros**:
 - Low latency, low resource requirements,
 - Bootstrap list can be updated by editing a domain name: no code change is needed,
-- Can reference to a greater list of nodes by pointing to other domain names in the code or in the ENR tree.
+- Can reference a greater list of nodes by pointing to other domain names in the code or in the ENR tree.
 
 **Cons**:
-- Prone to censorship: domain names can be blocked,
+- Prone to censorship: domain names can be censored,
 - Limited: Static number of nodes, operators must provide their ENR to the domain owner to get their node listed.
 
 

--- a/examples/noise/README.md
+++ b/examples/noise/README.md
@@ -2,7 +2,7 @@
 
 ## Background
 
-The `noise` application is an example that shows how to do pairing between js-waku and go-waku
+The `noise` application is an example that demonstrates how to do pairing between js-waku and go-waku
 
 ## Preparation
 ```
@@ -16,4 +16,4 @@ To start the `noise` application run the following from the project directory
 ```
 ./build/noise
 ```
-The app will display a QR and a link that will open the js-noise example in the browser. The handshake process will start afterwards
+The app will display a QR code and a link that opens the js-noise example in the browser. The handshake process begins afterwards

--- a/library/mobile/README.md
+++ b/library/mobile/README.md
@@ -4,7 +4,7 @@ Package mobile implements [gomobile](https://github.com/golang/mobile) bindings 
 
 ## Usage
 
-For properly using this package, please refer to Makefile in the root of `go-waku` directory.
+For proper use this package, please refer to Makefile in the root of `go-waku` directory.
 
 To manually build library, run following commands:
 
@@ -24,7 +24,7 @@ export ANDROID_HOME=/path/to/android/sdk/
 gomobile init
 gomobile bind -v -target=android -ldflags="-s -w" github.com/waku-org/go-waku/mobile
 ```
-This will generate `gowaku.aar` file in the current dir.
+This will generate `gowaku.aar` file in the current directory.
 
 ## Notes
 


### PR DESCRIPTION
Description: This PR includes several corrections to improve clarity, consistency, and terminology:

Changed "reference to a greater list" to "reference a greater list" for grammatical accuracy.
Capitalized "dns record" to "DNS record" to follow proper abbreviation conventions.
Replaced "can be blocked" with "can be censored" for better context.
Changed "shows" to "demonstrates" for a more formal tone.
Replaced "QR" with "QR code" for clarity.
Changed "will open" to "opens" for consistency in tense.
Replaced "will start" with "begins" for a more concise expression.
Corrected "For properly using" to "For proper use" for grammatical correctness.
Expanded "current dir" to "current directory" for clarity.