### PR TITLE
fix: have better defaults for send/recv rate-limits 

### DIFF
--- a/waku/v2/api/publish/message_sender.go
+++ b/waku/v2/api/publish/message_sender.go
@@ -16,8 +16,8 @@ import (
 )
 
 const DefaultPeersToPublishForLightpush = 2
-const DefaultPublishingLimiterRate = rate.Limit(2)
-const DefaultPublishingLimitBurst = 4
+const DefaultPublishingLimiterRate = rate.Limit(5)
+const DefaultPublishingLimitBurst = 10
 
 type PublishMethod int
 

--- a/waku/v2/protocol/filter/options.go
+++ b/waku/v2/protocol/filter/options.go
@@ -83,7 +83,7 @@ func WithLightNodeRateLimiter(r rate.Limit, b int) LightNodeOption {
 
 func DefaultLightNodeOptions() []LightNodeOption {
 	return []LightNodeOption{
-		WithLightNodeRateLimiter(1, 1),
+		WithLightNodeRateLimiter(15, 20),
 	}
 }
 


### PR DESCRIPTION
# Description

have better defaults for send/recv rate-limits to accomodate status use-case

default rate-limits set for publishing and filter client receiving is not sufficient for status and is causing message reliability issues like https://github.com/status-im/status-mobile/pull/21809#issuecomment-2539022490.


# Changes

<!-- List of detailed changes -->

- increase receive rate-limit to match ~1000/min
- increase publish rate-limit to 5 per second

note that i have given higher bursts so that there is room for occasional bursts.
