### PR TITLE
fix: setting peerId for store query

### DIFF
--- a/waku/v2/protocol/store/client.go
+++ b/waku/v2/protocol/store/client.go
@@ -203,9 +203,19 @@ func (s *WakuStore) RequestRaw(ctx context.Context, peerInfo peer.AddrInfo, stor
 	}
 
 	var params Parameters
-	params.selectedPeer = peerInfo.ID
-	if params.selectedPeer == "" {
+	params.peerAddr = peerInfo.Addrs
+	if len(params.peerAddr) == 0 {
 		return nil, ErrMustSelectPeer
+	}
+
+	//Add Peer to peerstore.
+	if s.pm != nil && params.peerAddr != nil {
+		pData, err := s.pm.AddPeer(params.peerAddr, peerstore.Static, []string{}, StoreQueryID_v300)
+		if err != nil {
+			return nil, err
+		}
+		s.pm.Connect(pData)
+		params.selectedPeer = pData.AddrInfo.ID
 	}
 
 	response, err := s.queryFrom(ctx, storeRequest, &params)

--- a/waku/v2/protocol/store/client.go
+++ b/waku/v2/protocol/store/client.go
@@ -205,22 +205,13 @@ func (s *WakuStore) RequestRaw(ctx context.Context, peerInfo peer.AddrInfo, stor
 
 	var params Parameters
 	params.peerAddr = peerInfo.Addrs
-	if len(params.peerAddr) == 0 {
+	params.selectedPeer = peerInfo.ID
+	if len(params.peerAddr) == 0 || params.selectedPeer == "" {
 		return nil, ErrMustSelectPeer
 	}
 
 	//Add Peer to peerstore.
-	if s.pm != nil && params.peerAddr != nil {
-		infoArr, err := peer.AddrInfosFromP2pAddrs(params.peerAddr...)
-		if err != nil {
-			return nil, err
-		}
-		for _, info := range infoArr {
-			s.h.Peerstore().AddAddrs(info.ID, info.Addrs, libp2pPeerstore.AddressTTL)
-
-		}
-		params.selectedPeer = infoArr[0].ID
-	}
+	s.h.Peerstore().AddAddrs(peerInfo.ID, peerInfo.Addrs, libp2pPeerstore.AddressTTL)
 
 	response, err := s.queryFrom(ctx, storeRequest, &params)
 	if err != nil {

--- a/waku/v2/protocol/store/client.go
+++ b/waku/v2/protocol/store/client.go
@@ -203,8 +203,8 @@ func (s *WakuStore) RequestRaw(ctx context.Context, peerInfo peer.AddrInfo, stor
 	}
 
 	var params Parameters
-	params.peerAddr = peerInfo.Addrs
-	if len(params.peerAddr) == 0 {
+	params.selectedPeer = peerInfo.ID
+	if params.selectedPeer == "" {
 		return nil, ErrMustSelectPeer
 	}
 


### PR DESCRIPTION
# Description
Improving a small change introduced in https://github.com/waku-org/go-waku/pull/1269 which breaks the store queries in `status-go` 

# Changes

- [x] setting the peerId before performing a store query and adding the peer to the peer store



## Issue
 https://github.com/status-im/status-go/issues/6439 and https://github.com/status-im/status-mobile/issues/22343
