### PR TITLE
fix: use simple protocol and pubsubTopic based selection for peerExchange

### DIFF
--- a/waku/v2/peermanager/peer_manager.go
+++ b/waku/v2/peermanager/peer_manager.go
@@ -96,6 +96,7 @@ type PeerSelection int
 const (
 	Automatic PeerSelection = iota
 	LowestRTT
+	ProtoPubSubTopicOnly //This is added to address an issue with peerExchange where on-demand discovery cannot be used.
 )
 
 const maxFailedAttempts = 5

--- a/waku/v2/protocol/peer_exchange/client.go
+++ b/waku/v2/protocol/peer_exchange/client.go
@@ -53,7 +53,7 @@ func (wakuPX *WakuPeerExchange) Request(ctx context.Context, numPeers int, opts 
 		}
 		selectedPeers, err := wakuPX.pm.SelectPeers(
 			peermanager.PeerSelectionCriteria{
-				SelectionType: params.peerSelectionType,
+				SelectionType: peermanager.ProtoPubSubTopicOnly, //Overriding selection type, this is hacky but to avoid refactor
 				Proto:         PeerExchangeID_v20alpha1,
 				PubsubTopics:  pubsubTopics,
 				SpecificPeers: params.preferredPeers,


### PR DESCRIPTION
# Description
Since PeerExchange is not indicated in Waku ENR and hence peers are not added in service slots, when we try to do random peer selection it fails with below error as reported by @igor-sirotin 

```
2025-10-03T15:58:21.950+0100    WARN    node2.peer-manager    peermanager/peer_discovery.go:59    cannot do on demand discovery for non-waku protocol    {"protocol": "/vac/waku/peer-exchange/2.0.0-alpha1"}
github.com/waku-org/go-waku/waku/v2/peermanager.(*PeerManager).discoverOnDemand
    /Users/sirotin/Repositories/status/status-go/vendor/github.com/waku-org/go-waku/waku/v2/peermanager/peer_discovery.go:59
github.com/waku-org/go-waku/waku/v2/peermanager.(*PeerManager).DiscoverAndConnectToPeers
    /Users/sirotin/Repositories/status/status-go/vendor/github.com/waku-org/go-waku/waku/v2/peermanager/peer_discovery.go:25
github.com/waku-org/go-waku/waku/v2/peermanager.(*PeerManager).discoverPeersByPubsubTopics
    /Users/sirotin/Repositories/status/status-go/vendor/github.com/waku-org/go-waku/waku/v2/peermanager/peer_discovery.go:115
github.com/waku-org/go-waku/waku/v2/peermanager.(*PeerManager).selectServicePeer
    /Users/sirotin/Repositories/status/status-go/vendor/github.com/waku-org/go-waku/waku/v2/peermanager/peer_selection.go:153
github.com/waku-org/go-waku/waku/v2/peermanager.(*PeerManager).SelectRandom
    /Users/sirotin/Repositories/status/status-go/vendor/github.com/waku-org/go-waku/waku/v2/peermanager/peer_selection.go:60
github.com/waku-org/go-waku/waku/v2/peermanager.(*PeerManager).SelectPeers
    /Users/sirotin/Repositories/status/status-go/vendor/github.com/waku-org/go-waku/waku/v2/peermanager/peer_selection.go:199
github.com/waku-org/go-waku/waku/v2/protocol/peer_exchange.(*WakuPeerExchange).Request
    /Users/sirotin/Repositories/status/status-go/vendor/github.com/waku-org/go-waku/waku/v2/protocol/peer_exchange/client.go:54
github.com/status-im/status-go/messaging/waku.(*Waku).runPeerExchangeLoop
    /Users/sirotin/Repositories/status/status-go/messaging/waku/gowaku.go:618
2025-10-03T15:58:21.950+0100    WARN    node2.peer-manager    peermanager/peer_discovery.go:117    failed to discover and connect to peers    {"error": "cannot do on demand discovery for non-waku protocol"}
github.com/waku-org/go-waku/waku/v2/peermanager.(*PeerManager).discoverPeersByPubsubTopics
    /Users/sirotin/Repositories/status/status-go/vendor/github.com/waku-org/go-waku/waku/v2/peermanager/peer_discovery.go:117
github.com/waku-org/go-waku/waku/v2/peermanager.(*PeerManager).selectServicePeer
    /Users/sirotin/Repositories/status/status-go/vendor/github.com/waku-org/go-waku/waku/v2/peermanager/peer_selection.go:153
github.com/waku-org/go-waku/waku/v2/peermanager.(*PeerManager).SelectRandom
    /Users/sirotin/Repositories/status/status-go/vendor/github.com/waku-org/go-waku/waku/v2/peermanager/peer_selection.go:60
github.com/waku-org/go-waku/waku/v2/peermanager.(*PeerManager).SelectPeers
    /Users/sirotin/Repositories/status/status-go/vendor/github.com/waku-org/go-waku/waku/v2/peermanager/peer_selection.go:199
github.com/waku-org/go-waku/waku/v2/protocol/peer_exchange.(*WakuPeerExchange).Request
    /Users/sirotin/Repositories/status/status-go/vendor/github.com/waku-org/go-waku/waku/v2/protocol/peer_exchange/client.go:54
github.com/status-im/status-go/messaging/waku.(*Waku).runPeerExchangeLoop
    /Users/sirotin/Repositories/status/status-go/messaging/waku/gowaku.go:618
```

This PR fixes this by introducing a new simpler peer-selection criteria just by using protocolID and pubsubTopics.

# Changes

<!-- List of detailed changes -->

- [x] introduce a new simple peer selection criteria  `ProtoPubSubTopicOnly` using protocol and pubsubTopic and skip on-demand discovery
- [x] override peer-exchange client to always use this new peer selection criteria `ProtoPubSubTopicOnly`

