### PR TITLE
ci: fix linter, storev3 tests and nix-flake jobs

### DIFF
--- a/.github/docker-compose/nwaku.yml
+++ b/.github/docker-compose/nwaku.yml
@@ -1,6 +1,6 @@
 services:
   nwaku:
-    image: "harbor.status.im/wakuorg/nwaku:latest"
+    image: "harbor.status.im/wakuorg/nwaku:v0.35.1"
     command:
       [
         "--relay",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,8 +74,8 @@ jobs:
       - name: Execute golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.55.2
-          args: --deadline=5m
+          version: v1.64.6
+          args: --timeout=5m
 
   build:
     needs: [changes, env]

--- a/ci/Jenkinsfile.nix-flake
+++ b/ci/Jenkinsfile.nix-flake
@@ -1,4 +1,4 @@
-library 'status-jenkins-lib@v1.9.16'
+library 'status-jenkins-lib@v1.9.26'
 
 pipeline {
   agent {
@@ -28,7 +28,7 @@ pipeline {
       stages {
         stage('Build') {
           steps { script {
-            nix.flake('node',[path: 'git+https://github.com/waku-org/go-waku'])
+            nix.flake('node')
           } }
         }
         stage('Check') {

--- a/waku/v2/protocol/filter/server.go
+++ b/waku/v2/protocol/filter/server.go
@@ -13,6 +13,8 @@ import (
 	libp2pProtocol "github.com/libp2p/go-libp2p/core/protocol"
 	"github.com/libp2p/go-msgio/pbio"
 	"github.com/prometheus/client_golang/prometheus"
+	"go.uber.org/zap"
+
 	"github.com/waku-org/go-waku/logging"
 	"github.com/waku-org/go-waku/waku/v2/peermanager"
 	"github.com/waku-org/go-waku/waku/v2/protocol"
@@ -21,7 +23,6 @@ import (
 	"github.com/waku-org/go-waku/waku/v2/service"
 	"github.com/waku-org/go-waku/waku/v2/timesource"
 	"github.com/waku-org/go-waku/waku/v2/utils"
-	"go.uber.org/zap"
 )
 
 // FilterSubscribeID_v20beta1 is the current Waku Filter protocol identifier for servers to
@@ -282,7 +283,7 @@ func (wf *WakuFilterFullNode) pushMessage(ctx context.Context, logger *zap.Logge
 
 	stream, err := wf.h.NewStream(ctx, peerID, FilterPushID_v20beta1)
 	if err != nil {
-		if errors.Is(context.DeadlineExceeded, err) {
+		if errors.Is(err, context.DeadlineExceeded) {
 			wf.metrics.RecordError(pushTimeoutFailure)
 		} else {
 			wf.metrics.RecordError(dialFailure)
@@ -297,7 +298,7 @@ func (wf *WakuFilterFullNode) pushMessage(ctx context.Context, logger *zap.Logge
 	writer := pbio.NewDelimitedWriter(stream)
 	err = writer.WriteMsg(messagePush)
 	if err != nil {
-		if errors.Is(context.DeadlineExceeded, err) {
+		if errors.Is(err, context.DeadlineExceeded) {
 			wf.metrics.RecordError(pushTimeoutFailure)
 		} else {
 			wf.metrics.RecordError(writeResponseFailure)


### PR DESCRIPTION
1. Upgrade `golangci-lint` to v1.64.6
2. Fix some linter issues
3. Fix `nwaku` version used in storev3 tests, otherwise they fail. Upgrading to the latest one is probably not reasonable for this purpose.
4. `nix-flake` job fix by @jakubgs from https://github.com/waku-org/go-waku/pull/1290/commits

Required for https://github.com/waku-org/go-waku/pull/1288