### PR TITLE
Fix Jenkinsfil and Go version

### DIFF
--- a/ci/Jenkinsfile.nix-flake
+++ b/ci/Jenkinsfile.nix-flake
@@ -1,4 +1,4 @@
-library 'status-jenkins-lib@v1.9.16'
+library 'status-jenkins-lib@v1.9.26'
 
 pipeline {
   agent {
@@ -28,7 +28,7 @@ pipeline {
       stages {
         stage('Build') {
           steps { script {
-            nix.flake('node',[path: 'git+https://github.com/waku-org/go-waku'])
+            nix.flake('node')
           } }
         }
         stage('Check') {

--- a/default.nix
+++ b/default.nix
@@ -8,7 +8,7 @@
   version ? builtins.readFile ./VERSION,
 }:
 
-pkgs.buildGo121Module {
+pkgs.buildGo123Module {
   name = "go-waku";
   src = self;
 


### PR DESCRIPTION
- [`go-waku#a551b1f4`](https://github.com/status-im/go-waku/commit/a551b1f4) - ci: drop unnecessary path from node build
- [`go-waku#16c6182b`](https://github.com/status-im/go-waku/commit/16c6182b) - nix: ugprade Go from 1.21 to 1.23
