### PR TITLE
fix: filter network change

### DIFF
--- a/waku/v2/api/filter/filter_test.go
+++ b/waku/v2/api/filter/filter_test.go
@@ -161,9 +161,9 @@ func (s *FilterApiTestSuite) TestFilterManager() {
 	// Mock peers going down
 	s.LightNodeHost.Peerstore().RemovePeer(s.FullNodeHost.ID())
 
-	fm.OnConnectionStatusChange("", false)
+	fm.OnConnectionStatusChange("", false, 0)
 	time.Sleep(2 * time.Second)
-	fm.OnConnectionStatusChange("", true)
+	fm.OnConnectionStatusChange("", true, 0)
 	s.ConnectToFullNode(s.LightNode, s.FullNode)
 	time.Sleep(3 * time.Second)
 

--- a/waku/v2/protocol/filter/client.go
+++ b/waku/v2/protocol/filter/client.go
@@ -175,7 +175,7 @@ func (wf *WakuFilterLightNode) onRequest(ctx context.Context) func(network.Strea
 		}
 
 		if !wf.subscriptions.IsSubscribedTo(peerID) {
-			logger.Warn("received message push from unknown peer", logging.HostID("peerID", peerID))
+			logger.Warn("received message push from unknown peer")
 			wf.metrics.RecordError(unknownPeerMessagePush)
 			//Send a wildcard unsubscribe to this peer so that further requests are not forwarded to us
 			if err := stream.Reset(); err != nil {


### PR DESCRIPTION
# Description
If there is a network type change i.e from wifi to 4G even if it involves an intermediary transition to offline, then unsubscribe and resubscribe all filters. 

This is to avoid filter-push issue noticed as per https://discord.com/channels/1110799176264056863/1111541184490393691/1318842541436829717. 



<!--
## How to test

1.
1.
1.

-->


<!--
## Issue

closes #
-->
