### PR TITLE
fix: store query by hash

### DIFF
--- a/.github/docker-compose/nwaku.yml
+++ b/.github/docker-compose/nwaku.yml
@@ -1,6 +1,13 @@
 services:
   nwaku:
     image: "harbor.status.im/wakuorg/nwaku:latest"
-    command: ["--relay", "--store", "--nodekey=1122334455667788990011223344556677889900112233445566778899001122", "--cluster-id=99", "--pubsub-topic=/waku/2/rs/99/1"]
+    command:
+      [
+        "--relay",
+        "--store",
+        "--nodekey=1122334455667788990011223344556677889900112233445566778899001122",
+        "--cluster-id=99",
+        "--shard=1",
+      ]
     ports:
       - "60000"

--- a/waku/v2/api/publish/default_verifier.go
+++ b/waku/v2/api/publish/default_verifier.go
@@ -6,6 +6,7 @@ import (
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/waku-org/go-waku/waku/v2/protocol/pb"
 	"github.com/waku-org/go-waku/waku/v2/protocol/store"
+	"github.com/waku-org/go-waku/waku/v2/utils"
 )
 
 func NewDefaultStorenodeMessageVerifier(store *store.WakuStore) StorenodeMessageVerifier {
@@ -19,10 +20,12 @@ type defaultStorenodeMessageVerifier struct {
 }
 
 func (d *defaultStorenodeMessageVerifier) MessageHashesExist(ctx context.Context, requestID []byte, peerInfo peer.AddrInfo, pageSize uint64, messageHashes []pb.MessageHash) ([]pb.MessageHash, error) {
+
+	addrs := utils.EncapsulatePeerID(peerInfo.ID, peerInfo.Addrs...)
+
 	var opts []store.RequestOption
 	opts = append(opts, store.WithRequestID(requestID))
-	opts = append(opts, store.WithPeerAddr(peerInfo.Addrs...))
-	opts = append(opts, store.WithPeer(peerInfo.ID))
+	opts = append(opts, store.WithPeerAddr(addrs...))
 	opts = append(opts, store.WithPaging(false, pageSize))
 	opts = append(opts, store.IncludeData(false))
 

--- a/waku/v2/api/publish/default_verifier.go
+++ b/waku/v2/api/publish/default_verifier.go
@@ -18,10 +18,11 @@ type defaultStorenodeMessageVerifier struct {
 	store *store.WakuStore
 }
 
-func (d *defaultStorenodeMessageVerifier) MessageHashesExist(ctx context.Context, requestID []byte, peerID peer.AddrInfo, pageSize uint64, messageHashes []pb.MessageHash) ([]pb.MessageHash, error) {
+func (d *defaultStorenodeMessageVerifier) MessageHashesExist(ctx context.Context, requestID []byte, peerInfo peer.AddrInfo, pageSize uint64, messageHashes []pb.MessageHash) ([]pb.MessageHash, error) {
 	var opts []store.RequestOption
 	opts = append(opts, store.WithRequestID(requestID))
-	opts = append(opts, store.WithPeerAddr(peerID.Addrs...))
+	opts = append(opts, store.WithPeerAddr(peerInfo.Addrs...))
+	opts = append(opts, store.WithPeer(peerInfo.ID))
 	opts = append(opts, store.WithPaging(false, pageSize))
 	opts = append(opts, store.IncludeData(false))
 


### PR DESCRIPTION
# Description
When querying for message hashes, we need to provide the multiaddresses containing the peer id, otherwise the query fails

# Changes

<!-- List of detailed changes -->

- [x] adding the peerId to the multiaddresses in`MessageHashesExist`
- [x] fixing store tests 



## Issue

https://github.com/status-im/status-desktop/issues/17774
